### PR TITLE
fix: use event timestamp for open notifications

### DIFF
--- a/src/navigation/novice-navigation.js
+++ b/src/navigation/novice-navigation.js
@@ -29,7 +29,7 @@ export const noviceMoves = (drag$, menu, { menuCenter, minSelectionDist }) => {
       type: 'open',
       menu,
       center: menuCenter,
-      timeStamp: performance ? performance.now() : Date.now(),
+      timeStamp: new Event('marking-menu-open').timeStamp,
     }),
     share()
   );

--- a/src/navigation/novice-navigation.test.js
+++ b/src/navigation/novice-navigation.test.js
@@ -38,24 +38,10 @@ const EndNotif = (type, position, active = null) => ({
   selection: active,
 });
 
-// Hacky, but without this spyOn performance do not work.
-beforeAll(() => {
-  Object.defineProperty(performance, 'now', {
-    value: performance.now,
-    configurable: true,
-    writable: true,
-  });
-});
-afterAll(() => {
-  Object.defineProperty(performance, 'now', {
-    value: performance.now,
-    configurable: false,
-    writable: false,
-  });
-});
-
 beforeEach(() => {
-  jest.spyOn(performance, 'now').mockImplementationOnce(() => 'mockTime');
+  jest.spyOn(global, 'Event').mockImplementation(() => ({
+    timeStamp: 'mockTime',
+  }));
   toPolar.mockImplementation(([radius, azymuth]) => ({ azymuth, radius }));
 });
 


### PR DESCRIPTION
## Summary

- generate `open` notification timestamps through the DOM `Event` clock
- keep `open` timestamps comparable with mouse and touch event timestamps
- update the novice-navigation test to mock the Event clock directly

## Root cause

`open` notifications used `performance.now()`, while subsequent notifications inherited `MouseEvent.timeStamp` or `TouchEvent.timeStamp`. Older Safari versions used a different clock origin for those event timestamps, producing incoherent values.

Creating a synthetic, undispatched `Event` makes the `open` notification use the browser's own event timestamp clock as well.

## Validation

- `yarn lint`
- `yarn test --runInBand` — 18 suites, 96 tests, and 46 snapshots passed

Fixes #3
