### PR TITLE
chore: correct 1.0 changesets

### DIFF
--- a/.changeset/caller-provided-item-ids.md
+++ b/.changeset/caller-provided-item-ids.md
@@ -1,6 +1,8 @@
 ---
-'marking-menu': minor
+'marking-menu': major
 ---
 
-Stop generating item IDs. Items without a caller-provided ID now have
-`id: undefined`.
+Stop assigning generated positional IDs to menu items. Items without a
+caller-provided ID now expose `id: undefined`; provide an explicit ID when an
+item must be addressed by ID. Positional identity is available separately as
+the library-assigned `key` property.

--- a/.changeset/children-by-label.md
+++ b/.changeset/children-by-label.md
@@ -1,5 +1,5 @@
 ---
-'marking-menu': minor
+'marking-menu': major
 ---
 
 Rename `getChildrenByName()` to `getChildrenByLabel()` on emitted menu items.

--- a/.changeset/drop-umd-build.md
+++ b/.changeset/drop-umd-build.md
@@ -1,5 +1,8 @@
 ---
-'marking-menu': minor
+'marking-menu': major
 ---
 
-Remove the UMD build. The package now ships only an ES module build.
+Ship a single ES module entry point at `dist/marking-menu.js`. Remove the UMD
+artifact, including its CommonJS, AMD, and `window.MarkingMenu` loading paths,
+and remove the former `marking-menu.mjs` entry point. Browser consumers must
+now load the package as an ES module.

--- a/.changeset/empty-nearest-child.md
+++ b/.changeset/empty-nearest-child.md
@@ -1,0 +1,6 @@
+---
+'marking-menu': major
+---
+
+Return `null` from `getNearestChild()` when an emitted menu item has no
+sub-items, instead of throwing.

--- a/.changeset/get-child-null.md
+++ b/.changeset/get-child-null.md
@@ -1,6 +1,7 @@
 ---
-'marking-menu': minor
+'marking-menu': major
 ---
 
-Return `null` instead of `undefined` from `getChild()` when an item ID is not
-found.
+Return `null` instead of `undefined` from `getChild()` when no direct sub-item
+has the requested ID. Calling `getChild()` on a leaf now also returns `null`
+instead of throwing.

--- a/.changeset/is-leaf-property.md
+++ b/.changeset/is-leaf-property.md
@@ -1,5 +1,5 @@
 ---
-'marking-menu': minor
+'marking-menu': major
 ---
 
 Replace the `isLeaf()` method on emitted menu items with an `isLeaf` boolean

--- a/.changeset/is-root-property.md
+++ b/.changeset/is-root-property.md
@@ -1,5 +1,5 @@
 ---
-'marking-menu': minor
+'marking-menu': major
 ---
 
 Replace the `isRoot()` method on emitted menu items with an `isRoot` boolean

--- a/.changeset/item-label-property.md
+++ b/.changeset/item-label-property.md
@@ -1,5 +1,5 @@
 ---
-'marking-menu': minor
+'marking-menu': major
 ---
 
 Rename the menu item `name` property to `label`.

--- a/.changeset/modern-browser-target.md
+++ b/.changeset/modern-browser-target.md
@@ -1,0 +1,6 @@
+---
+'marking-menu': major
+---
+
+Raise the browser build target to Chrome and Edge 111, Firefox 114, and
+Safari and iOS 16.4 or newer.

--- a/.changeset/named-create-export.md
+++ b/.changeset/named-create-export.md
@@ -1,5 +1,5 @@
 ---
-'marking-menu': minor
+'marking-menu': major
 ---
 
 Replace the default `MarkingMenu` export with the named `createMarkingMenu`

--- a/.changeset/node-24.md
+++ b/.changeset/node-24.md
@@ -1,0 +1,5 @@
+---
+'marking-menu': major
+---
+
+Require Node.js 24 or newer.

--- a/.changeset/object-based-menu-api.md
+++ b/.changeset/object-based-menu-api.md
@@ -1,5 +1,5 @@
 ---
-'marking-menu': minor
+'marking-menu': major
 ---
 
 Remove the string shorthand for menu items. Every menu item must now be an

--- a/.changeset/object-menu-config.md
+++ b/.changeset/object-menu-config.md
@@ -1,5 +1,5 @@
 ---
-'marking-menu': minor
+'marking-menu': major
 ---
 
 Pass a single configuration object to `createMarkingMenu` instead of using

--- a/.changeset/remove-item-parent.md
+++ b/.changeset/remove-item-parent.md
@@ -1,5 +1,5 @@
 ---
-'marking-menu': minor
+'marking-menu': major
 ---
 
 Remove the `parent` property from emitted menu items.

--- a/.changeset/rxjs-7-8.md
+++ b/.changeset/rxjs-7-8.md
@@ -1,5 +1,0 @@
----
-'marking-menu': major
----
-
-Require RxJS 7.8.2 or newer and consume it exclusively as a peer dependency.

--- a/.changeset/rxjs-7-8.md
+++ b/.changeset/rxjs-7-8.md
@@ -1,0 +1,5 @@
+---
+'marking-menu': major
+---
+
+Require RxJS 7.8.2 or newer and consume it exclusively as a peer dependency.

--- a/.changeset/selection-item-api.md
+++ b/.changeset/selection-item-api.md
@@ -1,5 +1,5 @@
 ---
-'marking-menu': minor
+'marking-menu': major
 ---
 
 Expose sub-items of emitted selection items as `items` instead of `children`.

--- a/.changeset/simplify-rxjs-imports.md
+++ b/.changeset/simplify-rxjs-imports.md
@@ -1,7 +1,6 @@
 ---
-'marking-menu': minor
+'marking-menu': patch
 ---
 
-Import RxJS operators from `rxjs`. ES module users can remove `rxjs/operators`
-from their import maps; custom shims must expose operators on the root `rxjs`
-export.
+Resolve RxJS operators from the root `rxjs` entry point. Native ES module
+consumers can remove the `rxjs/operators` entry from their import maps.

--- a/.changeset/submenu-items-property.md
+++ b/.changeset/submenu-items-property.md
@@ -1,5 +1,5 @@
 ---
-'marking-menu': minor
+'marking-menu': major
 ---
 
 Define submenus with `items` instead of `children`.

--- a/.changeset/submenu-opening-delay.md
+++ b/.changeset/submenu-opening-delay.md
@@ -1,0 +1,6 @@
+---
+'marking-menu': major
+---
+
+Rename the `subMenuOpeningDelay` configuration option to
+`submenuOpeningDelay`.

--- a/.changeset/unique-item-ids.md
+++ b/.changeset/unique-item-ids.md
@@ -1,5 +1,7 @@
 ---
-'marking-menu': minor
+'marking-menu': major
 ---
 
-Require caller-provided item IDs to be unique across the whole menu.
+Require caller-provided item IDs to be unique across the entire menu tree.
+Duplicate literal IDs are rejected by TypeScript, and duplicate IDs in
+dynamically built menus throw when the menu is created.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ bare `rxjs` imports:
     <script type="importmap">
       {
         "imports": {
-          "marking-menu": "https://esm.sh/marking-menu@0.10.1?raw",
+          "marking-menu": "https://esm.sh/marking-menu@1?raw",
           "rxjs": "https://esm.sh/rxjs@7.8.2"
         }
       }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
     "vitest": "^4.1.10"
   },
   "peerDependencies": {
-    "rxjs": "^7.8.2"
+    "rxjs": "^7.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3908,7 +3908,7 @@ __metadata:
     vite: "npm:^8.1.5"
     vitest: "npm:^4.1.10"
   peerDependencies:
-    rxjs: ^7.8.2
+    rxjs: ^7.2.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary
- classify consumer-facing breaking changes as major for the 1.0 release
- add missing compatibility notes found by comparing against v0.10.1
- clarify ID and ESM migrations and classify the internal RxJS import change as patch
- support RxJS 7.2 and newer, the first 7.x release with root operator exports
- fix the README CDN example to target the 1.x API

## Validation
- yarn test
- yarn typecheck
- yarn build
- yarn lint (3 existing warnings, no errors)
- yarn prettier --check .changeset README.md
- yarn changeset status
- runtime tests and production build against RxJS 7.2.0