### PR TITLE
refactor: consolidate rxjs imports to single entry point

### DIFF
--- a/.changeset/simplify-rxjs-imports.md
+++ b/.changeset/simplify-rxjs-imports.md
@@ -1,0 +1,7 @@
+---
+'marking-menu': minor
+---
+
+Import RxJS operators from `rxjs`. ES module users can remove `rxjs/operators`
+from their import maps; custom shims must expose operators on the root `rxjs`
+export. Standard RxJS 7 UMD users need no changes.

--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ its bare `rxjs` imports:
       {
         "imports": {
           "marking-menu": "https://esm.sh/marking-menu@0.10.1?raw",
-          "rxjs": "https://esm.sh/rxjs@7.5.5",
-          "rxjs/operators": "https://esm.sh/rxjs@7.5.5/operators"
+          "rxjs": "https://esm.sh/rxjs@7.8.2"
         }
       }
     </script>

--- a/demo/index.html
+++ b/demo/index.html
@@ -8,8 +8,7 @@
       {
         "imports": {
           "marking-menu": "./marking-menu.mjs",
-          "rxjs": "https://esm.sh/rxjs@7.5.5",
-          "rxjs/operators": "https://esm.sh/rxjs@7.5.5/operators"
+          "rxjs": "https://esm.sh/rxjs@7.8.2"
         }
       }
     </script>

--- a/src/layout/connect.ts
+++ b/src/layout/connect.ts
@@ -1,5 +1,4 @@
-import { finalize, tap } from 'rxjs/operators';
-import type { Observable } from 'rxjs';
+import { finalize, tap, type Observable } from 'rxjs';
 import rafThrottle from 'raf-schd';
 import type { NonEmptyArray, Point } from '../utils.js';
 import type { Menu } from './menu.js';

--- a/src/marking-menu.test.ts
+++ b/src/marking-menu.test.ts
@@ -1,8 +1,7 @@
-import { map } from 'rxjs/operators';
+import { map, type Observable } from 'rxjs';
 import { marbles } from 'rxjs-marbles/jest';
 import type { TestObservableLike } from 'rxjs-marbles/types';
 import { type Mock } from 'vitest';
-import type { Observable } from 'rxjs';
 import {
   createMarkingMenu as main,
   exportNotification,

--- a/src/marking-menu.ts
+++ b/src/marking-menu.ts
@@ -1,5 +1,4 @@
-import { tap, map, share, filter } from 'rxjs/operators';
-import type { Observable } from 'rxjs';
+import { tap, map, share, filter, type Observable } from 'rxjs';
 import { navigation } from './navigation/navigation.js';
 import {
   createMenu as createMenuLayout,

--- a/src/move/draw.ts
+++ b/src/move/draw.ts
@@ -1,5 +1,4 @@
-import { scan } from 'rxjs/operators';
-import type { Observable } from 'rxjs';
+import { scan, type Observable } from 'rxjs';
 import type { Point } from '../utils.js';
 
 /**

--- a/src/move/dwelling.ts
+++ b/src/move/dwelling.ts
@@ -1,4 +1,13 @@
-import { merge, type Observable, type SchedulerLike, debounceTime, takeUntil, first, withLatestFrom, last } from 'rxjs';
+import {
+  merge,
+  type Observable,
+  type SchedulerLike,
+  debounceTime,
+  takeUntil,
+  first,
+  withLatestFrom,
+  last,
+} from 'rxjs';
 import { longMoves, type DragNotification } from './long-move.js';
 
 /**

--- a/src/move/dwelling.ts
+++ b/src/move/dwelling.ts
@@ -1,11 +1,4 @@
-import { merge, type Observable, type SchedulerLike } from 'rxjs';
-import {
-  debounceTime,
-  takeUntil,
-  first,
-  withLatestFrom,
-  last,
-} from 'rxjs/operators';
+import { merge, type Observable, type SchedulerLike, debounceTime, takeUntil, first, withLatestFrom, last } from 'rxjs';
 import { longMoves, type DragNotification } from './long-move.js';
 
 /**

--- a/src/move/linear-drag.test.ts
+++ b/src/move/linear-drag.test.ts
@@ -1,5 +1,4 @@
-import { fromEvent, merge, EMPTY, of, type Observable } from 'rxjs';
-import { takeUntil, withLatestFrom } from 'rxjs/operators';
+import { fromEvent, merge, EMPTY, of, type Observable, takeUntil, withLatestFrom } from 'rxjs';
 import { marbles } from 'rxjs-marbles';
 import { type Mock } from 'vitest';
 import { watchDrags, mouseDrags, touchDrags } from './linear-drag.js';

--- a/src/move/linear-drag.test.ts
+++ b/src/move/linear-drag.test.ts
@@ -1,4 +1,12 @@
-import { fromEvent, merge, EMPTY, of, type Observable, takeUntil, withLatestFrom } from 'rxjs';
+import {
+  fromEvent,
+  merge,
+  EMPTY,
+  of,
+  type Observable,
+  takeUntil,
+  withLatestFrom,
+} from 'rxjs';
 import { marbles } from 'rxjs-marbles';
 import { type Mock } from 'vitest';
 import { watchDrags, mouseDrags, touchDrags } from './linear-drag.js';

--- a/src/move/linear-drag.ts
+++ b/src/move/linear-drag.ts
@@ -5,8 +5,11 @@ import {
   connectable,
   BehaviorSubject,
   type Observable,
+  map,
+  takeUntil,
+  filter,
+  startWith,
 } from 'rxjs';
-import { map, takeUntil, filter, startWith } from 'rxjs/operators';
 import {
   createPointerEventFromMouseEvent,
   createPointerEventFromTouchEvent,

--- a/src/move/long-move.ts
+++ b/src/move/long-move.ts
@@ -1,5 +1,4 @@
-import { scan, filter, map } from 'rxjs/operators';
-import type { Observable } from 'rxjs';
+import { scan, filter, map, type Observable } from 'rxjs';
 import { dist } from '../utils.js';
 
 /**

--- a/src/navigation/expert-navigation.ts
+++ b/src/navigation/expert-navigation.ts
@@ -1,5 +1,4 @@
-import { merge, type Observable } from 'rxjs';
-import { startWith, last, map, share } from 'rxjs/operators';
+import { merge, type Observable, startWith, last, map, share } from 'rxjs';
 import { draw } from '../move/draw.js';
 import { recognizeMarkingMenuStroke as recognize } from '../recognizer/recognize-mm-stroke.js';
 import type { MarkingMenuModelItem } from '../types.js';

--- a/src/navigation/navigation.test.ts
+++ b/src/navigation/navigation.test.ts
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention -- Observable testing use capital letters for HOO */
 /* eslint-disable @typescript-eslint/no-deprecated -- Marble tests require manually connected behavior observables */
 
-import { of, type Observable, type ConnectableObservable } from 'rxjs';
-import { publishBehavior, scan, map } from 'rxjs/operators';
+import { of, type Observable, type ConnectableObservable, publishBehavior, scan, map } from 'rxjs';
 import { marbles } from 'rxjs-marbles/jest';
 import { type Mock } from 'vitest';
 import { longMoves } from '../move/long-move.js';

--- a/src/navigation/navigation.test.ts
+++ b/src/navigation/navigation.test.ts
@@ -1,7 +1,14 @@
 /* eslint-disable @typescript-eslint/naming-convention -- Observable testing use capital letters for HOO */
 /* eslint-disable @typescript-eslint/no-deprecated -- Marble tests require manually connected behavior observables */
 
-import { of, type Observable, type ConnectableObservable, publishBehavior, scan, map } from 'rxjs';
+import {
+  of,
+  type Observable,
+  type ConnectableObservable,
+  publishBehavior,
+  scan,
+  map,
+} from 'rxjs';
 import { marbles } from 'rxjs-marbles/jest';
 import { type Mock } from 'vitest';
 import { longMoves } from '../move/long-move.js';

--- a/src/navigation/navigation.ts
+++ b/src/navigation/navigation.ts
@@ -1,13 +1,4 @@
-import { race, of, type Observable } from 'rxjs';
-import {
-  take,
-  map,
-  skip,
-  startWith,
-  switchAll,
-  mergeMap,
-  exhaustMap,
-} from 'rxjs/operators';
+import { race, of, type Observable, take, map, skip, startWith, switchAll, mergeMap, exhaustMap } from 'rxjs';
 import { longMoves } from '../move/long-move.js';
 import { dwellings } from '../move/dwelling.js';
 import { draw } from '../move/draw.js';

--- a/src/navigation/navigation.ts
+++ b/src/navigation/navigation.ts
@@ -1,4 +1,15 @@
-import { race, of, type Observable, take, map, skip, startWith, switchAll, mergeMap, exhaustMap } from 'rxjs';
+import {
+  race,
+  of,
+  type Observable,
+  take,
+  map,
+  skip,
+  startWith,
+  switchAll,
+  mergeMap,
+  exhaustMap,
+} from 'rxjs';
 import { longMoves } from '../move/long-move.js';
 import { dwellings } from '../move/dwelling.js';
 import { draw } from '../move/draw.js';

--- a/src/navigation/novice-navigation.ts
+++ b/src/navigation/novice-navigation.ts
@@ -1,4 +1,15 @@
-import { merge, type Observable, scan, startWith, share, last, map, filter, switchAll, take } from 'rxjs';
+import {
+  merge,
+  type Observable,
+  scan,
+  startWith,
+  share,
+  last,
+  map,
+  filter,
+  switchAll,
+  take,
+} from 'rxjs';
 import { toPolar, type Point } from '../utils.js';
 import { dwellings } from '../move/dwelling.js';
 import type { MarkingMenuModelItem } from '../types.js';

--- a/src/navigation/novice-navigation.ts
+++ b/src/navigation/novice-navigation.ts
@@ -1,14 +1,4 @@
-import { merge, type Observable } from 'rxjs';
-import {
-  scan,
-  startWith,
-  share,
-  last,
-  map,
-  filter,
-  switchAll,
-  take,
-} from 'rxjs/operators';
+import { merge, type Observable, scan, startWith, share, last, map, filter, switchAll, take } from 'rxjs';
 import { toPolar, type Point } from '../utils.js';
 import { dwellings } from '../move/dwelling.js';
 import type { MarkingMenuModelItem } from '../types.js';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,12 +27,11 @@ export default defineConfig({
     },
     minify: false,
     rolldownOptions: {
-      external: ['rxjs', 'rxjs/operators'],
+      external: ['rxjs'],
       output: {
         banner,
         globals: {
           rxjs: 'rxjs',
-          'rxjs/operators': 'rxjs.operators',
         },
       },
     },

--- a/vite.demo.config.ts
+++ b/vite.demo.config.ts
@@ -4,7 +4,6 @@ import { defineConfig } from 'vite';
 const importMapDependencies = new Set([
   'marking-menu',
   'rxjs',
-  'rxjs/operators',
 ]);
 
 export default defineConfig(({ command }) => ({

--- a/vite.demo.config.ts
+++ b/vite.demo.config.ts
@@ -1,10 +1,7 @@
 import path from 'node:path';
 import { defineConfig } from 'vite';
 
-const importMapDependencies = new Set([
-  'marking-menu',
-  'rxjs',
-]);
+const importMapDependencies = new Set(['marking-menu', 'rxjs']);
 
 export default defineConfig(({ command }) => ({
   base: './',


### PR DESCRIPTION
Drop `rxjs/operators` import map entries and consolidate all source imports to `from 'rxjs'`.

- RxJS v7+ re-exports all pipeable operators from the main `rxjs` entry point
- Removes unnecessary separate import map entries for `rxjs/operators`
- Updates RxJS version in docs/demo from 7.5.5 to 7.8.2 to match installed version