### PR TITLE
chore: normalize package scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ jobs:
       - run: yarn lint
       - run: yarn format:check
       - run: yarn typecheck
-      - run: yarn coverage
-      - run: yarn build-demo
-      - run: yarn publint
-      - run: yarn check-types-published
-      - run: yarn smoke-test
+      - run: yarn test:coverage
+      - run: yarn demo:build
+      - run: yarn package:lint
+      - run: yarn package:types
+      - run: yarn package:smoke-test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: yarn install --immutable
-      - run: yarn build-demo
+      - run: yarn demo:build
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:

--- a/package.json
+++ b/package.json
@@ -16,24 +16,23 @@
   "packageManager": "yarn@4.17.1",
   "scripts": {
     "test": "vitest run",
-    "watch-test": "vitest",
+    "test:watch": "vitest",
     "typecheck": "tsc -b",
-    "coverage": "vitest run --coverage",
+    "test:coverage": "vitest run --coverage",
     "build": "vite build",
-    "build-demo": "yarn build && vite build --config vite.demo.config.ts",
-    "dev": "vite --config vite.demo.config.ts",
-    "watch": "vite build --watch",
+    "build:watch": "vite build --watch",
+    "demo:build": "yarn build && vite build --config vite.demo.config.ts",
+    "demo:dev": "vite --config vite.demo.config.ts",
+    "demo:preview": "vite preview --config vite.demo.config.ts",
     "prepare": "yarn build",
     "changeset": "changeset",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "publint": "publint",
-    "check-types-published": "attw --pack . --profile esm-only",
-    "smoke-test": "node scripts/smoke-test.ts",
-    "serve": "yarn preview",
-    "preview": "vite preview --config vite.demo.config.ts"
+    "package:lint": "publint",
+    "package:types": "attw --pack . --profile esm-only",
+    "package:smoke-test": "node scripts/smoke-test.ts"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Summary
- organize package scripts by test, build, demo, and package targets
- remove the redundant serve alias
- update CI and deployment workflow script calls

## Validation
- yarn lint
- yarn format:check
- yarn typecheck
- yarn test:coverage
- yarn demo:build
- yarn package:lint
- yarn package:types
- yarn package:smoke-test