### PR TITLE
Allow partial logger configuration

### DIFF
--- a/src/marking-menu.test.ts
+++ b/src/marking-menu.test.ts
@@ -10,6 +10,7 @@ import {
   exportNotification,
   createMarkingMenu as main,
   type MarkingMenuConfig,
+  type MarkingMenuLogger,
 } from './marking-menu.js';
 import { createModel } from './model.js';
 import { pointerDrags } from './move/pointer-drag.js';
@@ -222,7 +223,8 @@ describe('main', () => {
     mockNavObs$ = m.hot(  '--a--b-c|', mockNavNotifs);
     connectedObs$ = m.hot('--d-e--f-g|');
     const connectedSub =  '^---------!';
-    callMain().subscribe();
+    const logDebug = vi.fn();
+    callMain({ log: { debug: logDebug } }).subscribe();
     expect(mockConnectLayout).toHaveBeenCalledTimes(1);
     const options = mockConnectLayout.mock.calls[0]?.[0] as {
       parent: unknown;
@@ -231,7 +233,7 @@ describe('main', () => {
       createUpperStrokeCanvas: unknown;
       createLowerStrokeCanvas: unknown;
       createGestureFeedback: unknown;
-      log: unknown;
+      log: MarkingMenuLogger;
     };
     expect(options.parent).toBe('mock-parent');
     m.expect(options.navigation$).toBeObservable(mockNavObs$);
@@ -240,7 +242,10 @@ describe('main', () => {
     expect(options.createUpperStrokeCanvas).toBeInstanceOf(Function);
     expect(options.createLowerStrokeCanvas).toBeInstanceOf(Function);
     expect(options.createGestureFeedback).toBeInstanceOf(Function);
-    expect(options.log).toBe('mock-log');
+    expect(options.log.error).toBeInstanceOf(Function);
+    expect(options.log.info).toBeInstanceOf(Function);
+    expect(options.log.warn).toBeInstanceOf(Function);
+    expect(options.log.debug).toBe(logDebug);
   }));
 
   it('properly binds MenuLayout when it connects the layout', () => {

--- a/src/marking-menu.ts
+++ b/src/marking-menu.ts
@@ -190,7 +190,7 @@ export type MarkingMenuConfig = MarkingMenuInput & {
    */
   notifySteps?: boolean;
   /** Override the default logger to use. */
-  log?: MarkingMenuLogger;
+  log?: Partial<MarkingMenuLogger>;
 };
 
 /**
@@ -235,15 +235,19 @@ export function createMarkingMenu<const Config extends MarkingMenuConfig>(
     gestureFeedbackCanceledStrokeColor = '#DE6C52',
     gestureFeedbackStrokeColor = strokeColor,
     notifySteps = false,
-    log = {
-      error: console?.error?.bind(console) ?? noOp,
-      info: console?.info?.bind(console) ?? noOp,
-      warn: console?.warn?.bind(console) ?? noOp,
-      debug: noOp,
-    },
+    log: {
+      error: logError = console?.error?.bind(console) ?? noOp,
+      info: logInfo = console?.info?.bind(console) ?? noOp,
+      warn: logWarn = console?.warn?.bind(console) ?? noOp,
+      debug: logDebug = noOp,
+    } = {},
   } = config;
-  // Create the display options.
-  const menuLayoutOptions = {};
+  const log = {
+    error: logError,
+    info: logInfo,
+    warn: logWarn,
+    debug: logDebug,
+  };
   const strokeCanvasOptions = {
     lineColor: strokeColor,
     lineWidth: strokeWidth,
@@ -298,7 +302,6 @@ export function createMarkingMenu<const Config extends MarkingMenuConfig>(
         parent: menuParent,
         model: menuModel,
         center,
-        ...menuLayoutOptions,
       }),
     createUpperStrokeCanvas: (canvasParent: HTMLElement) =>
       createStrokeCanvas({ parent: canvasParent, ...strokeCanvasOptions }),

--- a/src/marking-menu.ts
+++ b/src/marking-menu.ts
@@ -131,6 +131,13 @@ export type MarkingMenuLogger = {
   debug: (...args: unknown[]) => void;
 };
 
+const defaultLogger: MarkingMenuLogger = {
+  error: console?.error?.bind(console) ?? noOp,
+  info: console?.info?.bind(console) ?? noOp,
+  warn: console?.warn?.bind(console) ?? noOp,
+  debug: noOp,
+};
+
 /**
  Configuration of a marking menu, as accepted by {@link createMarkingMenu}.
  */
@@ -235,19 +242,8 @@ export function createMarkingMenu<const Config extends MarkingMenuConfig>(
     gestureFeedbackCanceledStrokeColor = '#DE6C52',
     gestureFeedbackStrokeColor = strokeColor,
     notifySteps = false,
-    log: {
-      error: logError = console?.error?.bind(console) ?? noOp,
-      info: logInfo = console?.info?.bind(console) ?? noOp,
-      warn: logWarn = console?.warn?.bind(console) ?? noOp,
-      debug: logDebug = noOp,
-    } = {},
   } = config;
-  const log = {
-    error: logError,
-    info: logInfo,
-    warn: logWarn,
-    debug: logDebug,
-  };
+  const log = { ...defaultLogger, ...config.log };
   const strokeCanvasOptions = {
     lineColor: strokeColor,
     lineWidth: strokeWidth,


### PR DESCRIPTION
## Summary

- accept partial `MarkingMenuLogger` overrides
- fill omitted logger methods with their defaults
- remove the unused empty `menuLayoutOptions` object
