### PR TITLE
Migrate E2E fixture to typed event API with shim layer

### DIFF
--- a/e2e/fixture/event-shim.ts
+++ b/e2e/fixture/event-shim.ts
@@ -17,6 +17,7 @@ import {
   type ModelMenus,
   type ReadonlyPoint,
 } from 'marking-menu';
+// eslint-disable-next-line import-x/order -- see the comment above: `marking-menu` resolves via this package's own path mapping, putting import-x's resolver and prettier's import sort at odds over where it belongs.
 import type { Observable, Subscription } from 'rxjs';
 
 /**

--- a/e2e/fixture/event-shim.ts
+++ b/e2e/fixture/event-shim.ts
@@ -17,7 +17,6 @@ import {
   type ModelMenus,
   type ReadonlyPoint,
 } from 'marking-menu';
-// eslint-disable-next-line import-x/order -- see the comment above: `marking-menu` resolves via this package's own path mapping, putting import-x's resolver and prettier's import sort at odds over where it belongs.
 import type { Observable, Subscription } from 'rxjs';
 
 /**

--- a/e2e/fixture/event-shim.ts
+++ b/e2e/fixture/event-shim.ts
@@ -56,8 +56,8 @@ class MarkingMenuEventShim<
       error(error: unknown) {
         console.error(error);
       },
-      next: (n) => {
-        this.#target.dispatchEvent(this.#toEvent(n));
+      next: (notification) => {
+        this.#target.dispatchEvent(this.#toEvent(notification));
       },
     });
   }

--- a/e2e/fixture/event-shim.ts
+++ b/e2e/fixture/event-shim.ts
@@ -1,0 +1,196 @@
+// `marking-menu` resolves through this package's own tsconfig path mapping
+// rather than node_modules, which puts eslint-plugin-import-x's resolver and
+// the prettier import-sort plugin at odds over where it belongs; the
+// disable keeps prettier's ordering rather than fighting both tools.
+import {
+  MarkingMenuCancelEvent,
+  MarkingMenuChangeEvent,
+  MarkingMenuMoveEvent,
+  MarkingMenuOpenEvent,
+  MarkingMenuSelectEvent,
+  MarkingMenuStartEvent,
+  type AnyModelNode,
+  type MarkingMenuEventMap,
+  type MarkingMenuEventTarget,
+  type MarkingMenuNotification,
+  type ModelItems,
+  type ModelMenus,
+  type ReadonlyPoint,
+} from 'marking-menu';
+import type { Observable, Subscription } from 'rxjs';
+
+/**
+ Test-only shim translating the legacy `notifySteps` Observable into the
+ final typed event contract (#153), so the E2E fixture and specs can target
+ the shape the library will eventually dispatch while the RxJS engine
+ underneath is unchanged. Deleted at cutover; nothing here is ever shipped.
+
+ The legacy stream has no `menu` on `move`/`change`, no `position` on `open`
+ (and, when a gesture ends without ever moving, on `select`/`cancel`
+ either), and names the abandoned-gesture item `selection` instead of
+ `active`. This carries the last-seen menu, active item, and drag position
+ forward across notifications to fill in what the legacy engine has no field
+ for, and renames on the way out.
+
+ Wraps a private `EventTarget` rather than extending one: a real
+ `class X extends EventTarget` overriding `addEventListener` fails
+ TypeScript's override-compatibility check against the base class member
+ (see `MarkingMenuEventTarget`'s own doc comment), so `addEventListener` and
+ `removeEventListener` are declared here with their own narrow-overload-over
+ -wide-implementation pair — the same idiom, applied to a method with no
+ base class member to conflict with — and forward to the private target.
+ */
+class MarkingMenuEventShim<
+  M extends AnyModelNode,
+> implements MarkingMenuEventTarget<M> {
+  readonly #target = new EventTarget();
+  readonly #subscription: Subscription;
+  #lastPosition: ReadonlyPoint = [0, 0];
+  #lastMenu: ModelMenus<M> | null = null;
+  #lastActive: ModelItems<M> | null = null;
+
+  constructor(notifications$: Observable<MarkingMenuNotification<M>>) {
+    // The one `subscribe` call left in the whole E2E suite: everything else
+    // consumes this shim through `addEventListener`.
+    this.#subscription = notifications$.subscribe({
+      error(error: unknown) {
+        console.error(error);
+      },
+      next: (n) => {
+        this.#target.dispatchEvent(this.#toEvent(n));
+      },
+    });
+  }
+
+  #toEvent(notification: MarkingMenuNotification<M>): Event {
+    const position = notification.position ?? this.#lastPosition;
+    this.#lastPosition = position;
+
+    switch (notification.type) {
+      case 'start': {
+        return new MarkingMenuStartEvent({ position });
+      }
+
+      case 'draw': {
+        // `draw` (startup|expert) merges into `move`: identical payload,
+        // and no menu can be active since none is open yet.
+        return new MarkingMenuMoveEvent<M>({
+          active: null,
+          menu: null,
+          mode: notification.mode,
+          position,
+        });
+      }
+
+      case 'open': {
+        this.#lastMenu = notification.menu;
+        // Nothing is active right at open (see `MarkingMenuOpenEvent`'s doc
+        // comment); without this, a submenu's first `change` would report
+        // the parent menu's last active item as `previousActive` instead of
+        // `null`.
+        this.#lastActive = null;
+        return new MarkingMenuOpenEvent<M>({
+          menu: notification.menu,
+          menuCenter: notification.menuCenter,
+          position,
+        });
+      }
+
+      case 'move': {
+        return new MarkingMenuMoveEvent<M>({
+          active: notification.active,
+          menu: this.#lastMenu,
+          mode: notification.mode,
+          position,
+        });
+      }
+
+      case 'change': {
+        const event = new MarkingMenuChangeEvent<M>({
+          active: notification.active,
+          // `#lastMenu` is always set here: `change` only fires in novice
+          // mode, once `open` has run.
+          menu: this.#lastMenu as ModelMenus<M>,
+          position,
+          previousActive: this.#lastActive,
+        });
+        this.#lastActive = notification.active;
+        return event;
+      }
+
+      case 'select': {
+        const event = new MarkingMenuSelectEvent<M>({
+          menu: this.#lastMenu,
+          mode: notification.mode,
+          position,
+          selection: notification.selection,
+        });
+        this.#lastMenu = null;
+        this.#lastActive = null;
+        return event;
+      }
+
+      case 'cancel': {
+        const event = new MarkingMenuCancelEvent<M>({
+          active: notification.selection ?? null,
+          menu: this.#lastMenu,
+          mode: notification.mode,
+          position,
+        });
+        this.#lastMenu = null;
+        this.#lastActive = null;
+        return event;
+      }
+    }
+  }
+
+  addEventListener<K extends keyof MarkingMenuEventMap<M>>(
+    type: K,
+    listener: (
+      this: MarkingMenuEventTarget<M>,
+      event: MarkingMenuEventMap<M>[K],
+    ) => void,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject | null,
+    options?: boolean | AddEventListenerOptions,
+  ): void {
+    this.#target.addEventListener(type, listener, options);
+  }
+
+  removeEventListener<K extends keyof MarkingMenuEventMap<M>>(
+    type: K,
+    listener: (
+      this: MarkingMenuEventTarget<M>,
+      event: MarkingMenuEventMap<M>[K],
+    ) => void,
+    options?: boolean | EventListenerOptions,
+  ): void;
+  removeEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject | null,
+    options?: boolean | EventListenerOptions,
+  ): void {
+    this.#target.removeEventListener(type, listener, options);
+  }
+
+  dispatchEvent(event: Event): boolean {
+    return this.#target.dispatchEvent(event);
+  }
+
+  dispose(): void {
+    this.#subscription.unsubscribe();
+  }
+}
+
+/**
+ Adapt a legacy `notifySteps` Observable to the final typed event contract.
+ See {@link MarkingMenuEventShim}.
+ */
+export function shimMarkingMenuEvents<M extends AnyModelNode>(
+  notifications$: Observable<MarkingMenuNotification<M>>,
+): MarkingMenuEventTarget<M> & { dispose(): void } {
+  return new MarkingMenuEventShim(notifications$);
+}

--- a/e2e/fixture/main.ts
+++ b/e2e/fixture/main.ts
@@ -47,15 +47,18 @@ const idOf = (node: unknown): string | undefined =>
     : undefined;
 
 const logEvent = (
-  event: { readonly mode: string; readonly position: ReadonlyPoint },
-  type: string,
+  event: {
+    readonly type: string;
+    readonly mode: string;
+    readonly position: ReadonlyPoint;
+  },
   fields: Record<string, string | undefined> = {},
 ): void => {
   log.append(
     `${JSON.stringify({
       mode: event.mode,
       position: event.position,
-      type,
+      type: event.type,
       ...fields,
     })}\n`,
   );
@@ -71,23 +74,23 @@ const activeAndMenuFields = (event: {
 });
 
 mm.addEventListener('start', (event) => {
-  logEvent(event, 'start');
+  logEvent(event);
 });
 mm.addEventListener('open', (event) => {
-  logEvent(event, 'open', { menuId: idOf(event.menu) });
+  logEvent(event, { menuId: idOf(event.menu) });
 });
 mm.addEventListener('move', (event) => {
-  logEvent(event, 'move', activeAndMenuFields(event));
+  logEvent(event, activeAndMenuFields(event));
 });
 mm.addEventListener('change', (event) => {
-  logEvent(event, 'change', activeAndMenuFields(event));
+  logEvent(event, activeAndMenuFields(event));
 });
 mm.addEventListener('select', (event) => {
-  logEvent(event, 'select', {
+  logEvent(event, {
     menuId: idOf(event.menu),
     selectionId: idOf(event.selection),
   });
 });
 mm.addEventListener('cancel', (event) => {
-  logEvent(event, 'cancel', activeAndMenuFields(event));
+  logEvent(event, activeAndMenuFields(event));
 });

--- a/e2e/fixture/main.ts
+++ b/e2e/fixture/main.ts
@@ -1,4 +1,5 @@
-import { createMarkingMenu } from 'marking-menu';
+import { createMarkingMenu, type ReadonlyPoint } from 'marking-menu';
+import { shimMarkingMenuEvents } from './event-shim.js';
 
 // The demo's eight-direction topology (see `demo/script.js`), with stable
 // ids added: tests key off `id`, not display order or label text.
@@ -28,7 +29,12 @@ if (!(surface instanceof HTMLElement) || !(log instanceof HTMLElement)) {
   throw new TypeError('Fixture markup is missing #surface or #log.');
 }
 
-const mm = createMarkingMenu({ items, notifySteps: true, parent: surface });
+const notifications$ = createMarkingMenu({
+  items,
+  notifySteps: true,
+  parent: surface,
+});
+const mm = shimMarkingMenuEvents(notifications$);
 
 // A node carries an `id` only when the caller gave it one (root has none);
 // tests need that id, not the whole node, so pull it out defensively.
@@ -40,27 +46,48 @@ const idOf = (node: unknown): string | undefined =>
     ? node.id
     : undefined;
 
-mm.subscribe({
-  error(error: unknown) {
-    console.error(error);
-  },
-  next(notification) {
-    const entry: Record<string, unknown> = {
-      mode: notification.mode,
-      type: notification.type,
-    };
-    if ('selection' in notification) {
-      entry.selectionId = idOf(notification.selection);
-    }
+const logEvent = (
+  event: { readonly mode: string; readonly position: ReadonlyPoint },
+  type: string,
+  fields: Record<string, string | undefined> = {},
+): void => {
+  log.append(
+    `${JSON.stringify({
+      mode: event.mode,
+      position: event.position,
+      type,
+      ...fields,
+    })}\n`,
+  );
+};
 
-    if ('active' in notification) {
-      entry.activeId = idOf(notification.active);
-    }
-
-    if ('menu' in notification) {
-      entry.menuId = idOf(notification.menu);
-    }
-
-    log.append(`${JSON.stringify(entry)}\n`);
-  },
+mm.addEventListener('start', (event) => {
+  logEvent(event, 'start');
+});
+mm.addEventListener('open', (event) => {
+  logEvent(event, 'open', { menuId: idOf(event.menu) });
+});
+mm.addEventListener('move', (event) => {
+  logEvent(event, 'move', {
+    activeId: idOf(event.active),
+    menuId: idOf(event.menu),
+  });
+});
+mm.addEventListener('change', (event) => {
+  logEvent(event, 'change', {
+    activeId: idOf(event.active),
+    menuId: idOf(event.menu),
+  });
+});
+mm.addEventListener('select', (event) => {
+  logEvent(event, 'select', {
+    menuId: idOf(event.menu),
+    selectionId: idOf(event.selection),
+  });
+});
+mm.addEventListener('cancel', (event) => {
+  logEvent(event, 'cancel', {
+    activeId: idOf(event.active),
+    menuId: idOf(event.menu),
+  });
 });

--- a/e2e/fixture/main.ts
+++ b/e2e/fixture/main.ts
@@ -1,5 +1,4 @@
 import { createMarkingMenu, type ReadonlyPoint } from 'marking-menu';
-// eslint-disable-next-line import-x/order -- see event-shim.ts's header comment: `marking-menu` resolves via this package's own path mapping, putting import-x's resolver and prettier's import sort at odds over where it belongs.
 import { shimMarkingMenuEvents } from './event-shim.js';
 
 // The demo's eight-direction topology (see `demo/script.js`), with stable

--- a/e2e/fixture/main.ts
+++ b/e2e/fixture/main.ts
@@ -1,4 +1,5 @@
 import { createMarkingMenu, type ReadonlyPoint } from 'marking-menu';
+// eslint-disable-next-line import-x/order -- see event-shim.ts's header comment: `marking-menu` resolves via this package's own path mapping, putting import-x's resolver and prettier's import sort at odds over where it belongs.
 import { shimMarkingMenuEvents } from './event-shim.js';
 
 // The demo's eight-direction topology (see `demo/script.js`), with stable

--- a/e2e/fixture/main.ts
+++ b/e2e/fixture/main.ts
@@ -61,6 +61,15 @@ const logEvent = (
   );
 };
 
+// `move`, `change`, and `cancel` all log the same pair of fields.
+const activeAndMenuFields = (event: {
+  readonly active: unknown;
+  readonly menu: unknown;
+}): Record<string, string | undefined> => ({
+  activeId: idOf(event.active),
+  menuId: idOf(event.menu),
+});
+
 mm.addEventListener('start', (event) => {
   logEvent(event, 'start');
 });
@@ -68,16 +77,10 @@ mm.addEventListener('open', (event) => {
   logEvent(event, 'open', { menuId: idOf(event.menu) });
 });
 mm.addEventListener('move', (event) => {
-  logEvent(event, 'move', {
-    activeId: idOf(event.active),
-    menuId: idOf(event.menu),
-  });
+  logEvent(event, 'move', activeAndMenuFields(event));
 });
 mm.addEventListener('change', (event) => {
-  logEvent(event, 'change', {
-    activeId: idOf(event.active),
-    menuId: idOf(event.menu),
-  });
+  logEvent(event, 'change', activeAndMenuFields(event));
 });
 mm.addEventListener('select', (event) => {
   logEvent(event, 'select', {
@@ -86,8 +89,5 @@ mm.addEventListener('select', (event) => {
   });
 });
 mm.addEventListener('cancel', (event) => {
-  logEvent(event, 'cancel', {
-    activeId: idOf(event.active),
-    menuId: idOf(event.menu),
-  });
+  logEvent(event, 'cancel', activeAndMenuFields(event));
 });

--- a/e2e/helpers/log.ts
+++ b/e2e/helpers/log.ts
@@ -8,6 +8,7 @@ import { expect, type Page } from '@playwright/test';
 export type LogEntry = {
   type: string;
   mode: string;
+  position: readonly [number, number];
   selectionId?: string;
   activeId?: string;
   menuId?: string;

--- a/e2e/tests/mouse.spec.ts
+++ b/e2e/tests/mouse.spec.ts
@@ -42,6 +42,14 @@ test('novice mode: dwelling opens the menu, lays out every item, and a release s
     selectionId: 'right',
     type: 'select',
   });
+  expect(
+    log.every(
+      (entry) =>
+        Array.isArray(entry.position) &&
+        entry.position.length === 2 &&
+        entry.position.every((coordinate) => typeof coordinate === 'number'),
+    ),
+  ).toBe(true);
 });
 
 test('expert mode: a quick decisive stroke selects without ever opening a menu', async ({
@@ -185,12 +193,13 @@ test('novice non-leaf cancellation: releasing over a submenu item (not far enoug
   await releaseAt(page);
 
   const log = await waitForLogEntry(page, (entry) => entry.type === 'cancel');
-  expect(log.at(-1)).toMatchObject({
+  const last = log.at(-1);
+  expect(last).toMatchObject({
     activeId: 'others',
     mode: 'novice',
-    selectionId: 'others',
     type: 'cancel',
   });
+  expect(last?.selectionId).toBeUndefined();
   expect(log.some((entry) => entry.type === 'select')).toBe(false);
 });
 


### PR DESCRIPTION
Closes #175

## Summary
Introduces a shim layer to bridge the legacy RxJS `notifySteps` Observable API with the new typed event contract, allowing the E2E fixture and tests to target the final event shape while the underlying engine remains unchanged.

## Key Changes
- **New event shim** (`e2e/fixture/event-shim.ts`): Implements `MarkingMenuEventShim` class that translates legacy `MarkingMenuNotification` objects into properly typed `MarkingMenuEvent` instances. The shim:
  - Maintains state (last position, menu, and active item) to fill gaps in the legacy notification format
  - Renames fields (`selection` → `selection`, `active` → `active`) to match the new contract
  - Provides a `MarkingMenuEventTarget`-compatible interface with typed `addEventListener`/`removeEventListener` overloads
  - Includes a `dispose()` method for cleanup

- **Updated fixture** (`e2e/fixture/main.ts`): Migrates from direct Observable subscription to event listener pattern:
  - Wraps the `notifySteps` Observable with `shimMarkingMenuEvents()`
  - Replaces single `subscribe()` call with six typed `addEventListener()` calls (one per event type)
  - Extracts logging logic into reusable `logEvent()` helper
  - All events now include `position` in the log output

- **Updated tests** (`e2e/tests/mouse.spec.ts`): Adapts assertions to the new event shape:
  - Adds validation that all log entries include a properly-formatted `position` array
  - Updates cancellation test to reflect that `cancel` events no longer include `selectionId` (only `activeId`)

- **Updated log type** (`e2e/helpers/log.ts`): Adds `position: readonly [number, number]` as a required field on all log entries

## Implementation Details
The shim uses private fields and a composition pattern (wrapping an internal `EventTarget`) rather than extending `EventTarget` directly, avoiding TypeScript's override-compatibility issues with the base class. The narrow-overload-over-wide-implementation pattern on `addEventListener`/`removeEventListener` provides type safety while forwarding to the private target.

This is a test-only change; the shim will be deleted at cutover when the RxJS engine is replaced with the final typed event implementation.

https://claude.ai/code/session_01WqZrvpWwbyirq2SqaShsYb
