### PR TITLE
feat: publish native ESM build alongside UMD

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ You can use [unpkg](https://unpkg.com) to fetch both [`rxjs`](http://reactivex.i
 </html>
 ```
 
+Or, as a native ES module via [esm.sh](https://esm.sh), which auto-resolves `marking-menu`'s own `rxjs` dependency:
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script type="module">
+      import MarkingMenu from 'https://esm.sh/marking-menu';
+      // Your stuff.
+    </script>
+  </head>
+  <body></body>
+</html>
+```
+
 ### ES modules or CommonJS
 
 ```sh

--- a/build-config/rollup.config.js
+++ b/build-config/rollup.config.js
@@ -19,17 +19,25 @@ const banner = `/*!
 
 export default {
   input: 'src/index.js',
-  output: {
-    name: 'MarkingMenu',
-    globals: {
-      rxjs: 'rxjs',
-      'rxjs/operators': 'rxjs.operators',
+  output: [
+    {
+      name: 'MarkingMenu',
+      globals: {
+        rxjs: 'rxjs',
+        'rxjs/operators': 'rxjs.operators',
+      },
+      sourcemap: true,
+      file: './marking-menu.js',
+      banner,
+      format: 'umd',
     },
-    sourcemap: true,
-    file: './marking-menu.js',
-    banner,
-    format: 'umd',
-  },
+    {
+      sourcemap: true,
+      file: './marking-menu.mjs',
+      banner,
+      format: 'es',
+    },
+  ],
   plugins: [
     resolve(),
     postcss({ minimize: true }),

--- a/package.json
+++ b/package.json
@@ -3,9 +3,19 @@
   "version": "0.10.0",
   "description": "Marking Menu Implementation in JavaScript.",
   "main": "marking-menu.js",
+  "module": "marking-menu.mjs",
+  "exports": {
+    ".": {
+      "import": "./marking-menu.mjs",
+      "require": "./marking-menu.js",
+      "default": "./marking-menu.js"
+    }
+  },
   "files": [
     "marking-menu.js",
-    "marking-menu.js.map"
+    "marking-menu.js.map",
+    "marking-menu.mjs",
+    "marking-menu.mjs.map"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- Adds a second Rollup output (`format: 'es'`) built to `marking-menu.mjs`, alongside the existing UMD `marking-menu.js` build. Same externals (`rxjs`, `rxjs/operators`), banner, and sourcemap settings as the UMD output.
- `package.json`: adds a `"module"` field pointing at `marking-menu.mjs`, and an `"exports"` map (`"."` → `import`/`require`/`default`) so ESM-aware bundlers resolve the new build while `require()` keeps resolving the existing UMD file. Both build outputs are added to `"files"`.
- `README.md`: adds a native-ESM CDN usage example via [esm.sh](https://esm.sh) (which auto-resolves the `rxjs` dependency) in the "Browser with CDN" section, alongside the existing unpkg/UMD example. The existing bundler ESM/CommonJS examples are unchanged — they now resolve to the real ESM/UMD builds via the new exports map.

This is a standalone, non-breaking addition (existing consumers keep resolving the UMD build via `require`/`main`); it does not touch the demo or deployment setup.

## Test plan

- [x] `yarn build` — confirms both `marking-menu.js` and `marking-menu.mjs` are produced
- [x] Manually imported the built `marking-menu.mjs` in Node to confirm it resolves `rxjs`/`rxjs/operators` as externals and exports a `default` function
- [x] `yarn lint` — clean
- [x] `yarn test` — 18 suites / 96 tests / 46 snapshots passing