### PR TITLE
chore: remove unused sass-lint config and modernize Renovate config

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -1,4 +1,0 @@
-rules:
-  property-sort-order:
-    - 1
-    - order: 'concentric'

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     ":automergeMinor",
-    ":automergeBranchPush",
+    ":automergeBranch",
     ":semanticCommits",
     ":rebaseStalePrs",
     ":semanticCommitScopeDisabled",
@@ -9,24 +10,22 @@
   ],
   "packageRules": [
     {
-      "packagePatterns": [
-        "eslint",
-        "husky",
-        "sass-lint",
-        "prettier",
-        "cross-env",
-        "commitlint",
-        "standard-version"
+      "matchPackageNames": [
+        "/eslint/",
+        "/husky/",
+        "/prettier/",
+        "/cross-env/",
+        "/commitlint/",
+        "/standard-version/"
       ],
       "groupName": "ci"
     },
     {
-      "packagePatterns": ["rollup", "babel"],
+      "matchPackageNames": ["/rollup/", "/babel/"],
       "groupName": "build"
     },
     {
-      "packagePatterns": ["jest"],
-      "packageNames": ["rxjs-marbles"],
+      "matchPackageNames": ["/jest/", "rxjs-marbles"],
       "groupName": "test"
     }
   ]


### PR DESCRIPTION
## Summary
- Delete `.sass-lint.yml` — dead config: the repo has no `.scss` files, `sass-lint` isn't a dependency, and the `lint` script only runs `eslint src`.
- Modernize `renovate.json`:
  - Replace `packagePatterns`/`packageNames` (legacy, no longer documented by Renovate) with the current `matchPackageNames` field, using `/regex/` patterns to preserve the original substring-match behavior for scoped packages (`@babel/*`, `@commitlint/*`, etc.).
  - Replace `:automergeBranchPush` — an officially removed Renovate preset that silently redirects to `:automergeBranch` — with the real preset name.
  - Drop the now-dead `sass-lint` entry from the `ci` group.
  - Add `$schema` for editor validation/autocomplete.

## Test plan
- [x] `yarn lint && yarn test` passed via the pre-commit hook