### PR TITLE
Extract the shared touch-action claim into an RxJS-free module

### DIFF
--- a/src/move/pointer-drag.ts
+++ b/src/move/pointer-drag.ts
@@ -9,54 +9,7 @@ import {
   createPointerNotification,
   type PointerNotification,
 } from './pointer-events.js';
-
-type TouchActionState = {
-  count: number;
-  priority: string;
-  value: string;
-};
-
-const touchActionStates = new WeakMap<HTMLElement, TouchActionState>();
-
-const disableTouchAction = (rootDOM: HTMLElement): (() => void) => {
-  const currentState = touchActionStates.get(rootDOM);
-  if (currentState) {
-    currentState.count += 1;
-  } else {
-    touchActionStates.set(rootDOM, {
-      count: 1,
-      priority: rootDOM.style.getPropertyPriority('touch-action'),
-      value: rootDOM.style.getPropertyValue('touch-action'),
-    });
-    rootDOM.style.setProperty('touch-action', 'none', 'important');
-  }
-
-  return () => {
-    const state = touchActionStates.get(rootDOM);
-    if (!state) {
-      return;
-    }
-
-    state.count -= 1;
-    if (state.count > 0) {
-      return;
-    }
-
-    touchActionStates.delete(rootDOM);
-    if (
-      rootDOM.style.getPropertyValue('touch-action') !== 'none' ||
-      rootDOM.style.getPropertyPriority('touch-action') !== 'important'
-    ) {
-      return;
-    }
-
-    if (state.value === '') {
-      rootDOM.style.removeProperty('touch-action');
-    } else {
-      rootDOM.style.setProperty('touch-action', state.value, state.priority);
-    }
-  };
-};
+import { claimTouchAction } from './touch-action.js';
 
 type ActiveDrag = {
   connection: Subscription;
@@ -76,7 +29,7 @@ export const pointerDrags = (
 ): Observable<Observable<PointerNotification<PointerEvent>>> =>
   new Observable((subscriber) => {
     let active: ActiveDrag | undefined;
-    const restoreTouchAction = disableTouchAction(rootDOM);
+    const releaseTouchAction = claimTouchAction(rootDOM);
 
     const releaseCapture = (pointerId: number) => {
       try {
@@ -192,6 +145,6 @@ export const pointerDrags = (
       rootDOM.removeEventListener('pointercancel', onPointerCancel);
       rootDOM.removeEventListener('lostpointercapture', onLostPointerCapture);
       finish();
-      restoreTouchAction();
+      releaseTouchAction();
     };
   });

--- a/src/move/touch-action.test.ts
+++ b/src/move/touch-action.test.ts
@@ -1,0 +1,110 @@
+import { claimTouchAction } from './touch-action.js';
+
+describe('claimTouchAction', () => {
+  it('forces touch-action none as important while a claim is held', () => {
+    const element = document.createElement('div');
+
+    claimTouchAction(element);
+
+    expect(element.style.getPropertyValue('touch-action')).toBe('none');
+    expect(element.style.getPropertyPriority('touch-action')).toBe('important');
+  });
+
+  it('removes the property entirely when there was no inline value', () => {
+    const element = document.createElement('div');
+
+    claimTouchAction(element)();
+
+    expect(element.style.getPropertyValue('touch-action')).toBe('');
+    expect(element.style.getPropertyPriority('touch-action')).toBe('');
+    expect(element.getAttribute('style')).not.toContain('touch-action');
+  });
+
+  it('restores the exact prior value and priority on the last release', () => {
+    const element = document.createElement('div');
+    element.style.setProperty('touch-action', 'pan-x', 'important');
+
+    claimTouchAction(element)();
+
+    expect(element.style.getPropertyValue('touch-action')).toBe('pan-x');
+    expect(element.style.getPropertyPriority('touch-action')).toBe('important');
+  });
+
+  it('restores a prior value that had no priority', () => {
+    const element = document.createElement('div');
+    element.style.setProperty('touch-action', 'pan-y');
+
+    claimTouchAction(element)();
+
+    expect(element.style.getPropertyValue('touch-action')).toBe('pan-y');
+    expect(element.style.getPropertyPriority('touch-action')).toBe('');
+  });
+
+  it('does not re-record the original value when a second claim is taken', () => {
+    const element = document.createElement('div');
+    element.style.setProperty('touch-action', 'pan-x');
+    const first = claimTouchAction(element);
+    const second = claimTouchAction(element);
+
+    first();
+    expect(element.style.getPropertyValue('touch-action')).toBe('none');
+    expect(element.style.getPropertyPriority('touch-action')).toBe('important');
+
+    second();
+    expect(element.style.getPropertyValue('touch-action')).toBe('pan-x');
+    expect(element.style.getPropertyPriority('touch-action')).toBe('');
+  });
+
+  it('ignores a claim released twice', () => {
+    const element = document.createElement('div');
+    element.style.setProperty('touch-action', 'pan-x');
+    const first = claimTouchAction(element);
+    const second = claimTouchAction(element);
+
+    first();
+    first();
+
+    expect(element.style.getPropertyValue('touch-action')).toBe('none');
+    expect(element.style.getPropertyPriority('touch-action')).toBe('important');
+
+    second();
+    expect(element.style.getPropertyValue('touch-action')).toBe('pan-x');
+  });
+
+  it('leaves an externally changed value alone on release', () => {
+    const element = document.createElement('div');
+    element.style.setProperty('touch-action', 'pan-x', 'important');
+    const release = claimTouchAction(element);
+
+    element.style.setProperty('touch-action', 'manipulation');
+    release();
+
+    expect(element.style.getPropertyValue('touch-action')).toBe('manipulation');
+    expect(element.style.getPropertyPriority('touch-action')).toBe('');
+  });
+
+  it('starts a fresh claim after the previous one was fully released', () => {
+    const element = document.createElement('div');
+    element.style.setProperty('touch-action', 'pan-x');
+    claimTouchAction(element)();
+
+    const release = claimTouchAction(element);
+    expect(element.style.getPropertyValue('touch-action')).toBe('none');
+    release();
+    expect(element.style.getPropertyValue('touch-action')).toBe('pan-x');
+  });
+
+  it('tracks claims on distinct elements independently', () => {
+    const first = document.createElement('div');
+    const second = document.createElement('div');
+    first.style.setProperty('touch-action', 'pan-x');
+
+    const releaseFirst = claimTouchAction(first);
+    claimTouchAction(second);
+
+    releaseFirst();
+
+    expect(first.style.getPropertyValue('touch-action')).toBe('pan-x');
+    expect(second.style.getPropertyValue('touch-action')).toBe('none');
+  });
+});

--- a/src/move/touch-action.ts
+++ b/src/move/touch-action.ts
@@ -16,8 +16,7 @@ const isClaimedOnElement = (element: HTMLElement): boolean =>
 
 const setTouchAction = (
   element: HTMLElement,
-  value: string,
-  priority: string,
+  { priority, value }: { priority: string; value: string },
 ): void => {
   if (value === '') {
     element.style.removeProperty(PROPERTY);
@@ -47,7 +46,10 @@ export const claimTouchAction = (element: HTMLElement): (() => void) => {
       priority: element.style.getPropertyPriority(PROPERTY),
       value: element.style.getPropertyValue(PROPERTY),
     });
-    setTouchAction(element, CLAIMED_VALUE, CLAIMED_PRIORITY);
+    setTouchAction(element, {
+      priority: CLAIMED_PRIORITY,
+      value: CLAIMED_VALUE,
+    });
   }
 
   let isReleased = false;
@@ -72,6 +74,6 @@ export const claimTouchAction = (element: HTMLElement): (() => void) => {
       return;
     }
 
-    setTouchAction(element, state.value, state.priority);
+    setTouchAction(element, state);
   };
 };

--- a/src/move/touch-action.ts
+++ b/src/move/touch-action.ts
@@ -1,3 +1,7 @@
+const PROPERTY = 'touch-action';
+const CLAIMED_VALUE = 'none';
+const CLAIMED_PRIORITY = 'important';
+
 type TouchActionClaimState = {
   count: number;
   priority: string;
@@ -5,6 +9,22 @@ type TouchActionClaimState = {
 };
 
 const claimStates = new WeakMap<HTMLElement, TouchActionClaimState>();
+
+const isClaimedOnElement = (element: HTMLElement): boolean =>
+  element.style.getPropertyValue(PROPERTY) === CLAIMED_VALUE &&
+  element.style.getPropertyPriority(PROPERTY) === CLAIMED_PRIORITY;
+
+const setTouchAction = (
+  element: HTMLElement,
+  value: string,
+  priority: string,
+): void => {
+  if (value === '') {
+    element.style.removeProperty(PROPERTY);
+  } else {
+    element.style.setProperty(PROPERTY, value, priority);
+  }
+};
 
 /**
  Claim an element's inline `touch-action`, forcing `none !important` on it.
@@ -24,10 +44,10 @@ export const claimTouchAction = (element: HTMLElement): (() => void) => {
   } else {
     claimStates.set(element, {
       count: 1,
-      priority: element.style.getPropertyPriority('touch-action'),
-      value: element.style.getPropertyValue('touch-action'),
+      priority: element.style.getPropertyPriority(PROPERTY),
+      value: element.style.getPropertyValue(PROPERTY),
     });
-    element.style.setProperty('touch-action', 'none', 'important');
+    setTouchAction(element, CLAIMED_VALUE, CLAIMED_PRIORITY);
   }
 
   let isReleased = false;
@@ -48,17 +68,10 @@ export const claimTouchAction = (element: HTMLElement): (() => void) => {
     }
 
     claimStates.delete(element);
-    if (
-      element.style.getPropertyValue('touch-action') !== 'none' ||
-      element.style.getPropertyPriority('touch-action') !== 'important'
-    ) {
+    if (!isClaimedOnElement(element)) {
       return;
     }
 
-    if (state.value === '') {
-      element.style.removeProperty('touch-action');
-    } else {
-      element.style.setProperty('touch-action', state.value, state.priority);
-    }
+    setTouchAction(element, state.value, state.priority);
   };
 };

--- a/src/move/touch-action.ts
+++ b/src/move/touch-action.ts
@@ -1,0 +1,64 @@
+type TouchActionClaimState = {
+  count: number;
+  priority: string;
+  value: string;
+};
+
+const claimStates = new WeakMap<HTMLElement, TouchActionClaimState>();
+
+/**
+ Claim an element's inline `touch-action`, forcing `none !important` on it.
+
+ Claims are reference-counted per element, so several controllers may share a
+ single parent. The first claim records the inline value and priority the
+ element had; the last release restores them exactly, removing the property
+ when there was none.
+
+ The returned release function is idempotent, and restoring is skipped
+ altogether when the inline value was changed from outside while claimed.
+ */
+export const claimTouchAction = (element: HTMLElement): (() => void) => {
+  const currentState = claimStates.get(element);
+  if (currentState) {
+    currentState.count += 1;
+  } else {
+    claimStates.set(element, {
+      count: 1,
+      priority: element.style.getPropertyPriority('touch-action'),
+      value: element.style.getPropertyValue('touch-action'),
+    });
+    element.style.setProperty('touch-action', 'none', 'important');
+  }
+
+  let isReleased = false;
+  return () => {
+    if (isReleased) {
+      return;
+    }
+
+    isReleased = true;
+    const state = claimStates.get(element);
+    if (!state) {
+      return;
+    }
+
+    state.count -= 1;
+    if (state.count > 0) {
+      return;
+    }
+
+    claimStates.delete(element);
+    if (
+      element.style.getPropertyValue('touch-action') !== 'none' ||
+      element.style.getPropertyPriority('touch-action') !== 'important'
+    ) {
+      return;
+    }
+
+    if (state.value === '') {
+      element.style.removeProperty('touch-action');
+    } else {
+      element.style.setProperty('touch-action', state.value, state.priority);
+    }
+  };
+};


### PR DESCRIPTION
Closes #172.

## What changed

The reference-counted `touch-action` claim moves out of the RxJS pointer-drag helper into a standalone `src/move/touch-action.ts`. It exports `claimTouchAction(element)`, which returns a release handle, and imports nothing at all — no RxJS.

- `pointerDrags` now delegates; its ~50 lines of claim logic are gone and `pointer-drag.test.ts` is untouched.
- New unit tests cover the behaviours the old tests did not pin: a claim released at most once, and restore being skipped when the inline value was changed externally while claimed.

## Why

Prefactor for #177. The replacement pointer source must share *one* claim registry with the existing helper — two registries would each keep their own count, and the "exactly one shared claim per parent" guarantee would break silently while both engines coexist.

## For the reviewer

**There is one deliberate behaviour difference, and it is the only one.** The old release callback decremented the count on every call, so releasing the same claim twice could drop another controller's claim. The extracted handle ignores every call after the first (acceptance criterion: "Releasing the same claim twice is a no-op"). `pointerDrags` only ever released once in its teardown, so its observable behaviour is unchanged — but the diff is not a pure move, and shouldn't be read as one.

Everything else is byte-for-byte preserved, including the guard that only restores when the property currently reads exactly `none !important`. Setting `touch-action: none` *without* `!important` from outside while claimed still leaves `none` stuck; that is pre-existing, not new.

No changeset — internal refactor, no public API change.

## Verification

Full suite 185/185, typecheck clean, prettier clean. Lint is clean apart from a pre-existing `max-params` warning in `src/navigation/navigation.ts`. The Playwright E2E suite was not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)