### PR TITLE
Narrow MarkingMenuLogger to { error }

### DIFF
--- a/.changeset/narrow-logger-to-error.md
+++ b/.changeset/narrow-logger-to-error.md
@@ -1,0 +1,11 @@
+---
+'marking-menu': major
+---
+
+Narrow `MarkingMenuLogger` to `{ error: (error: unknown) => void }`. Previously
+overriding the logger required supplying `info`, `warn` and `debug` alongside
+`error`, even though `error` is the only method the library ever calls. Any
+object exposing an `error` method — `console` included — still satisfies the
+type, so most consumers are unaffected; only bespoke loggers that relied on
+`error` accepting multiple arguments (rather than a single value) need an
+update.

--- a/.changeset/narrow-logger-to-error.md
+++ b/.changeset/narrow-logger-to-error.md
@@ -2,10 +2,7 @@
 'marking-menu': major
 ---
 
-Narrow `MarkingMenuLogger` to `{ error: (error: unknown) => void }`. Previously
-overriding the logger required supplying `info`, `warn` and `debug` alongside
-`error`, even though `error` is the only method the library ever calls. Any
-object exposing an `error` method — `console` included — still satisfies the
-type, so most consumers are unaffected; only bespoke loggers that relied on
-`error` accepting multiple arguments (rather than a single value) need an
-update.
+Narrow `MarkingMenuLogger` to `{ error: (error: unknown) => void }`. `info`,
+`warn` and `debug` are gone since nothing in the library called them. Anything
+with an `error` method, `console` included, still satisfies the type; only a
+custom logger whose `error` took more than one argument needs an update.

--- a/.changeset/narrow-logger-to-error.md
+++ b/.changeset/narrow-logger-to-error.md
@@ -4,5 +4,6 @@
 
 Narrow `MarkingMenuLogger` to `{ error: (error: unknown) => void }`. `info`,
 `warn` and `debug` are gone since nothing in the library called them. Anything
-with an `error` method, `console` included, still satisfies the type; only a
-custom logger whose `error` took more than one argument needs an update.
+with an `error` method, `console` included, still satisfies the type. `log`
+stays a partial override, so `error` can still be left out; only a custom
+logger whose `error` took more than one argument needs an update.

--- a/.changeset/narrow-logger-to-error.md
+++ b/.changeset/narrow-logger-to-error.md
@@ -2,9 +2,12 @@
 'marking-menu': major
 ---
 
-Narrow `MarkingMenuLogger` to `error`, now taking a single `unknown` argument
-rather than varargs. `info`, `warn` and `debug` become optional and ignored,
-since nothing in the library ever called them. `console` still satisfies the
-type, and `log` can still be overridden partially. Two things break: a logger
-whose `error` declares two or more required parameters, and any code that
-imported `MarkingMenuLogger` to call `.info()`, `.warn()` or `.debug()` on it.
+Narrow `MarkingMenuLogger` to `error`, now taking a single `Error` argument
+rather than varargs of `unknown`. Errors are normalized before reaching it, so
+a handler typed to expect an `Error` can be passed directly. `info`, `warn`
+and `debug` become optional and ignored, since nothing in the library ever
+called them. `console` still satisfies the type, and `log` can still be
+overridden partially. Three things break: a logger whose `error` expects
+something other than (or in addition to) an `Error`, a logger whose `error`
+declares two or more required parameters, and any code that imported
+`MarkingMenuLogger` to call `.info()`, `.warn()` or `.debug()` on it.

--- a/.changeset/narrow-logger-to-error.md
+++ b/.changeset/narrow-logger-to-error.md
@@ -1,8 +1,10 @@
 ---
-'marking-menu': patch
+'marking-menu': major
 ---
 
-`MarkingMenuLogger`'s `error` now takes a single `unknown` argument instead of
-varargs, matching how it's actually called. `info`, `warn` and `debug` are now
-optional and ignored; `console` still satisfies the type, and `log` can be
-partially overridden, `error` included.
+Narrow `MarkingMenuLogger` to `error`, now taking a single `unknown` argument
+rather than varargs. `info`, `warn` and `debug` become optional and ignored,
+since nothing in the library ever called them. `console` still satisfies the
+type, and `log` can still be overridden partially. Two things break: a logger
+whose `error` declares two or more required parameters, and any code that
+imported `MarkingMenuLogger` to call `.info()`, `.warn()` or `.debug()` on it.

--- a/.changeset/narrow-logger-to-error.md
+++ b/.changeset/narrow-logger-to-error.md
@@ -1,9 +1,8 @@
 ---
-'marking-menu': major
+'marking-menu': patch
 ---
 
-Narrow `MarkingMenuLogger` to `{ error: (error: unknown) => void }`. `info`,
-`warn` and `debug` are gone since nothing in the library called them. Anything
-with an `error` method, `console` included, still satisfies the type. `log`
-stays a partial override, so `error` can still be left out; only a custom
-logger whose `error` took more than one argument needs an update.
+`MarkingMenuLogger`'s `error` now takes a single `unknown` argument instead of
+varargs, matching how it's actually called. `info`, `warn` and `debug` are now
+optional and ignored; `console` still satisfies the type, and `log` can be
+partially overridden, `error` included.

--- a/src/layout/connect.test.ts
+++ b/src/layout/connect.test.ts
@@ -299,6 +299,32 @@ describe('connect', () => {
   }));
 
   // prettier-ignore
+  it('normalizes a non-Error upstream error before logging it, but rethrows the original value', marbles(m => {
+    const values: Record<string, Notification> = {
+      s: { type: 'start', position: 'pos1' as unknown as Point },
+    };
+    const error = 'a plain string failure';
+    const obs = m.hot('---s--#', values, error);
+    const exp = m.hot('---s--#', values, error);
+    m.expect(
+      connect<string, Notification>({
+        parent: parentElement,
+        navigation$: obs,
+        createMenuLayout: menuLayout,
+        createUpperStrokeCanvas: upperStrokeCanvas,
+        createLowerStrokeCanvas: lowerStrokeCanvas,
+        createGestureFeedback: gestureFeedback,
+        log,
+      })
+    ).toBeObservable(exp);
+    m.flush();
+    expect(log.error.mock.calls).toEqual([[expect.any(Error)]]);
+    const [loggedError] = log.error.mock.calls[0] as [Error];
+    expect(loggedError.message).toContain(error);
+    expect(loggedError.cause).toBe(error);
+  }));
+
+  // prettier-ignore
   it('cleans-up and throws on unknown event type', marbles(m => {
     const values: Record<string, Notification> = {
       s: { type: 'start', position: 'pos1' as unknown as Point },

--- a/src/layout/connect.ts
+++ b/src/layout/connect.ts
@@ -21,6 +21,15 @@ export type LayoutNotification<M> =
   | { type: 'move'; position?: Point };
 
 /**
+ Normalize a caught or emitted value into an `Error` before it reaches
+ `log.error`, whose `error` only accepts `Error`. The upstream navigation
+ observable is `unknown` on error, so a non-`Error` value (e.g. thrown by a
+ caller-supplied model) can otherwise reach here.
+ */
+const toError = (value: unknown): Error =>
+  value instanceof Error ? value : new Error(String(value), { cause: value });
+
+/**
  Connect navigation notifications to menu opening and closing.
 
  @param options - Connection options.
@@ -54,7 +63,7 @@ export function connectLayout<M, N extends LayoutNotification<M>>({
   createUpperStrokeCanvas: (parentDOM: HTMLElement) => StrokeCanvas;
   createLowerStrokeCanvas: (parentDOM: HTMLElement) => StrokeCanvas;
   createGestureFeedback: (options: { parent: HTMLElement }) => GestureFeedback;
-  log: { error: (error: unknown) => void };
+  log: { error: (error: Error) => void };
 }): Observable<N> {
   // The menu object.
   let menu: Menu | null = null;
@@ -266,12 +275,12 @@ export function connectLayout<M, N extends LayoutNotification<M>>({
         try {
           onNotification(notification);
         } catch (error) {
-          log.error(error);
+          log.error(toError(error));
           throw error;
         }
       },
       error(error: unknown) {
-        log.error(error);
+        log.error(toError(error));
         throw error;
       },
     }),
@@ -279,7 +288,7 @@ export function connectLayout<M, N extends LayoutNotification<M>>({
       try {
         cleanUp();
       } catch (error) {
-        log.error(error);
+        log.error(toError(error));
         throw error;
       }
     }),

--- a/src/marking-menu.test-d.ts
+++ b/src/marking-menu.test-d.ts
@@ -1,6 +1,6 @@
 import type { Observable } from 'rxjs';
 import { describe, expectTypeOf, it } from 'vitest';
-import { createMarkingMenu } from './marking-menu.js';
+import { createMarkingMenu, type MarkingMenuLogger } from './marking-menu.js';
 import type { MarkingMenuItemInput } from './types.js';
 
 /*
@@ -76,5 +76,41 @@ describe('createMarkingMenu', () => {
     expectTypeOf<
       Extract<Value<typeof menu$>, { type: string }>
     >().not.toBeNever();
+  });
+
+  it('accepts a logger overriding only `error`', () => {
+    createMarkingMenu({
+      items: [{ id: 'right', label: 'Right' }],
+      parent,
+      log: { error: (error: unknown) => sendToSentry(error) },
+    });
+  });
+
+  it('accepts `console` as the logger', () => {
+    createMarkingMenu({
+      items: [{ id: 'right', label: 'Right' }],
+      parent,
+      log: console,
+    });
+  });
+
+  it('rejects a logger missing `error`', () => {
+    createMarkingMenu({
+      items: [{ id: 'right', label: 'Right' }],
+      parent,
+      // @ts-expect-error -- `log` no longer accepts `info`/`warn`/`debug` in
+      // place of the required `error`.
+      log: { info: (message: unknown) => sendToSentry(message) },
+    });
+  });
+});
+
+declare function sendToSentry(error: unknown): void;
+
+describe('MarkingMenuLogger', () => {
+  it('narrows `error` to a single `unknown` argument, not varargs', () => {
+    expectTypeOf<MarkingMenuLogger>().toEqualTypeOf<{
+      error: (error: unknown) => void;
+    }>();
   });
 });

--- a/src/marking-menu.test-d.ts
+++ b/src/marking-menu.test-d.ts
@@ -94,12 +94,18 @@ describe('createMarkingMenu', () => {
     });
   });
 
-  it('rejects a logger using `info`/`warn`/`debug` in place of `error`', () => {
+  it('accepts a logger implementing extra methods like `info`/`warn`/`debug`', () => {
+    // Nothing in the library calls them, but a richer logger (e.g. one
+    // shared with the rest of an app) can still be passed as-is.
     createMarkingMenu({
       items: [{ id: 'right', label: 'Right' }],
       parent,
-      // @ts-expect-error -- `log` no longer accepts `info`/`warn`/`debug`.
-      log: { info: (message: unknown) => sendToSentry(message) },
+      log: {
+        error: (error: unknown) => sendToSentry(error),
+        info: (message: unknown) => sendToSentry(message),
+        warn: (message: unknown) => sendToSentry(message),
+        debug: (message: unknown) => sendToSentry(message),
+      },
     });
   });
 
@@ -113,14 +119,30 @@ describe('createMarkingMenu', () => {
       log: {},
     });
   });
+
+  it('accepts a logger with only extra methods and no `error`', () => {
+    createMarkingMenu({
+      items: [{ id: 'right', label: 'Right' }],
+      parent,
+      log: { info: (message: unknown) => sendToSentry(message) },
+    });
+  });
 });
 
 declare function sendToSentry(error: unknown): void;
 
 describe('MarkingMenuLogger', () => {
   it('narrows `error` to a single `unknown` argument, not varargs', () => {
-    expectTypeOf<MarkingMenuLogger>().toEqualTypeOf<{
-      error: (error: unknown) => void;
-    }>();
+    expectTypeOf<MarkingMenuLogger['error']>().toEqualTypeOf<
+      (error: unknown) => void
+    >();
+  });
+
+  it('allows properties beyond `error`', () => {
+    const logger: MarkingMenuLogger = {
+      error: (error: unknown) => sendToSentry(error),
+      info: (message: unknown) => sendToSentry(message),
+    };
+    expectTypeOf(logger.info).not.toBeNever();
   });
 });

--- a/src/marking-menu.test-d.ts
+++ b/src/marking-menu.test-d.ts
@@ -94,13 +94,23 @@ describe('createMarkingMenu', () => {
     });
   });
 
-  it('rejects a logger missing `error`', () => {
+  it('rejects a logger using `info`/`warn`/`debug` in place of `error`', () => {
     createMarkingMenu({
       items: [{ id: 'right', label: 'Right' }],
       parent,
-      // @ts-expect-error -- `log` no longer accepts `info`/`warn`/`debug` in
-      // place of the required `error`.
+      // @ts-expect-error -- `log` no longer accepts `info`/`warn`/`debug`.
       log: { info: (message: unknown) => sendToSentry(message) },
+    });
+  });
+
+  it('accepts a logger omitting `error`', () => {
+    // Useless at runtime (nothing overrides the default), but harmless — and
+    // it leaves room for future logger methods without forcing every partial
+    // override to include `error`.
+    createMarkingMenu({
+      items: [{ id: 'right', label: 'Right' }],
+      parent,
+      log: {},
     });
   });
 });

--- a/src/marking-menu.test-d.ts
+++ b/src/marking-menu.test-d.ts
@@ -127,14 +127,26 @@ describe('createMarkingMenu', () => {
       log: { info: (message: unknown) => sendToSentry(message) },
     });
   });
+
+  it('accepts a logger whose `error` expects an `Error`', () => {
+    // The point of typing `error` as `Error` rather than `unknown`: a
+    // handler that only accepts `Error` (`reportError`, here) can be passed
+    // directly, without a wrapper that widens its parameter first.
+    createMarkingMenu({
+      items: [{ id: 'right', label: 'Right' }],
+      parent,
+      log: { error: reportError },
+    });
+  });
 });
 
 declare function sendToSentry(error: unknown): void;
+declare function reportError(error: Error): void;
 
 describe('MarkingMenuLogger', () => {
-  it('narrows `error` to a single `unknown` argument, not varargs', () => {
+  it('narrows `error` to a single `Error` argument, not varargs', () => {
     expectTypeOf<MarkingMenuLogger['error']>().toEqualTypeOf<
-      (error: unknown) => void
+      (error: Error) => void
     >();
   });
 

--- a/src/marking-menu.test.ts
+++ b/src/marking-menu.test.ts
@@ -223,8 +223,8 @@ describe('main', () => {
     mockNavObs$ = m.hot(  '--a--b-c|', mockNavNotifs);
     connectedObs$ = m.hot('--d-e--f-g|');
     const connectedSub =  '^---------!';
-    const logDebug = vi.fn();
-    callMain({ log: { debug: logDebug } }).subscribe();
+    const logError = vi.fn();
+    callMain({ log: { error: logError } }).subscribe();
     expect(mockConnectLayout).toHaveBeenCalledTimes(1);
     const options = mockConnectLayout.mock.calls[0]?.[0] as {
       parent: unknown;
@@ -242,11 +242,16 @@ describe('main', () => {
     expect(options.createUpperStrokeCanvas).toBeInstanceOf(Function);
     expect(options.createLowerStrokeCanvas).toBeInstanceOf(Function);
     expect(options.createGestureFeedback).toBeInstanceOf(Function);
-    expect(options.log.error).toBeInstanceOf(Function);
-    expect(options.log.info).toBeInstanceOf(Function);
-    expect(options.log.warn).toBeInstanceOf(Function);
-    expect(options.log.debug).toBe(logDebug);
+    expect(options.log.error).toBe(logError);
   }));
+
+  it('defaults log.error when no override is given', () => {
+    callMain();
+    const options = mockConnectLayout.mock.calls[0]?.[0] as {
+      log: MarkingMenuLogger;
+    };
+    expect(options.log.error).toBeInstanceOf(Function);
+  });
 
   it('properly binds MenuLayout when it connects the layout', () => {
     callMain();

--- a/src/marking-menu.ts
+++ b/src/marking-menu.ts
@@ -122,20 +122,16 @@ export const exportNotification = (
 });
 
 /**
- A logger, as accepted by {@link createMarkingMenu}.
+ A logger, as accepted by {@link createMarkingMenu}. `error` is the only
+ method anything in the library calls, so any object exposing it — `console`
+ included — satisfies this type.
  */
 export type MarkingMenuLogger = {
-  error: (...args: unknown[]) => void;
-  info: (...args: unknown[]) => void;
-  warn: (...args: unknown[]) => void;
-  debug: (...args: unknown[]) => void;
+  error: (error: unknown) => void;
 };
 
 const defaultLogger: MarkingMenuLogger = {
   error: console?.error?.bind(console) ?? noOp,
-  info: console?.info?.bind(console) ?? noOp,
-  warn: console?.warn?.bind(console) ?? noOp,
-  debug: noOp,
 };
 
 /**
@@ -197,7 +193,7 @@ export type MarkingMenuConfig = MarkingMenuInput & {
    */
   notifySteps?: boolean;
   /** Override the default logger to use. */
-  log?: Partial<MarkingMenuLogger>;
+  log?: MarkingMenuLogger;
 };
 
 /**

--- a/src/marking-menu.ts
+++ b/src/marking-menu.ts
@@ -124,10 +124,14 @@ export const exportNotification = (
 /**
  A logger, as accepted by {@link createMarkingMenu}. `error` is the only
  method anything in the library calls, so any object exposing it — `console`
- included — satisfies this type.
+ included — satisfies this type. `info`/`warn`/`debug` are accepted but
+ ignored, so a fuller logger doesn't need to be stripped down first.
  */
 export type MarkingMenuLogger = {
   error: (error: unknown) => void;
+  info?: unknown;
+  warn?: unknown;
+  debug?: unknown;
 };
 
 const defaultLogger: MarkingMenuLogger = {

--- a/src/marking-menu.ts
+++ b/src/marking-menu.ts
@@ -193,7 +193,7 @@ export type MarkingMenuConfig = MarkingMenuInput & {
    */
   notifySteps?: boolean;
   /** Override the default logger to use. */
-  log?: MarkingMenuLogger;
+  log?: Partial<MarkingMenuLogger>;
 };
 
 /**

--- a/src/marking-menu.ts
+++ b/src/marking-menu.ts
@@ -125,10 +125,13 @@ export const exportNotification = (
  A logger, as accepted by {@link createMarkingMenu}. `error` is the only
  method anything in the library calls, so any object exposing it — `console`
  included — satisfies this type. `info`/`warn`/`debug` are accepted but
- ignored, so a fuller logger doesn't need to be stripped down first.
+ ignored, so a fuller logger doesn't need to be stripped down first. Errors
+ raised internally are always normalized to `Error` before reaching `error`,
+ so a handler typed to expect an `Error` (rather than `unknown`) can be passed
+ directly.
  */
 export type MarkingMenuLogger = {
-  error: (error: unknown) => void;
+  error: (error: Error) => void;
   info?: unknown;
   warn?: unknown;
   debug?: unknown;


### PR DESCRIPTION
## Summary

- `MarkingMenuLogger`'s `error` now takes a single `Error` argument instead of varargs of `unknown`. `unknown` sits in contravariant position, so it was actually the *less* ergonomic choice: a consumer's own `(error: Error) => void` handler couldn't satisfy it, forcing a wrapper that widened the parameter first.
- Errors are normalized to `Error` before reaching `log.error` ([connect.ts](src/layout/connect.ts)'s new `toError()`), so a handler typed to expect an `Error` can be passed directly. The rethrow still carries the original, unwrapped value — normalization only affects what the logger sees.
- `info`, `warn` and `debug` are now optional and ignored (nothing in the library ever called them), instead of required alongside `error`.
- `console` still satisfies the type, and a logger with extra methods can still be passed as-is.
- `log` itself stays a partial override: `error` can be left out too (e.g. `log: {}`).
- Ships its own changeset — `major`. Genuinely breaking for: a logger whose `error` expects something other than `Error`, a logger whose `error` declares 2+ required parameters, and code that imported `MarkingMenuLogger` to call `.info()`/`.warn()`/`.debug()`.

Closes #173.

## Test plan

- [x] `yarn typecheck` — clean
- [x] `yarn test` — 195 tests pass, including type-level tests (console as logger, error-only override, extra methods, omitted error, `Error`-typed handler) and a runtime test confirming a non-`Error` upstream failure is normalized before logging but rethrown unwrapped
- [x] `yarn lint` / `yarn format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)