### PR TITLE
Enforce sorted imports (alphabetically within groups)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ its bare `rxjs` imports:
     </script>
     <script type="module">
       import { createMarkingMenu } from 'marking-menu';
+
       // Your stuff.
     </script>
   </head>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,7 @@
-import { defineConfig } from 'eslint/config';
+import vitest from '@vitest/eslint-plugin';
 import eslintConfigXo from 'eslint-config-xo';
 import importX from 'eslint-plugin-import-x';
-import vitest from '@vitest/eslint-plugin';
+import { defineConfig } from 'eslint/config';
 
 export default defineConfig([
   {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.31.1",
+    "@ianvs/prettier-plugin-sort-imports": "^4.7.1",
     "@types/node": "^26.1.1",
     "@typescript/native": "npm:typescript@^7.0.2",
     "@vitest/coverage-v8": "^4.1.10",

--- a/prettier.config.ts
+++ b/prettier.config.ts
@@ -2,6 +2,9 @@ import type { Config } from 'prettier';
 
 const config: Config = {
   singleQuote: true,
+  plugins: ['@ianvs/prettier-plugin-sort-imports'],
+  importOrder: ['<BUILTIN_MODULES>', '<THIRD_PARTY_MODULES>', '^[.]'],
+  importOrderCaseSensitive: false,
 };
 
 export default config;

--- a/src/layout/connect.test.ts
+++ b/src/layout/connect.test.ts
@@ -6,9 +6,9 @@ import {
   connectLayout as connect,
   type LayoutNotification,
 } from './connect.js';
+import type { GestureFeedback } from './gesture-feedback.js';
 import type { Menu } from './menu.js';
 import type { StrokeCanvas } from './stroke.js';
-import type { GestureFeedback } from './gesture-feedback.js';
 
 vi.mock('raf-schd', () => ({ default: vi.fn((f: unknown) => f) }));
 

--- a/src/layout/connect.ts
+++ b/src/layout/connect.ts
@@ -1,10 +1,10 @@
-import { finalize, tap } from 'rxjs/operators';
-import type { Observable } from 'rxjs';
 import rafThrottle from 'raf-schd';
+import type { Observable } from 'rxjs';
+import { finalize, tap } from 'rxjs/operators';
 import type { NonEmptyArray, Point } from '../utils.js';
+import type { GestureFeedback } from './gesture-feedback.js';
 import type { Menu } from './menu.js';
 import type { StrokeCanvas } from './stroke.js';
-import type { GestureFeedback } from './gesture-feedback.js';
 
 /**
  A navigation notification consumed by the layout.

--- a/src/layout/menu.test-d.ts
+++ b/src/layout/menu.test-d.ts
@@ -1,4 +1,4 @@
-import { describe, it, expectTypeOf } from 'vitest';
+import { describe, expectTypeOf, it } from 'vitest';
 import { createModel } from '../model.js';
 import type { MenuLayoutModel } from './menu.js';
 

--- a/src/marking-menu.test.ts
+++ b/src/marking-menu.test.ts
@@ -1,20 +1,20 @@
-import { map } from 'rxjs/operators';
+import type { Observable } from 'rxjs';
 import { marbles } from 'rxjs-marbles/jest';
 import type { TestObservableLike } from 'rxjs-marbles/types';
+import { map } from 'rxjs/operators';
 import { type Mock } from 'vitest';
-import type { Observable } from 'rxjs';
-import {
-  createMarkingMenu as main,
-  exportNotification,
-  type MarkingMenuConfig,
-} from './marking-menu.js';
-import { navigation } from './navigation/navigation.js';
-import { createModel } from './model.js';
+import { connectLayout } from './layout/connect.js';
+import { createGestureFeedback } from './layout/gesture-feedback.js';
 import { createMenu as createMenuLayout } from './layout/menu.js';
 import { createStrokeCanvas } from './layout/stroke.js';
-import { createGestureFeedback } from './layout/gesture-feedback.js';
-import { connectLayout } from './layout/connect.js';
+import {
+  exportNotification,
+  createMarkingMenu as main,
+  type MarkingMenuConfig,
+} from './marking-menu.js';
+import { createModel } from './model.js';
 import { watchDrags } from './move/linear-drag.js';
+import { navigation } from './navigation/navigation.js';
 
 vi.mock('./navigation/navigation');
 vi.mock('./layout/menu');

--- a/src/marking-menu.ts
+++ b/src/marking-menu.ts
@@ -1,17 +1,17 @@
-import { tap, map, share, filter } from 'rxjs/operators';
 import type { Observable } from 'rxjs';
-import { navigation } from './navigation/navigation.js';
+import { filter, map, share, tap } from 'rxjs/operators';
+import { connectLayout, type LayoutNotification } from './layout/connect.js';
+import { createGestureFeedback } from './layout/gesture-feedback.js';
 import {
   createMenu as createMenuLayout,
   type MenuLayoutModel,
 } from './layout/menu.js';
 import { createStrokeCanvas } from './layout/stroke.js';
-import { connectLayout, type LayoutNotification } from './layout/connect.js';
-import { createGestureFeedback } from './layout/gesture-feedback.js';
 import { createModel } from './model.js';
 import { watchDrags } from './move/linear-drag.js';
-import { noOp, type Point } from './utils.js';
+import { navigation } from './navigation/navigation.js';
 import type { MarkingMenuItemInput } from './types.js';
+import { noOp, type Point } from './utils.js';
 
 /**
  A notification as produced by the navigation/layout pipeline, before it is

--- a/src/model.test-d.ts
+++ b/src/model.test-d.ts
@@ -1,4 +1,4 @@
-import { describe, it, expectTypeOf } from 'vitest';
+import { describe, expectTypeOf, it } from 'vitest';
 import { createModel } from './model.js';
 import type { MarkingMenuItemInput } from './types.js';
 

--- a/src/move/draw.ts
+++ b/src/move/draw.ts
@@ -1,5 +1,5 @@
-import { scan } from 'rxjs/operators';
 import type { Observable } from 'rxjs';
+import { scan } from 'rxjs/operators';
 import type { Point } from '../utils.js';
 
 /**

--- a/src/move/dwelling.ts
+++ b/src/move/dwelling.ts
@@ -1,10 +1,10 @@
 import { merge, type Observable, type SchedulerLike } from 'rxjs';
 import {
   debounceTime,
-  takeUntil,
   first,
-  withLatestFrom,
   last,
+  takeUntil,
+  withLatestFrom,
 } from 'rxjs/operators';
 import { longMoves, type DragNotification } from './long-move.js';
 

--- a/src/move/linear-drag.test.ts
+++ b/src/move/linear-drag.test.ts
@@ -1,11 +1,11 @@
-import { fromEvent, merge, EMPTY, of, type Observable } from 'rxjs';
-import { takeUntil, withLatestFrom } from 'rxjs/operators';
+import { EMPTY, fromEvent, merge, of, type Observable } from 'rxjs';
 import { marbles } from 'rxjs-marbles';
+import { takeUntil, withLatestFrom } from 'rxjs/operators';
 import { type Mock } from 'vitest';
-import { watchDrags, mouseDrags, touchDrags } from './linear-drag.js';
+import { mouseDrags, touchDrags, watchDrags } from './linear-drag.js';
 import {
-  createPointerEventFromTouchEvent,
   createPointerEventFromMouseEvent,
+  createPointerEventFromTouchEvent,
 } from './pointer-events.js';
 
 const toPromise = async (obs: Observable<unknown>): Promise<void> =>

--- a/src/move/linear-drag.ts
+++ b/src/move/linear-drag.ts
@@ -1,12 +1,12 @@
 import {
-  fromEvent,
-  of,
-  merge,
-  connectable,
   BehaviorSubject,
+  connectable,
+  fromEvent,
+  merge,
+  of,
   type Observable,
 } from 'rxjs';
-import { map, takeUntil, filter, startWith } from 'rxjs/operators';
+import { filter, map, startWith, takeUntil } from 'rxjs/operators';
 import {
   createPointerEventFromMouseEvent,
   createPointerEventFromTouchEvent,

--- a/src/move/long-move.ts
+++ b/src/move/long-move.ts
@@ -1,5 +1,5 @@
-import { scan, filter, map } from 'rxjs/operators';
 import type { Observable } from 'rxjs';
+import { filter, map, scan } from 'rxjs/operators';
 import { dist } from '../utils.js';
 
 /**

--- a/src/navigation/expert-navigation.test.ts
+++ b/src/navigation/expert-navigation.test.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/naming-convention -- Observable testing use capital letters for HOO */
-import { marbles } from 'rxjs-marbles';
 import { type Observable } from 'rxjs';
+import { marbles } from 'rxjs-marbles';
 import { type Mock } from 'vitest';
-import type { Point } from '../utils.js';
-import type { MarkingMenuModelItem } from '../types.js';
 import { recognizeMarkingMenuStroke as recognize } from '../recognizer/recognize-mm-stroke.js';
+import type { MarkingMenuModelItem } from '../types.js';
+import type { Point } from '../utils.js';
 import { expertNavigation, type NavigationDrag } from './expert-navigation.js';
 
 vi.mock('../recognizer/recognize-mm-stroke');

--- a/src/navigation/expert-navigation.ts
+++ b/src/navigation/expert-navigation.ts
@@ -1,5 +1,5 @@
 import { merge, type Observable } from 'rxjs';
-import { startWith, last, map, share } from 'rxjs/operators';
+import { last, map, share, startWith } from 'rxjs/operators';
 import { draw } from '../move/draw.js';
 import { recognizeMarkingMenuStroke as recognize } from '../recognizer/recognize-mm-stroke.js';
 import type { MarkingMenuModelItem } from '../types.js';

--- a/src/navigation/navigation.test.ts
+++ b/src/navigation/navigation.test.ts
@@ -1,26 +1,26 @@
 /* eslint-disable @typescript-eslint/naming-convention -- Observable testing use capital letters for HOO */
 /* eslint-disable @typescript-eslint/no-deprecated -- Marble tests require manually connected behavior observables */
 
-import { of, type Observable, type ConnectableObservable } from 'rxjs';
-import { publishBehavior, scan, map } from 'rxjs/operators';
+import { of, type ConnectableObservable, type Observable } from 'rxjs';
 import { marbles } from 'rxjs-marbles/jest';
+import { map, publishBehavior, scan } from 'rxjs/operators';
 import { type Mock } from 'vitest';
-import { longMoves } from '../move/long-move.js';
-import { dwellings } from '../move/dwelling.js';
 import { draw } from '../move/draw.js';
+import { dwellings } from '../move/dwelling.js';
+import { longMoves } from '../move/long-move.js';
 import { recognizeMarkingMenuStroke as recognize } from '../recognizer/recognize-mm-stroke.js';
 import type { MarkingMenuModelItem } from '../types.js';
 import type { Point } from '../utils.js';
+import { expertNavigation, type NavigationDrag } from './expert-navigation.js';
 import {
-  navigation,
   confirmedExpertNavigationHOO,
   confirmedNoviceNavigationHOO,
   expertToNoviceSwitchHOO,
-  startup,
+  navigation,
   navigationFromDrag,
+  startup,
   type NavigationOptions,
 } from './navigation.js';
-import { expertNavigation, type NavigationDrag } from './expert-navigation.js';
 import { noviceNavigation } from './novice-navigation.js';
 
 vi.mock('./expert-navigation');

--- a/src/navigation/navigation.ts
+++ b/src/navigation/navigation.ts
@@ -1,21 +1,21 @@
-import { race, of, type Observable } from 'rxjs';
+import { of, race, type Observable } from 'rxjs';
 import {
-  take,
+  exhaustMap,
   map,
+  mergeMap,
   skip,
   startWith,
   switchAll,
-  mergeMap,
-  exhaustMap,
+  take,
 } from 'rxjs/operators';
-import { longMoves } from '../move/long-move.js';
-import { dwellings } from '../move/dwelling.js';
 import { draw } from '../move/draw.js';
+import { dwellings } from '../move/dwelling.js';
+import { longMoves } from '../move/long-move.js';
 import { recognizeMarkingMenuStroke as recognize } from '../recognizer/recognize-mm-stroke.js';
 import type { MarkingMenuModelItem } from '../types.js';
 import type { Point } from '../utils.js';
-import { noviceNavigation } from './novice-navigation.js';
 import { expertNavigation, type NavigationDrag } from './expert-navigation.js';
+import { noviceNavigation } from './novice-navigation.js';
 
 /**
  Configuration options threaded through the navigation.

--- a/src/navigation/novice-navigation.test.ts
+++ b/src/navigation/novice-navigation.test.ts
@@ -1,20 +1,20 @@
 /* eslint-disable @typescript-eslint/naming-convention -- Observable testing use capital letters for HOO */
 
-import { marbles } from 'rxjs-marbles/jest';
 import { Observable } from 'rxjs';
+import { marbles } from 'rxjs-marbles/jest';
 import { type Mock } from 'vitest';
-import { toPolar, type Point } from '../utils.js';
 import { dwellings } from '../move/dwelling.js';
 import type { MarkingMenuModelItem } from '../types.js';
-import {
-  noviceNavigation,
-  noviceMoves,
-  menuSelection,
-  submenuNavigation,
-  type NoviceNotification,
-  type NoviceNavigationOptions,
-} from './novice-navigation.js';
+import { toPolar, type Point } from '../utils.js';
 import type { NavigationDrag } from './expert-navigation.js';
+import {
+  menuSelection,
+  noviceMoves,
+  noviceNavigation,
+  submenuNavigation,
+  type NoviceNavigationOptions,
+  type NoviceNotification,
+} from './novice-navigation.js';
 
 vi.mock('../utils');
 vi.mock('../move/dwelling');

--- a/src/navigation/novice-navigation.ts
+++ b/src/navigation/novice-navigation.ts
@@ -1,17 +1,17 @@
 import { merge, type Observable } from 'rxjs';
 import {
-  scan,
-  startWith,
-  share,
+  filter,
   last,
   map,
-  filter,
+  scan,
+  share,
+  startWith,
   switchAll,
   take,
 } from 'rxjs/operators';
-import { toPolar, type Point } from '../utils.js';
 import { dwellings } from '../move/dwelling.js';
 import type { MarkingMenuModelItem } from '../types.js';
+import { toPolar, type Point } from '../utils.js';
 import type { NavigationDrag } from './expert-navigation.js';
 
 /**

--- a/src/recognizer/articulation-points.ts
+++ b/src/recognizer/articulation-points.ts
@@ -1,7 +1,7 @@
 import type { Point } from '../utils.js';
 import {
-  findNextPointFurtherThan,
   findMiddlePointForMinAngle,
+  findNextPointFurtherThan,
 } from './find-points.js';
 
 /**

--- a/src/recognizer/find-points.ts
+++ b/src/recognizer/find-points.ts
@@ -1,4 +1,4 @@
-import { dist, angle, type Point } from '../utils.js';
+import { angle, dist, type Point } from '../utils.js';
 
 /**
  Find the index of the first point of `pointList` that is at least `minDist` away from a

--- a/src/recognizer/recognize-mm-stroke.test.ts
+++ b/src/recognizer/recognize-mm-stroke.test.ts
@@ -1,16 +1,16 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { promisify } from 'node:util';
-import { parse as csvParseCallback } from 'csv-parse';
 import angles from 'angles';
+import { parse as csvParseCallback } from 'csv-parse';
 import { type Mock } from 'vitest';
-import type { Point } from '../utils.js';
 import type { ModelItem, ModelRoot } from '../types.js';
+import type { Point } from '../utils.js';
 import {
-  recognizeMarkingMenuStroke,
-  pointsToSegments,
   divideLongestSegment,
   findItem,
+  pointsToSegments,
+  recognizeMarkingMenuStroke,
   walkModel,
 } from './recognize-mm-stroke.js';
 

--- a/src/recognizer/recognize-mm-stroke.ts
+++ b/src/recognizer/recognize-mm-stroke.ts
@@ -1,3 +1,4 @@
+import type { MarkingMenuModelItem } from '../types.js';
 import {
   dist,
   findMaxEntry,
@@ -6,7 +7,6 @@ import {
   type Point,
   type Segment,
 } from '../utils.js';
-import type { MarkingMenuModelItem } from '../types.js';
 import { getStrokeArticulationPoints } from './articulation-points.js';
 import { strokeLength } from './stroke-length.js';
 

--- a/src/utils.test-d.ts
+++ b/src/utils.test-d.ts
@@ -1,15 +1,15 @@
-import { describe, it, expectTypeOf } from 'vitest';
+import { describe, expectTypeOf, it } from 'vitest';
 import {
   isNonEmptyArray,
-  type SetOptional,
-  type Simplify,
   type DeepReadonly,
-  type NonEmptyArray,
-  type EmptyTuple,
   type EmptyArray,
+  type EmptyTuple,
   type IsTuple,
+  type NonEmptyArray,
   type Point,
   type Segment,
+  type SetOptional,
+  type Simplify,
 } from './utils.js';
 
 /*

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,14 +1,14 @@
 import {
-  deltaAngle,
-  mod,
-  dist,
   angle,
-  findMaxEntry,
-  toPolar,
-  radiansToDegrees,
   degreesToRadians,
-  noOp,
+  deltaAngle,
+  dist,
+  findMaxEntry,
   isNonEmptyArray,
+  mod,
+  noOp,
+  radiansToDegrees,
+  toPolar,
 } from './utils.js';
 
 describe('mod', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -56,7 +56,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.29.7":
+"@babel/generator@npm:^7.26.2, @babel/generator@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/generator@npm:7.29.7"
   dependencies:
@@ -90,7 +90,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.10.3, @babel/parser@npm:^7.29.3, @babel/parser@npm:^7.29.7":
+"@babel/parser@npm:^7.10.3, @babel/parser@npm:^7.26.2, @babel/parser@npm:^7.29.3, @babel/parser@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/parser@npm:7.29.7"
   dependencies:
@@ -119,7 +119,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.10.3":
+"@babel/traverse@npm:^7.10.3, @babel/traverse@npm:^7.25.9":
   version: 7.29.7
   resolution: "@babel/traverse@npm:7.29.7"
   dependencies:
@@ -134,7 +134,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.10.3, @babel/types@npm:^7.29.0, @babel/types@npm:^7.29.7":
+"@babel/types@npm:^7.10.3, @babel/types@npm:^7.26.0, @babel/types@npm:^7.29.0, @babel/types@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/types@npm:7.29.7"
   dependencies:
@@ -838,6 +838,34 @@ __metadata:
   version: 0.4.3
   resolution: "@humanwhocodes/retry@npm:0.4.3"
   checksum: 10c0/3775bb30087d4440b3f7406d5a057777d90e4b9f435af488a4923ef249e93615fb78565a85f173a186a076c7706a81d0d57d563a2624e4de2c5c9c66c486ce42
+  languageName: node
+  linkType: hard
+
+"@ianvs/prettier-plugin-sort-imports@npm:^4.7.1":
+  version: 4.7.1
+  resolution: "@ianvs/prettier-plugin-sort-imports@npm:4.7.1"
+  dependencies:
+    "@babel/generator": "npm:^7.26.2"
+    "@babel/parser": "npm:^7.26.2"
+    "@babel/traverse": "npm:^7.25.9"
+    "@babel/types": "npm:^7.26.0"
+    semver: "npm:^7.5.2"
+  peerDependencies:
+    "@prettier/plugin-oxc": ^0.0.4 || ^0.1.0
+    "@vue/compiler-sfc": 2.7.x || 3.x
+    content-tag: ^4.0.0
+    prettier: 2 || 3 || ^4.0.0-0
+    prettier-plugin-ember-template-tag: ^2.1.0
+  peerDependenciesMeta:
+    "@prettier/plugin-oxc":
+      optional: true
+    "@vue/compiler-sfc":
+      optional: true
+    content-tag:
+      optional: true
+    prettier-plugin-ember-template-tag:
+      optional: true
+  checksum: 10c0/cda335ef13b4f95825c7667a4962bd679c0065863572f9d3bd715f2d2a463e56e93808dc7b5c24ecca33d63ddf2159780cfdb3d78f30c828b6efb054972dfc5b
   languageName: node
   linkType: hard
 
@@ -3861,6 +3889,7 @@ __metadata:
   dependencies:
     "@changesets/changelog-github": "npm:^0.7.0"
     "@changesets/cli": "npm:^2.31.1"
+    "@ianvs/prettier-plugin-sort-imports": "npm:^4.7.1"
     "@types/node": "npm:^26.1.1"
     "@typescript/native": "npm:typescript@^7.0.2"
     "@vitest/coverage-v8": "npm:^4.1.10"
@@ -5117,7 +5146,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.5, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.3, semver@npm:^7.7.1, semver@npm:^7.7.2, semver@npm:^7.7.3, semver@npm:^7.8.5":
+"semver@npm:^7.3.5, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.3, semver@npm:^7.7.1, semver@npm:^7.7.2, semver@npm:^7.7.3, semver@npm:^7.8.5":
   version: 7.8.5
   resolution: "semver@npm:7.8.5"
   bin:


### PR DESCRIPTION
Switch import sorting from ESLint (`import-x/order`) to Prettier via `@ianvs/prettier-plugin-sort-imports`.

Changes:
- Added `@ianvs/prettier-plugin-sort-imports` dependency
- Configured plugin in `prettier.config.ts` with groups `[builtin, external, relative]` and case-insensitive alphabetical order
- Removed redundant `import-x/order` rule from ESLint config
- Ran `yarn format` to apply sorting across all source files

On save, VS Code users with `editor.formatOnSave: true` will get imports automatically sorted.