### PR TITLE
docs: fix native ESM example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ its bare `rxjs` imports:
     <script type="importmap">
       {
         "imports": {
-          "marking-menu": "https://unpkg.com/marking-menu/marking-menu.mjs",
+          "marking-menu": "https://esm.sh/marking-menu@0.10.1?raw",
           "rxjs": "https://esm.sh/rxjs@7.5.5",
           "rxjs/operators": "https://esm.sh/rxjs@7.5.5/operators"
         }

--- a/README.md
+++ b/README.md
@@ -45,14 +45,24 @@ You can use [unpkg](https://unpkg.com) to fetch both [`rxjs`](http://reactivex.i
 </html>
 ```
 
-Or, as a native ES module via [esm.sh](https://esm.sh), which auto-resolves `marking-menu`'s own `rxjs` dependency:
+Or, as a native ES module using an import map to resolve `marking-menu` and
+its bare `rxjs` imports:
 
 ```html
 <!DOCTYPE html>
 <html>
   <head>
+    <script type="importmap">
+      {
+        "imports": {
+          "marking-menu": "https://unpkg.com/marking-menu/marking-menu.mjs",
+          "rxjs": "https://esm.sh/rxjs@7.5.5",
+          "rxjs/operators": "https://esm.sh/rxjs@7.5.5/operators"
+        }
+      }
+    </script>
     <script type="module">
-      import MarkingMenu from 'https://esm.sh/marking-menu';
+      import MarkingMenu from 'marking-menu';
       // Your stuff.
     </script>
   </head>


### PR DESCRIPTION
## Summary

- add an import map to the browser ESM example
- map `marking-menu`, `rxjs`, and `rxjs/operators`
- import `marking-menu` through its mapped bare specifier

## Why

The published ESM build imports `rxjs` and `rxjs/operators` using bare
specifiers. Browsers cannot resolve those specifiers on their own, so the
previous example could fail when used as native ESM. The import map makes every
dependency explicit and lets readers copy the example directly.

## Impact

The README now documents a working native-browser setup without implying that
source maps resolve module imports.

## Validation

- `yarn prettier --check README.md`
- `git diff --check`
- test suite: 18 suites, 96 tests passed
