### PR TITLE
build: drop UMD build, keep only ESM output

### DIFF
--- a/.changeset/drop-umd-build.md
+++ b/.changeset/drop-umd-build.md
@@ -1,0 +1,5 @@
+---
+'marking-menu': minor
+---
+
+Remove the UMD build. The package now ships only an ES module build.

--- a/.changeset/simplify-rxjs-imports.md
+++ b/.changeset/simplify-rxjs-imports.md
@@ -4,4 +4,4 @@
 
 Import RxJS operators from `rxjs`. ES module users can remove `rxjs/operators`
 from their import maps; custom shims must expose operators on the root `rxjs`
-export. Standard RxJS 7 UMD users need no changes.
+export.

--- a/README.md
+++ b/README.md
@@ -23,31 +23,8 @@ The authors and contributors of this library may not be held responsible for any
 
 ### Browser with CDN
 
-You can use [unpkg](https://unpkg.com) to fetch both [`rxjs`](http://reactivex.io/rxjs/) and `marking-menu`:
-
-- https://unpkg.com/rxjs@7/dist/bundles/rxjs.umd.js,
-- https://unpkg.com/marking-menu,
-
-```html
-<!DOCTYPE html>
-<html>
-  <head>
-    <script
-      src="https://unpkg.com/rxjs@7/dist/bundles/rxjs.umd.js"
-      defer
-    ></script>
-    <script src="https://unpkg.com/marking-menu" defer></script>
-    <script defer>
-      const { createMarkingMenu } = window.createMarkingMenu;
-      // Your stuff.
-    </script>
-  </head>
-  <body></body>
-</html>
-```
-
-Or, as a native ES module using an import map to resolve `marking-menu` and
-its bare `rxjs` imports:
+Use a native ES module with an import map to resolve `marking-menu` and its
+bare `rxjs` imports:
 
 ```html
 <!DOCTYPE html>
@@ -71,22 +48,16 @@ its bare `rxjs` imports:
 </html>
 ```
 
-### ES modules or CommonJS
+### ES modules
 
 ```sh
 npm install -S marking-menu
 ```
 
-Then (ES modules)
+Then:
 
 ```js
 import { createMarkingMenu } from 'marking-menu';
-```
-
-or (CommonJS)
-
-```js
-const { createMarkingMenu } = require('marking-menu');
 ```
 
 ## API

--- a/demo/index.html
+++ b/demo/index.html
@@ -7,7 +7,7 @@
     <script type="importmap">
       {
         "imports": {
-          "marking-menu": "./marking-menu.mjs",
+          "marking-menu": "./marking-menu.js",
           "rxjs": "https://esm.sh/rxjs@7.8.2"
         }
       }

--- a/package.json
+++ b/package.json
@@ -6,13 +6,7 @@
   "repository": "github:QuentinRoy/Marking-Menu",
   "author": "Quentin Roy <quentin@quentinroy.fr>",
   "type": "module",
-  "exports": {
-    ".": {
-      "import": "./dist/marking-menu.mjs",
-      "require": "./dist/marking-menu.js",
-      "default": "./dist/marking-menu.js"
-    }
-  },
+  "exports": "./dist/marking-menu.mjs",
   "sideEffects": false,
   "engines": {
     "node": ">=24"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "github:QuentinRoy/Marking-Menu",
   "author": "Quentin Roy <quentin@quentinroy.fr>",
   "type": "module",
-  "exports": "./dist/marking-menu.mjs",
+  "exports": "./dist/marking-menu.js",
   "sideEffects": false,
   "engines": {
     "node": ">=24"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,20 +20,13 @@ export default defineConfig({
     cssMinify: 'lightningcss',
     lib: {
       entry: path.resolve(import.meta.dirname, 'src/index.ts'),
-      fileName: (format) =>
-        format === 'es' ? 'marking-menu.mjs' : 'marking-menu.js',
-      formats: ['es', 'umd'],
-      name: 'createMarkingMenu',
+      fileName: 'marking-menu.mjs',
+      formats: ['es'],
     },
     minify: false,
     rolldownOptions: {
       external: ['rxjs'],
-      output: {
-        banner,
-        globals: {
-          rxjs: 'rxjs',
-        },
-      },
+      output: { banner },
     },
     sourcemap: true,
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,8 +20,7 @@ export default defineConfig({
     cssMinify: 'lightningcss',
     lib: {
       entry: path.resolve(import.meta.dirname, 'src/index.ts'),
-      // Using a callback so vite does not add the .js extension to the file name.
-      fileName: () => 'marking-menu.mjs',
+      fileName: 'marking-menu',
       formats: ['es'],
     },
     minify: false,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,8 @@ export default defineConfig({
     cssMinify: 'lightningcss',
     lib: {
       entry: path.resolve(import.meta.dirname, 'src/index.ts'),
-      fileName: 'marking-menu.mjs',
+      // Using a callback so vite does not add the .js extension to the file name.
+      fileName: () => 'marking-menu.mjs',
       formats: ['es'],
     },
     minify: false,


### PR DESCRIPTION
## Summary
- remove the UMD build configuration
- add a minor Changeset for the ESM-only distribution
- remove the stale UMD compatibility note from the RxJS Changeset

## Verification
- yarn changeset status