### PR TITLE
fix: scope Jest tests to source

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  roots: ['<rootDir>/src'],
   collectCoverageFrom: ['src/**/*.js'],
   testEnvironment: 'jsdom',
   transform: {


### PR DESCRIPTION
## Summary

- restrict Jest discovery to the repository's `src` directory
- prevent nested tool-created worktrees from being collected as duplicate test suites

## Root cause

Jest searched the entire repository and discovered test files inside nested worktress. Those nested checkouts did not use the root Babel configuration, causing 54 duplicate suites to fail while all 18 intended suites passed.

## Impact

`yarn test` now runs only the project's intended tests, regardless of local tool or worktree directories.

## Validation

- `yarn test` — 18 suites, 96 tests, and 46 snapshots passed
- `yarn lint`
- `git diff --check`
