### PR TITLE
ci: install corepack explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .tool-versions
-      - run: corepack enable
+      - run: npm install --global corepack
       - name: Get Yarn cache directory
         id: yarn-cache
         run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .tool-versions
-      - run: corepack enable
+      - run: npm install --global corepack
       - name: Get Yarn cache directory
         id: yarn-cache
         run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version-file: .tool-versions
           registry-url: https://registry.npmjs.org
-      - run: corepack enable
+      - run: npm install --global corepack
       - name: Get Yarn cache directory
         id: yarn-cache
         run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- install Corepack from npm in CI, deploy, and release workflows
- stop relying on the runner image's bundled Corepack after moving to Node 26

## Verification
- `git diff --check`
- `./node_modules/.bin/prettier --check .github/workflows/ci.yml .github/workflows/deploy.yml .github/workflows/release.yml`