### PR TITLE
chore: update renovate config after Vite/Vitest migration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,18 +14,17 @@
         "/eslint/",
         "/husky/",
         "/prettier/",
-        "/cross-env/",
         "/commitlint/",
         "/standard-version/"
       ],
       "groupName": "ci"
     },
     {
-      "matchPackageNames": ["/rollup/", "/babel/"],
+      "matchPackageNames": ["/vite/"],
       "groupName": "build"
     },
     {
-      "matchPackageNames": ["/jest/", "rxjs-marbles"],
+      "matchPackageNames": ["/vitest/", "rxjs-marbles"],
       "groupName": "test"
     }
   ]


### PR DESCRIPTION
## Summary
- The build/test tooling migrated to Vite/Vitest in #118, but `renovate.json`'s `packageRules` still grouped updates by the old `rollup`/`babel` (build) and `jest` (test) package names, so those groups were matching nothing.
- Updated the `build` group to match `vite` and the `test` group to match `vitest` (kept `rxjs-marbles`).
- Dropped `cross-env` from the `ci` group since it isn't a dependency anymore.

## Test plan
- [x] `renovate.json` is valid JSON
- [x] Confirmed `rollup`, `babel`, `jest`, and `cross-env` no longer appear in `package.json`