### PR TITLE
Ship the public event classes and typed EventTarget facade

### DIFF
--- a/.changeset/marking-menu-events.md
+++ b/.changeset/marking-menu-events.md
@@ -7,5 +7,4 @@ upcoming native event-based API will use: `MarkingMenuStartEvent`,
 `MarkingMenuOpenEvent`, `MarkingMenuMoveEvent`, `MarkingMenuChangeEvent`,
 `MarkingMenuSelectEvent`, `MarkingMenuCancelEvent`, their shared
 `MarkingMenuEventBase`, the `MarkingMenuEventMap`/`MarkingMenuEvent` types, and
-`MarkingMenuEventTarget`. Nothing dispatches these yet; this ships the
-contract ahead of the engine that will emit them.
+`MarkingMenuEventTarget`.

--- a/.changeset/marking-menu-events.md
+++ b/.changeset/marking-menu-events.md
@@ -1,0 +1,11 @@
+---
+'marking-menu': minor
+---
+
+Export the public event classes and typed `EventTarget` facade that the
+upcoming native event-based API will use: `MarkingMenuStartEvent`,
+`MarkingMenuOpenEvent`, `MarkingMenuMoveEvent`, `MarkingMenuChangeEvent`,
+`MarkingMenuSelectEvent`, `MarkingMenuCancelEvent`, their shared
+`MarkingMenuEventBase`, the `MarkingMenuEventMap`/`MarkingMenuEvent` types, and
+`MarkingMenuEventTarget`. Nothing dispatches these yet; this ships the
+contract ahead of the engine that will emit them.

--- a/src/events.test-d.ts
+++ b/src/events.test-d.ts
@@ -1,0 +1,149 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type {
+  MarkingMenuCancelEvent,
+  MarkingMenuChangeEvent,
+  MarkingMenuEvent,
+  MarkingMenuEventMap,
+  MarkingMenuEventTarget,
+  MarkingMenuMoveEvent,
+  MarkingMenuOpenEvent,
+  MarkingMenuSelectEvent,
+  MarkingMenuStartEvent,
+} from './events.js';
+import { createModel } from './model.js';
+import { noOp } from './utils.js';
+
+/*
+ Type level tests: they assert what the type system knows about the event map
+ and the discriminated union it derives. Checked by `tsc`, not run.
+ */
+
+const menu = createModel({
+  items: [{ id: 'right', label: 'Right' }],
+});
+type M = typeof menu;
+
+describe('MarkingMenuEventMap', () => {
+  it('maps each event name to its exact event class', () => {
+    expectTypeOf<MarkingMenuEventMap<M>>().toEqualTypeOf<{
+      start: MarkingMenuStartEvent;
+      open: MarkingMenuOpenEvent<M>;
+      move: MarkingMenuMoveEvent<M>;
+      change: MarkingMenuChangeEvent<M>;
+      select: MarkingMenuSelectEvent<M>;
+      cancel: MarkingMenuCancelEvent<M>;
+    }>();
+  });
+
+  it('is closed: only the six event names are keys', () => {
+    expectTypeOf<keyof MarkingMenuEventMap<M>>().toEqualTypeOf<
+      'start' | 'open' | 'move' | 'change' | 'select' | 'cancel'
+    >();
+  });
+});
+
+describe('MarkingMenuEvent', () => {
+  it('is the union of every event in the map', () => {
+    expectTypeOf<MarkingMenuEvent<M>>().toEqualTypeOf<
+      | MarkingMenuStartEvent
+      | MarkingMenuOpenEvent<M>
+      | MarkingMenuMoveEvent<M>
+      | MarkingMenuChangeEvent<M>
+      | MarkingMenuSelectEvent<M>
+      | MarkingMenuCancelEvent<M>
+    >();
+  });
+
+  it('discriminates exhaustively on `type` across a `switch`', () => {
+    // No `default` case: `@typescript-eslint/switch-exhaustiveness-check`
+    // already fails the build if a case is missing, and `noImplicitReturns`
+    // fails it if a covered case doesn't return.
+    function handle(event: MarkingMenuEvent<M>): string {
+      switch (event.type) {
+        case 'start': {
+          expectTypeOf(event).toEqualTypeOf<MarkingMenuStartEvent>();
+          return event.mode;
+        }
+
+        case 'open': {
+          expectTypeOf(event).toEqualTypeOf<MarkingMenuOpenEvent<M>>();
+          return String(event.menu.isLeaf);
+        }
+
+        case 'move': {
+          expectTypeOf(event).toEqualTypeOf<MarkingMenuMoveEvent<M>>();
+          return String(event.active?.label);
+        }
+
+        case 'change': {
+          expectTypeOf(event).toEqualTypeOf<MarkingMenuChangeEvent<M>>();
+          return String(event.previousActive?.label);
+        }
+
+        case 'select': {
+          expectTypeOf(event).toEqualTypeOf<MarkingMenuSelectEvent<M>>();
+          return event.selection.label;
+        }
+
+        case 'cancel': {
+          expectTypeOf(event).toEqualTypeOf<MarkingMenuCancelEvent<M>>();
+          return String(event.active?.label);
+        }
+      }
+    }
+
+    expectTypeOf(handle).returns.toBeString();
+  });
+});
+
+declare const target: MarkingMenuEventTarget<M>;
+
+describe('MarkingMenuEventTarget', () => {
+  it('types the listener parameter of addEventListener per event name', () => {
+    target.addEventListener('select', (event) => {
+      expectTypeOf(event).toEqualTypeOf<MarkingMenuSelectEvent<M>>();
+    });
+    target.addEventListener('open', (event) => {
+      expectTypeOf(event).toEqualTypeOf<MarkingMenuOpenEvent<M>>();
+    });
+  });
+
+  it('types the listener parameter of removeEventListener per event name', () => {
+    target.removeEventListener('select', noOp);
+  });
+
+  it('rejects unknown event names on addEventListener and removeEventListener', () => {
+    // @ts-expect-error -- `selectt` is not one of the six known event names.
+    target.addEventListener('selectt', noOp);
+    // @ts-expect-error -- there is no `type: string` fallback overload.
+    target.addEventListener('anything', noOp);
+    // @ts-expect-error -- same rejection applies to removeEventListener.
+    target.removeEventListener('selectt', noOp);
+  });
+
+  it('leaves `once`, `signal` and `capture` unaffected', () => {
+    const controller = new AbortController();
+    target.addEventListener('select', noOp, {
+      once: true,
+      capture: true,
+      signal: controller.signal,
+    });
+    target.addEventListener('select', noOp, { capture: true });
+  });
+
+  it('remains assignable to EventTarget via the documented escape hatch', () => {
+    // The typed facade narrows the listener parameter, so plain implicit
+    // assignment to `EventTarget` is intentionally not what's being tested
+    // here — the documented escape hatch is the explicit downcast, which
+    // stays available for exactly the case an unknown event name is needed.
+    const asEventTarget: EventTarget = target as EventTarget;
+    asEventTarget.addEventListener('anything', noOp);
+    expectTypeOf(asEventTarget).toEqualTypeOf<EventTarget>();
+  });
+
+  it('keeps dispatchEvent unmodified from EventTarget', () => {
+    expectTypeOf(target.dispatchEvent).toEqualTypeOf<
+      EventTarget['dispatchEvent']
+    >();
+  });
+});

--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -1,0 +1,238 @@
+import {
+  MarkingMenuCancelEvent,
+  MarkingMenuChangeEvent,
+  MarkingMenuMoveEvent,
+  MarkingMenuOpenEvent,
+  MarkingMenuSelectEvent,
+  MarkingMenuStartEvent,
+} from './events.js';
+import { createModel } from './model.js';
+
+const menu = createModel({
+  items: [
+    { id: 'right', label: 'Right' },
+    { id: 'bottom', label: 'Bottom', items: [{ id: 'sub', label: 'Sub' }] },
+  ],
+});
+type M = typeof menu;
+
+describe('MarkingMenuStartEvent', () => {
+  it('carries the mode and position it was constructed with', () => {
+    const event = new MarkingMenuStartEvent({ position: [10, 20] });
+
+    expect(event.type).toBe('start');
+    expect(event.mode).toBe('startup');
+    expect(event.position).toEqual([10, 20]);
+  });
+
+  it('exposes its type as a static, matching the instance type', () => {
+    expect(MarkingMenuStartEvent.type).toBe('start');
+
+    const event = new MarkingMenuStartEvent({ position: [0, 0] });
+    expect(event.type).toBe(MarkingMenuStartEvent.type);
+  });
+
+  it('is a non-cancelable, non-bubbling, non-composed DOM event', () => {
+    const event = new MarkingMenuStartEvent({ position: [0, 0] });
+
+    expect(event).toBeInstanceOf(Event);
+    expect(event.cancelable).toBe(false);
+    expect(event.bubbles).toBe(false);
+    expect(event.composed).toBe(false);
+  });
+});
+
+describe('MarkingMenuOpenEvent', () => {
+  it('carries the menu, its center, and the position it was opened at', () => {
+    const event = new MarkingMenuOpenEvent<M>({
+      position: [5, 5],
+      menu,
+      menuCenter: [50, 50],
+    });
+
+    expect(event.type).toBe('open');
+    expect(event.mode).toBe('novice');
+    expect(event.position).toEqual([5, 5]);
+    expect(event.menu).toBe(menu);
+    expect(event.menuCenter).toEqual([50, 50]);
+  });
+
+  it('is a non-cancelable, non-bubbling, non-composed DOM event', () => {
+    const event = new MarkingMenuOpenEvent<M>({
+      position: [0, 0],
+      menu,
+      menuCenter: [0, 0],
+    });
+
+    expect(event.cancelable).toBe(false);
+    expect(event.bubbles).toBe(false);
+    expect(event.composed).toBe(false);
+  });
+});
+
+describe('MarkingMenuMoveEvent', () => {
+  it('carries the mode, active item and open menu at the time of the move', () => {
+    const event = new MarkingMenuMoveEvent<M>({
+      mode: 'novice',
+      position: [1, 2],
+      active: menu.items[0],
+      menu,
+    });
+
+    expect(event.type).toBe('move');
+    expect(event.mode).toBe('novice');
+    expect(event.position).toEqual([1, 2]);
+    expect(event.active).toBe(menu.items[0]);
+    expect(event.menu).toBe(menu);
+  });
+
+  it('allows a null active item and a null menu, for startup and expert', () => {
+    const event = new MarkingMenuMoveEvent<M>({
+      mode: 'expert',
+      position: [1, 2],
+      active: null,
+      menu: null,
+    });
+
+    expect(event.mode).toBe('expert');
+    expect(event.active).toBeNull();
+    expect(event.menu).toBeNull();
+  });
+
+  it('is a non-cancelable, non-bubbling, non-composed DOM event', () => {
+    const event = new MarkingMenuMoveEvent<M>({
+      mode: 'startup',
+      position: [0, 0],
+      active: null,
+      menu: null,
+    });
+
+    expect(event.cancelable).toBe(false);
+    expect(event.bubbles).toBe(false);
+    expect(event.composed).toBe(false);
+  });
+});
+
+describe('MarkingMenuChangeEvent', () => {
+  it('carries the new and previous active item, and the open menu', () => {
+    const event = new MarkingMenuChangeEvent<M>({
+      position: [1, 2],
+      active: menu.items[1],
+      previousActive: menu.items[0],
+      menu,
+    });
+
+    expect(event.type).toBe('change');
+    expect(event.mode).toBe('novice');
+    expect(event.active).toBe(menu.items[1]);
+    expect(event.previousActive).toBe(menu.items[0]);
+    expect(event.menu).toBe(menu);
+  });
+
+  it('allows a null active item, for a change onto or off of empty space', () => {
+    const event = new MarkingMenuChangeEvent<M>({
+      position: [1, 2],
+      active: null,
+      previousActive: menu.items[0],
+      menu,
+    });
+
+    expect(event.active).toBeNull();
+    expect(event.previousActive).toBe(menu.items[0]);
+  });
+
+  it('is a non-cancelable, non-bubbling, non-composed DOM event', () => {
+    const event = new MarkingMenuChangeEvent<M>({
+      position: [0, 0],
+      active: null,
+      previousActive: null,
+      menu,
+    });
+
+    expect(event.cancelable).toBe(false);
+    expect(event.bubbles).toBe(false);
+    expect(event.composed).toBe(false);
+  });
+});
+
+describe('MarkingMenuSelectEvent', () => {
+  it('carries the mode, the selected leaf, and the menu it was selected from', () => {
+    const event = new MarkingMenuSelectEvent<M>({
+      mode: 'novice',
+      position: [1, 2],
+      selection: menu.items[0],
+      menu,
+    });
+
+    expect(event.type).toBe('select');
+    expect(event.mode).toBe('novice');
+    expect(event.selection).toBe(menu.items[0]);
+    expect(event.menu).toBe(menu);
+  });
+
+  it('allows a null menu, for a selection made in expert mode', () => {
+    const event = new MarkingMenuSelectEvent<M>({
+      mode: 'expert',
+      position: [1, 2],
+      selection: menu.items[0],
+      menu: null,
+    });
+
+    expect(event.mode).toBe('expert');
+    expect(event.menu).toBeNull();
+  });
+
+  it('is a non-cancelable, non-bubbling, non-composed DOM event', () => {
+    const event = new MarkingMenuSelectEvent<M>({
+      mode: 'startup',
+      position: [0, 0],
+      selection: menu.items[0],
+      menu: null,
+    });
+
+    expect(event.cancelable).toBe(false);
+    expect(event.bubbles).toBe(false);
+    expect(event.composed).toBe(false);
+  });
+});
+
+describe('MarkingMenuCancelEvent', () => {
+  it('carries the mode, the active item at abandon time, and the open menu', () => {
+    const event = new MarkingMenuCancelEvent<M>({
+      mode: 'novice',
+      position: [1, 2],
+      active: menu.items[0],
+      menu,
+    });
+
+    expect(event.type).toBe('cancel');
+    expect(event.mode).toBe('novice');
+    expect(event.active).toBe(menu.items[0]);
+    expect(event.menu).toBe(menu);
+  });
+
+  it('allows a null active item and a null menu', () => {
+    const event = new MarkingMenuCancelEvent<M>({
+      mode: 'startup',
+      position: [1, 2],
+      active: null,
+      menu: null,
+    });
+
+    expect(event.active).toBeNull();
+    expect(event.menu).toBeNull();
+  });
+
+  it('is a non-cancelable, non-bubbling, non-composed DOM event', () => {
+    const event = new MarkingMenuCancelEvent<M>({
+      mode: 'expert',
+      position: [0, 0],
+      active: null,
+      menu: null,
+    });
+
+    expect(event.cancelable).toBe(false);
+    expect(event.bubbles).toBe(false);
+    expect(event.composed).toBe(false);
+  });
+});

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,379 @@
+import type {
+  AnyModelNode,
+  ModelItems,
+  ModelLeaves,
+  ModelMenus,
+} from './types.js';
+
+/*
+ The public event contract: the events {@link createMarkingMenu}'s controller
+ dispatches, and the typed facade it dispatches them through.
+ */
+
+/* -------------------------------------------------------------------------- *
+ * Shared payload types
+ * -------------------------------------------------------------------------- */
+
+/** The navigation mode a gesture is in when an event is dispatched. */
+export type MarkingMenuMode = 'startup' | 'novice' | 'expert';
+
+/** A 2D point, as carried by event payloads. */
+export type ReadonlyPoint = readonly [number, number];
+
+/* -------------------------------------------------------------------------- *
+ * Event classes
+ * -------------------------------------------------------------------------- */
+
+/**
+ What every marking menu event has in common: the mode the gesture was in, and
+ the pointer position, both at dispatch time. Every marking menu event is
+ non-cancelable, non-bubbling and non-composed: consumers observe committed
+ state, so there is no default action left to prevent, and the events have no
+ shadow-DOM boundary to cross.
+ */
+export abstract class MarkingMenuEventBase extends Event {
+  readonly #mode: MarkingMenuMode;
+  readonly #position: ReadonlyPoint;
+
+  constructor(
+    type: string,
+    data: { readonly mode: MarkingMenuMode; readonly position: ReadonlyPoint },
+  ) {
+    super(type, { cancelable: false, bubbles: false, composed: false });
+    this.#mode = data.mode;
+    this.#position = data.position;
+  }
+
+  /** The navigation mode the gesture was in when this event was dispatched. */
+  get mode(): MarkingMenuMode {
+    return this.#mode;
+  }
+
+  /** The pointer position at the time this event was dispatched. */
+  get position(): ReadonlyPoint {
+    return this.#position;
+  }
+}
+
+/**
+ Dispatched once, as the first event of a gesture, when a primary pointer goes
+ down.
+ */
+export class MarkingMenuStartEvent extends MarkingMenuEventBase {
+  /** This event's type, as a literal. */
+  static get type(): 'start' {
+    return 'start';
+  }
+
+  declare readonly type: 'start';
+
+  constructor(data: { readonly position: ReadonlyPoint }) {
+    super(MarkingMenuStartEvent.type, {
+      mode: 'startup',
+      position: data.position,
+    });
+  }
+
+  override get mode(): 'startup' {
+    return 'startup';
+  }
+}
+
+/**
+ Dispatched once per gesture, when novice mode opens a menu: the dwell that
+ starts novice mode, or a submenu dwell while already in novice mode.
+ */
+export class MarkingMenuOpenEvent<
+  M extends AnyModelNode,
+> extends MarkingMenuEventBase {
+  /** This event's type, as a literal. */
+  static get type(): 'open' {
+    return 'open';
+  }
+
+  readonly #menu: ModelMenus<M>;
+  readonly #menuCenter: ReadonlyPoint;
+
+  declare readonly type: 'open';
+
+  constructor(data: {
+    readonly position: ReadonlyPoint;
+    readonly menu: ModelMenus<M>;
+    readonly menuCenter: ReadonlyPoint;
+  }) {
+    super(MarkingMenuOpenEvent.type, {
+      mode: 'novice',
+      position: data.position,
+    });
+    this.#menu = data.menu;
+    this.#menuCenter = data.menuCenter;
+  }
+
+  override get mode(): 'novice' {
+    return 'novice';
+  }
+
+  /** The menu that was just opened. */
+  get menu(): ModelMenus<M> {
+    return this.#menu;
+  }
+
+  /** The center the opened menu is positioned at. */
+  get menuCenter(): ReadonlyPoint {
+    return this.#menuCenter;
+  }
+}
+
+/**
+ The shared constructor payload of {@link MarkingMenuMoveEvent} and
+ {@link MarkingMenuCancelEvent}: both carry the mode, position, active item
+ and open menu at a moment where none of those is fixed by the event itself.
+ */
+type ActiveMenuData<M extends AnyModelNode> = {
+  readonly mode: MarkingMenuMode;
+  readonly position: ReadonlyPoint;
+  readonly active: ModelItems<M> | null;
+  readonly menu: ModelMenus<M> | null;
+};
+
+/**
+ Dispatched on pointer movement, in every mode. `active` and `menu` are always
+ `null` in startup and expert, since no menu is open yet for anything to be
+ active in.
+ */
+export class MarkingMenuMoveEvent<
+  M extends AnyModelNode,
+> extends MarkingMenuEventBase {
+  /** This event's type, as a literal. */
+  static get type(): 'move' {
+    return 'move';
+  }
+
+  readonly #active: ModelItems<M> | null;
+  readonly #menu: ModelMenus<M> | null;
+
+  declare readonly type: 'move';
+
+  constructor(data: ActiveMenuData<M>) {
+    super(MarkingMenuMoveEvent.type, {
+      mode: data.mode,
+      position: data.position,
+    });
+    this.#active = data.active;
+    this.#menu = data.menu;
+  }
+
+  /** The item under the pointer, or `null` if none is. */
+  get active(): ModelItems<M> | null {
+    return this.#active;
+  }
+
+  /** The menu currently open, or `null` in startup and expert. */
+  get menu(): ModelMenus<M> | null {
+    return this.#menu;
+  }
+}
+
+/**
+ Dispatched in novice mode whenever the active item changes: the only event
+ that carries both the new and the previous active item, so a consumer never
+ has to remember the last `move`'s `active` to animate a highlight
+ transition.
+ */
+export class MarkingMenuChangeEvent<
+  M extends AnyModelNode,
+> extends MarkingMenuEventBase {
+  /** This event's type, as a literal. */
+  static get type(): 'change' {
+    return 'change';
+  }
+
+  readonly #active: ModelItems<M> | null;
+  readonly #previousActive: ModelItems<M> | null;
+  readonly #menu: ModelMenus<M>;
+
+  declare readonly type: 'change';
+
+  constructor(data: {
+    readonly position: ReadonlyPoint;
+    readonly active: ModelItems<M> | null;
+    readonly previousActive: ModelItems<M> | null;
+    readonly menu: ModelMenus<M>;
+  }) {
+    super(MarkingMenuChangeEvent.type, {
+      mode: 'novice',
+      position: data.position,
+    });
+    this.#active = data.active;
+    this.#previousActive = data.previousActive;
+    this.#menu = data.menu;
+  }
+
+  override get mode(): 'novice' {
+    return 'novice';
+  }
+
+  /** The item under the pointer after the change, or `null` if none is. */
+  get active(): ModelItems<M> | null {
+    return this.#active;
+  }
+
+  /** The item that was active before this change, or `null` if none was. */
+  get previousActive(): ModelItems<M> | null {
+    return this.#previousActive;
+  }
+
+  /** The menu currently open. */
+  get menu(): ModelMenus<M> {
+    return this.#menu;
+  }
+}
+
+/**
+ Dispatched once, as the last event of a gesture, when it ends on a leaf.
+ `menu` is the menu the leaf was selected from — `null` in expert mode, since
+ no menu is open there even though the leaf demonstrably has a parent.
+ */
+export class MarkingMenuSelectEvent<
+  M extends AnyModelNode,
+> extends MarkingMenuEventBase {
+  /** This event's type, as a literal. */
+  static get type(): 'select' {
+    return 'select';
+  }
+
+  readonly #selection: ModelLeaves<M>;
+  readonly #menu: ModelMenus<M> | null;
+
+  declare readonly type: 'select';
+
+  constructor(data: {
+    readonly mode: MarkingMenuMode;
+    readonly position: ReadonlyPoint;
+    readonly selection: ModelLeaves<M>;
+    readonly menu: ModelMenus<M> | null;
+  }) {
+    super(MarkingMenuSelectEvent.type, {
+      mode: data.mode,
+      position: data.position,
+    });
+    this.#selection = data.selection;
+    this.#menu = data.menu;
+  }
+
+  /** The leaf that was selected. */
+  get selection(): ModelLeaves<M> {
+    return this.#selection;
+  }
+
+  /** The menu the selection was made from, or `null` in expert mode. */
+  get menu(): ModelMenus<M> | null {
+    return this.#menu;
+  }
+}
+
+/**
+ Dispatched once, as the last event of a gesture, when it ends without a
+ selection. `active` is the item that was active at the moment the gesture
+ was abandoned — `ModelItems`, not `ModelLeaves`, since it need not be one;
+ `null` carries the genuine "nothing under the pointer" case.
+ */
+export class MarkingMenuCancelEvent<
+  M extends AnyModelNode,
+> extends MarkingMenuEventBase {
+  /** This event's type, as a literal. */
+  static get type(): 'cancel' {
+    return 'cancel';
+  }
+
+  readonly #active: ModelItems<M> | null;
+  readonly #menu: ModelMenus<M> | null;
+
+  declare readonly type: 'cancel';
+
+  constructor(data: ActiveMenuData<M>) {
+    super(MarkingMenuCancelEvent.type, {
+      mode: data.mode,
+      position: data.position,
+    });
+    this.#active = data.active;
+    this.#menu = data.menu;
+  }
+
+  /** The item that was active when the gesture was abandoned, or `null`. */
+  get active(): ModelItems<M> | null {
+    return this.#active;
+  }
+
+  /** The menu the gesture was abandoned from, or `null` in expert mode. */
+  get menu(): ModelMenus<M> | null {
+    return this.#menu;
+  }
+}
+
+/* -------------------------------------------------------------------------- *
+ * Event map, union, and typed facade
+ * -------------------------------------------------------------------------- */
+
+/**
+ The closed map from every event name to its exact event class. There is no
+ `type: string` fallback: an unknown event name is not a key of this map.
+ */
+export type MarkingMenuEventMap<M extends AnyModelNode> = {
+  start: MarkingMenuStartEvent;
+  open: MarkingMenuOpenEvent<M>;
+  move: MarkingMenuMoveEvent<M>;
+  change: MarkingMenuChangeEvent<M>;
+  select: MarkingMenuSelectEvent<M>;
+  cancel: MarkingMenuCancelEvent<M>;
+};
+
+/**
+ The union of every event a marking menu dispatches, discriminated on `type`.
+ */
+export type MarkingMenuEvent<M extends AnyModelNode> =
+  MarkingMenuEventMap<M>[keyof MarkingMenuEventMap<M>];
+
+/**
+ The typed `EventTarget` facade a marking menu controller satisfies.
+ `addEventListener`/`removeEventListener` are narrowed to the six known event
+ names via a single generic overload — there is no `type: string` fallback,
+ so an unknown event name is rejected at the call site.
+
+ Declared as a standalone type, not a class extending `EventTarget`: a real
+ `class X extends EventTarget` overriding `addEventListener` with a narrower
+ listener parameter fails TypeScript's override-compatibility check
+ (`EventTarget`'s own signature accepts any string and
+ `EventListenerOrEventListenerObject | null`, and narrowing it is only valid
+ for interfaces such as `lib.dom.d.ts`'s own `HTMLElement`, which redeclares
+ `addEventListener` without literally extending a real base class member).
+ Declaring the facade as its own type — implemented by the controller class,
+ not extended by it — sidesteps that check while keeping every constraint
+ below intact: the narrowing compiles with zero type assertions, and the
+ type is still structurally close enough to `EventTarget` that an explicit
+ downcast works as the escape hatch for an unknown event name:
+ `(menu as EventTarget).addEventListener(…)`. `dispatchEvent` is included
+ unmodified: narrowing it would be unsound and evaporate the moment the
+ controller is widened to a plain `EventTarget`.
+ */
+export type MarkingMenuEventTarget<M extends AnyModelNode> = {
+  addEventListener<K extends keyof MarkingMenuEventMap<M>>(
+    type: K,
+    listener: (
+      this: MarkingMenuEventTarget<M>,
+      event: MarkingMenuEventMap<M>[K],
+    ) => void,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+
+  removeEventListener<K extends keyof MarkingMenuEventMap<M>>(
+    type: K,
+    listener: (
+      this: MarkingMenuEventTarget<M>,
+      event: MarkingMenuEventMap<M>[K],
+    ) => void,
+    options?: boolean | EventListenerOptions,
+  ): void;
+
+  dispatchEvent(event: Event): boolean;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,18 @@
 export {
+  MarkingMenuCancelEvent,
+  MarkingMenuChangeEvent,
+  type MarkingMenuEvent,
+  MarkingMenuEventBase,
+  type MarkingMenuEventMap,
+  type MarkingMenuEventTarget,
+  type MarkingMenuMode,
+  MarkingMenuMoveEvent,
+  MarkingMenuOpenEvent,
+  MarkingMenuSelectEvent,
+  MarkingMenuStartEvent,
+  type ReadonlyPoint,
+} from './events.js';
+export {
   createMarkingMenu,
   type MarkingMenuConfig,
   type MarkingMenuLogger,


### PR DESCRIPTION
Closes #174.

## Summary

- Adds the six navigation event classes (`start`, `open`, `move`, `change`, `select`, `cancel`) and their shared `MarkingMenuEventBase`, each exported as a value with a `static get type()` and a literal-narrowed `type`.
- Adds the closed `MarkingMenuEventMap<M>` / `MarkingMenuEvent<M>` union, and `MarkingMenuEventTarget<M>`, the typed facade that narrows `addEventListener`/`removeEventListener` to those six names with zero type assertions.
- Nothing dispatches these yet — this ships the contract ahead of the state-machine engine that will emit them (per #153).

## A deliberate spec deviation (verified necessary)

Parent spec #153 §7 sketches `MarkingMenuEventTarget` as a `declare class ... extends EventTarget`. I verified — against this repo's pinned TypeScript *and* mainstream stable TypeScript 5.9.3 — that a real class extending `EventTarget` and overriding `addEventListener` with a narrower listener parameter fails the compiler's override-compatibility check, unless a public exact-matching fallback overload is added, which reopens exactly the "reject unknown event names" hole the ticket requires closed.

So `MarkingMenuEventTarget` ships as a standalone object type instead of a class extending `EventTarget` — the same reason `lib.dom.d.ts` declares `HTMLElement` as an interface, not a class. This keeps the closed map, the zero-assertion guarantee, and the documented `(menu as EventTarget)` escape hatch all intact. Full rationale is in the doc comment on `MarkingMenuEventTarget` in `src/events.ts`.

Flagged as a comment on #153 for whoever scopes the future controller ticket.

## Test plan

- [x] `yarn typecheck` — clean.
- [x] `yarn lint` — clean (one pre-existing, unrelated warning).
- [x] `yarn format:check` — clean.
- [x] `yarn vitest run --coverage` — 203 tests pass, 100% coverage on the new file.
- [x] Vertical TDD: one event class per red/green cycle, then the closed map/union type tests, then the facade type tests.
- [x] Changeset included (`minor`, additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)