### PR TITLE
Add Playwright coverage for concurrent pointers and multiple controllers

### DIFF
--- a/e2e/helpers/log.ts
+++ b/e2e/helpers/log.ts
@@ -43,3 +43,24 @@ export const waitForLogEntry = async (
     .toBe(true);
   return log;
 };
+
+/**
+ Poll the log until it holds more than `minLength` entries, then return it
+ as it stood at that point. For a gesture run after one already logged a
+ matching entry (a repeated `select`, say), `waitForLogEntry` would resolve
+ on that stale entry immediately; waiting on growth instead targets the
+ entries the next gesture actually appends.
+ */
+export const waitForLogGrowth = async (
+  page: Page,
+  minLength: number,
+): Promise<LogEntry[]> => {
+  let log: LogEntry[] = [];
+  await expect
+    .poll(async () => {
+      log = await readLog(page);
+      return log.length > minLength;
+    })
+    .toBe(true);
+  return log;
+};

--- a/e2e/helpers/touch.ts
+++ b/e2e/helpers/touch.ts
@@ -124,15 +124,6 @@ export class CdpMultiTouchDrag {
     await this.#dispatchEnd([id]);
   }
 
-  async movePrimary(at: Point): Promise<void> {
-    this.#points.set(0, at);
-    await this.#dispatchActive('touchMove');
-  }
-
-  async endPrimary(): Promise<void> {
-    await this.#dispatchEnd([0]);
-  }
-
   // `Symbol.asyncDispose` is standard (part of the explicit-resource-management
   // proposal TypeScript and Node already support — see e2e/tsconfig.json's
   // `lib` comment); `eslint-plugin-unicorn`@72's built-in `Symbol` property

--- a/e2e/helpers/touch.ts
+++ b/e2e/helpers/touch.ts
@@ -46,19 +46,26 @@ export class CdpTouchDrag {
 }
 
 /**
- A two-finger touch driven through CDP, for scenarios that need a genuine
- second concurrent pointer id rather than a single drag. The primary finger
- (id 0) is the one Pointer Events reports as `isPrimary`; the secondary
- finger (id 1) can be added, moved and lifted independently while the
- primary stays down, the same way a real second touch contact behaves.
+ A multi-finger touch driven through CDP, for scenarios that need genuine
+ concurrent pointer ids rather than a single drag. The primary finger (id 0)
+ is the one Pointer Events reports as `isPrimary`; any number of other
+ fingers (ids 1, 2, ...) can be added, moved and lifted independently while
+ the primary stays down, the same way real extra touch contacts behave.
 
  `Input.dispatchTouchEvent` takes `touchPoints` differently depending on
  `type`: `touchStart`/`touchMove` want every currently active point (a
  point missing from the list is otherwise untouched, so this always sends
- the two finger's full current positions), but `touchEnd` wants only the
- point(s) *ending* in that event — sending the still-down finger there too
+ every finger's full current positions), but `touchEnd` wants only the
+ point(s) *ending* in that event — sending a still-down finger there too
  (as if it were the "remaining active set") ends it as well, which is not
- what "lift one finger, keep the other down" means.
+ what "lift one finger, keep the others down" means.
+
+ Disposal (closing the underlying CDP session) is kept separate from ending
+ the primary — rather than folded into it, the way `CdpTouchDrag.end` does
+ for its single point — so a test can end the primary and keep driving
+ other fingers afterward, e.g. lifting a decoy that outlives the gesture it
+ was a decoy for. It's exposed as `Symbol.asyncDispose` so callers open it
+ with `await using` instead of a manual try/finally.
  */
 export class CdpMultiTouchDrag {
   static async start(page: Page, primaryAt: Point): Promise<CdpMultiTouchDrag> {
@@ -102,18 +109,19 @@ export class CdpMultiTouchDrag {
     }
   }
 
-  async addSecondary(at: Point): Promise<void> {
-    this.#points.set(1, at);
+  /** Touch a non-primary finger down. `id` must be neither 0 nor already active. */
+  async addFinger(id: number, at: Point): Promise<void> {
+    this.#points.set(id, at);
     await this.#dispatchActive('touchStart');
   }
 
-  async moveSecondary(at: Point): Promise<void> {
-    this.#points.set(1, at);
+  async moveFinger(id: number, at: Point): Promise<void> {
+    this.#points.set(id, at);
     await this.#dispatchActive('touchMove');
   }
 
-  async liftSecondary(): Promise<void> {
-    await this.#dispatchEnd([1]);
+  async liftFinger(id: number): Promise<void> {
+    await this.#dispatchEnd([id]);
   }
 
   async movePrimary(at: Point): Promise<void> {
@@ -123,6 +131,14 @@ export class CdpMultiTouchDrag {
 
   async endPrimary(): Promise<void> {
     await this.#dispatchEnd([0]);
+  }
+
+  // `Symbol.asyncDispose` is standard (part of the explicit-resource-management
+  // proposal TypeScript and Node already support — see e2e/tsconfig.json's
+  // `lib` comment); `eslint-plugin-unicorn`@72's built-in `Symbol` property
+  // list simply predates it.
+  // eslint-disable-next-line unicorn/no-nonstandard-builtin-properties
+  async [Symbol.asyncDispose](): Promise<void> {
     await this.#client.detach();
   }
 }

--- a/e2e/helpers/touch.ts
+++ b/e2e/helpers/touch.ts
@@ -44,3 +44,85 @@ export class CdpTouchDrag {
     await this.#client.detach();
   }
 }
+
+/**
+ A two-finger touch driven through CDP, for scenarios that need a genuine
+ second concurrent pointer id rather than a single drag. The primary finger
+ (id 0) is the one Pointer Events reports as `isPrimary`; the secondary
+ finger (id 1) can be added, moved and lifted independently while the
+ primary stays down, the same way a real second touch contact behaves.
+
+ `Input.dispatchTouchEvent` takes `touchPoints` differently depending on
+ `type`: `touchStart`/`touchMove` want every currently active point (a
+ point missing from the list is otherwise untouched, so this always sends
+ the two finger's full current positions), but `touchEnd` wants only the
+ point(s) *ending* in that event — sending the still-down finger there too
+ (as if it were the "remaining active set") ends it as well, which is not
+ what "lift one finger, keep the other down" means.
+ */
+export class CdpMultiTouchDrag {
+  static async start(page: Page, primaryAt: Point): Promise<CdpMultiTouchDrag> {
+    const client = await page.context().newCDPSession(page);
+    const drag = new CdpMultiTouchDrag(client);
+    drag.#points.set(0, primaryAt);
+    await drag.#dispatchActive('touchStart');
+    return drag;
+  }
+
+  readonly #client: CDPSession;
+  readonly #points = new Map<number, Point>();
+
+  private constructor(client: CDPSession) {
+    this.#client = client;
+  }
+
+  async #dispatchActive(type: 'touchMove' | 'touchStart'): Promise<void> {
+    const touchPoints: Array<{ id: number; x: number; y: number }> = [];
+    for (const [id, { x, y }] of this.#points) {
+      touchPoints.push({ id, x, y });
+    }
+
+    await this.#client.send('Input.dispatchTouchEvent', { touchPoints, type });
+  }
+
+  async #dispatchEnd(ids: readonly number[]): Promise<void> {
+    await this.#client.send('Input.dispatchTouchEvent', {
+      touchPoints: ids.map((id) => {
+        const point = this.#points.get(id);
+        if (!point) {
+          throw new TypeError(`No active touch point with id ${id}.`);
+        }
+
+        return { id, x: point.x, y: point.y };
+      }),
+      type: 'touchEnd',
+    });
+    for (const id of ids) {
+      this.#points.delete(id);
+    }
+  }
+
+  async addSecondary(at: Point): Promise<void> {
+    this.#points.set(1, at);
+    await this.#dispatchActive('touchStart');
+  }
+
+  async moveSecondary(at: Point): Promise<void> {
+    this.#points.set(1, at);
+    await this.#dispatchActive('touchMove');
+  }
+
+  async liftSecondary(): Promise<void> {
+    await this.#dispatchEnd([1]);
+  }
+
+  async movePrimary(at: Point): Promise<void> {
+    this.#points.set(0, at);
+    await this.#dispatchActive('touchMove');
+  }
+
+  async endPrimary(): Promise<void> {
+    await this.#dispatchEnd([0]);
+    await this.#client.detach();
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -36,8 +36,11 @@ export default defineConfig({
   },
   projects: [
     {
+      // `multiple-controllers.spec.ts` drives the library directly (no
+      // pointer input), so one browser is enough coverage for it; it rides
+      // along with this project rather than getting its own.
       name: 'chromium',
-      testMatch: /mouse\.spec\.ts/v,
+      testMatch: /(?:mouse|multiple-controllers)\.spec\.ts/v,
       use: { ...devices['Desktop Chrome'], viewport },
     },
     {
@@ -51,8 +54,11 @@ export default defineConfig({
       use: { ...devices['Desktop Safari'], viewport },
     },
     {
+      // `concurrent-pointers.spec.ts` needs the same CDP-driven native touch
+      // input as `touch.spec.ts` (see `e2e/helpers/touch.ts`), to get a
+      // genuine second pointer id rather than a simulated one.
       name: 'chromium-touch',
-      testMatch: /touch\.spec\.ts/v,
+      testMatch: /(?:concurrent-pointers|touch)\.spec\.ts/v,
       use: { ...devices['Desktop Chrome'], hasTouch: true, viewport },
     },
   ],

--- a/e2e/tests/concurrent-pointers.spec.ts
+++ b/e2e/tests/concurrent-pointers.spec.ts
@@ -32,8 +32,8 @@ test('concurrent pointers: a second touch cannot move, select or cancel the owni
   expect(await readLog(page)).toEqual(logBeforeDecoy);
 
   // The owner finishes normally, as if the decoy had never happened.
-  await drag.movePrimary(target);
-  await drag.endPrimary();
+  await drag.moveFinger(0, target);
+  await drag.liftFinger(0);
 
   const log = await waitForLogEntry(page, (entry) => entry.type === 'select');
   expect(log.at(-1)).toMatchObject({
@@ -70,8 +70,8 @@ test('a decoy finger lifted after the gesture it never touched has already ended
 
   // The decoy touches down and just stays put while the owner finishes.
   await drag.addFinger(1, decoy);
-  await drag.movePrimary(target);
-  await drag.endPrimary();
+  await drag.moveFinger(0, target);
+  await drag.liftFinger(0);
 
   const log = await waitForLogEntry(page, (entry) => entry.type === 'select');
   expect(log.at(-1)).toMatchObject({
@@ -107,8 +107,8 @@ test('three concurrent pointers: two decoys produce nothing regardless of order,
   await drag.liftFinger(1);
   expect(await readLog(page)).toEqual(logBeforeDecoys);
 
-  await drag.movePrimary(target);
-  await drag.endPrimary();
+  await drag.moveFinger(0, target);
+  await drag.liftFinger(0);
 
   const log = await waitForLogEntry(page, (entry) => entry.type === 'select');
   expect(log.at(-1)).toMatchObject({

--- a/e2e/tests/concurrent-pointers.spec.ts
+++ b/e2e/tests/concurrent-pointers.spec.ts
@@ -19,16 +19,16 @@ test('concurrent pointers: a second touch cannot move, select or cancel the owni
   const decoyStart = offset(center, TOP_LEVEL_ITEMS.left.angle, SELECT_RADIUS);
   const decoyMoved = offset(center, TOP_LEVEL_ITEMS.up.angle, SELECT_RADIUS);
 
-  const drag = await CdpMultiTouchDrag.start(page, center);
+  await using drag = await CdpMultiTouchDrag.start(page, center);
   await waitForMenuOpen(page);
   const logBeforeDecoy = await readLog(page);
 
   // A second finger touches down, drags across the menu, and lifts while
   // the first finger (the gesture's owner) stays put. None of it should
   // produce a single notification.
-  await drag.addSecondary(decoyStart);
-  await drag.moveSecondary(decoyMoved);
-  await drag.liftSecondary();
+  await drag.addFinger(1, decoyStart);
+  await drag.moveFinger(1, decoyMoved);
+  await drag.liftFinger(1);
   expect(await readLog(page)).toEqual(logBeforeDecoy);
 
   // The owner finishes normally, as if the decoy had never happened.
@@ -53,6 +53,66 @@ test('concurrent pointers: a second touch cannot move, select or cancel the owni
   const freshLog = await waitForLogGrowth(page, log.length);
   expect(freshLog.at(-1)).toMatchObject({
     mode: 'expert',
+    selectionId: 'right',
+    type: 'select',
+  });
+});
+
+test('a decoy finger lifted after the gesture it never touched has already ended still produces nothing', async ({
+  page,
+}) => {
+  const center = await surfaceCenter(page);
+  const target = offset(center, TOP_LEVEL_ITEMS.right.angle, SELECT_RADIUS);
+  const decoy = offset(center, TOP_LEVEL_ITEMS.left.angle, SELECT_RADIUS);
+
+  await using drag = await CdpMultiTouchDrag.start(page, center);
+  await waitForMenuOpen(page);
+
+  // The decoy touches down and just stays put while the owner finishes.
+  await drag.addFinger(1, decoy);
+  await drag.movePrimary(target);
+  await drag.endPrimary();
+
+  const log = await waitForLogEntry(page, (entry) => entry.type === 'select');
+  expect(log.at(-1)).toMatchObject({
+    mode: 'novice',
+    selectionId: 'right',
+    type: 'select',
+  });
+
+  // Only now, after the gesture it was never part of has already ended, is
+  // the decoy lifted. It never owned a gesture to cancel or select, so this
+  // must be as much of a no-op as everything else it did.
+  await drag.liftFinger(1);
+  expect(await readLog(page)).toEqual(log);
+});
+
+test('three concurrent pointers: two decoys produce nothing regardless of order, and the owner still finishes', async ({
+  page,
+}) => {
+  const center = await surfaceCenter(page);
+  const target = offset(center, TOP_LEVEL_ITEMS.right.angle, SELECT_RADIUS);
+  const decoyA = offset(center, TOP_LEVEL_ITEMS.left.angle, SELECT_RADIUS);
+  const decoyB = offset(center, TOP_LEVEL_ITEMS.up.angle, SELECT_RADIUS);
+
+  await using drag = await CdpMultiTouchDrag.start(page, center);
+  await waitForMenuOpen(page);
+  const logBeforeDecoys = await readLog(page);
+
+  // Two more fingers land concurrently (three total), then lift in reverse
+  // order from how they landed.
+  await drag.addFinger(1, decoyA);
+  await drag.addFinger(2, decoyB);
+  await drag.liftFinger(2);
+  await drag.liftFinger(1);
+  expect(await readLog(page)).toEqual(logBeforeDecoys);
+
+  await drag.movePrimary(target);
+  await drag.endPrimary();
+
+  const log = await waitForLogEntry(page, (entry) => entry.type === 'select');
+  expect(log.at(-1)).toMatchObject({
+    mode: 'novice',
     selectionId: 'right',
     type: 'select',
   });

--- a/e2e/tests/concurrent-pointers.spec.ts
+++ b/e2e/tests/concurrent-pointers.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from '../helpers/fixtures.js';
+import {
+  offset,
+  surfaceCenter,
+  TOP_LEVEL_ITEMS,
+  waitForMenuOpen,
+} from '../helpers/gestures.js';
+import { readLog, waitForLogEntry } from '../helpers/log.js';
+import { CdpMultiTouchDrag, CdpTouchDrag } from '../helpers/touch.js';
+
+// Same margin-from-thresholds rationale as mouse.spec.ts.
+const SELECT_RADIUS = 100;
+
+test('concurrent pointers: a second touch cannot move, select or cancel the owning gesture, and a fresh gesture works once it finishes', async ({
+  page,
+}) => {
+  const center = await surfaceCenter(page);
+  const target = offset(center, TOP_LEVEL_ITEMS.right.angle, SELECT_RADIUS);
+  const decoyStart = offset(center, TOP_LEVEL_ITEMS.left.angle, SELECT_RADIUS);
+  const decoyMoved = offset(center, TOP_LEVEL_ITEMS.up.angle, SELECT_RADIUS);
+
+  const drag = await CdpMultiTouchDrag.start(page, center);
+  await waitForMenuOpen(page);
+  const logBeforeDecoy = await readLog(page);
+
+  // A second finger touches down, drags across the menu, and lifts while
+  // the first finger (the gesture's owner) stays put. None of it should
+  // produce a single notification.
+  await drag.addSecondary(decoyStart);
+  await drag.moveSecondary(decoyMoved);
+  await drag.liftSecondary();
+  expect(await readLog(page)).toEqual(logBeforeDecoy);
+
+  // The owner finishes normally, as if the decoy had never happened.
+  await drag.movePrimary(target);
+  await drag.endPrimary();
+
+  const log = await waitForLogEntry(page, (entry) => entry.type === 'select');
+  expect(log.at(-1)).toMatchObject({
+    mode: 'novice',
+    selectionId: 'right',
+    type: 'select',
+  });
+
+  // A fresh gesture afterward still works: the owner's release fully freed
+  // the surface for a new primary pointer. The log already holds a `select`
+  // entry from the first gesture, so wait on log growth rather than
+  // `waitForLogEntry`, which would resolve on that stale entry immediately.
+  const logLengthBeforeFresh = log.length;
+  const freshDrag = await CdpTouchDrag.start(page, center);
+  await freshDrag.moveTo(target);
+  await freshDrag.end();
+
+  let freshLog: Awaited<ReturnType<typeof readLog>> = [];
+  await expect
+    .poll(async () => {
+      freshLog = await readLog(page);
+      return freshLog.length > logLengthBeforeFresh;
+    })
+    .toBe(true);
+  expect(freshLog.at(-1)).toMatchObject({
+    mode: 'expert',
+    selectionId: 'right',
+    type: 'select',
+  });
+});

--- a/e2e/tests/concurrent-pointers.spec.ts
+++ b/e2e/tests/concurrent-pointers.spec.ts
@@ -5,7 +5,7 @@ import {
   TOP_LEVEL_ITEMS,
   waitForMenuOpen,
 } from '../helpers/gestures.js';
-import { readLog, waitForLogEntry } from '../helpers/log.js';
+import { readLog, waitForLogEntry, waitForLogGrowth } from '../helpers/log.js';
 import { CdpMultiTouchDrag, CdpTouchDrag } from '../helpers/touch.js';
 
 // Same margin-from-thresholds rationale as mouse.spec.ts.
@@ -46,18 +46,11 @@ test('concurrent pointers: a second touch cannot move, select or cancel the owni
   // the surface for a new primary pointer. The log already holds a `select`
   // entry from the first gesture, so wait on log growth rather than
   // `waitForLogEntry`, which would resolve on that stale entry immediately.
-  const logLengthBeforeFresh = log.length;
   const freshDrag = await CdpTouchDrag.start(page, center);
   await freshDrag.moveTo(target);
   await freshDrag.end();
 
-  let freshLog: Awaited<ReturnType<typeof readLog>> = [];
-  await expect
-    .poll(async () => {
-      freshLog = await readLog(page);
-      return freshLog.length > logLengthBeforeFresh;
-    })
-    .toBe(true);
+  const freshLog = await waitForLogGrowth(page, log.length);
   expect(freshLog.at(-1)).toMatchObject({
     mode: 'expert',
     selectionId: 'right',

--- a/e2e/tests/multiple-controllers.spec.ts
+++ b/e2e/tests/multiple-controllers.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from '../helpers/fixtures.js';
+
+/**
+ Reads `touch-action`'s inline value and priority off `element` (both empty
+ strings when the property isn't set at all).
+ */
+type TouchActionStyle = { priority: string; value: string };
+
+test('multiple controllers on one parent: touch-action stays claimed until the last controller is disposed, then the exact prior inline value and priority are restored', async ({
+  page,
+}) => {
+  // A detached element, distinct from the fixture's own `#surface` (which
+  // already has its own live controller for the whole test session): this
+  // test drives its own controllers directly against the library, through
+  // the same `marking-menu` module the fixture's import map resolves.
+  const styles = await page.evaluate(async (): Promise<TouchActionStyle[]> => {
+    const { createMarkingMenu } = await import('marking-menu');
+    const element = document.createElement('div');
+    element.style.setProperty('touch-action', 'pan-y', 'important');
+    const readStyle = (): TouchActionStyle => ({
+      priority: element.style.getPropertyPriority('touch-action'),
+      value: element.style.getPropertyValue('touch-action'),
+    });
+
+    const items = [
+      { id: 'a', label: 'A' },
+      { id: 'b', label: 'B' },
+    ];
+    const results: TouchActionStyle[] = [];
+
+    const first = createMarkingMenu({ items, parent: element }).subscribe();
+    results.push(readStyle());
+
+    const second = createMarkingMenu({ items, parent: element }).subscribe();
+    results.push(readStyle());
+
+    first.unsubscribe();
+    results.push(readStyle());
+
+    second.unsubscribe();
+    results.push(readStyle());
+
+    return results;
+  });
+
+  const [afterFirst, afterSecond, afterFirstRelease, afterSecondRelease] =
+    styles;
+  const claimed = { priority: 'important', value: 'none' };
+
+  expect(afterFirst).toEqual(claimed);
+  expect(afterSecond).toEqual(claimed);
+  expect(afterFirstRelease, 'still claimed by the second controller').toEqual(
+    claimed,
+  );
+  expect(
+    afterSecondRelease,
+    'the exact prior inline value and priority',
+  ).toEqual({ priority: 'important', value: 'pan-y' });
+});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -3,7 +3,12 @@
     "target": "ES2024",
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    // ESNext over ES2024 to get `Symbol.dispose`/`Symbol.asyncDispose`
+    // (explicit resource management) for `using`/`await using` in the specs
+    // and CDP helpers — this project is `noEmit`, so the down-level codegen
+    // ships through Vite's own transpile of the fixture, not `tsc`, so there
+    // is no separate polyfill to add here.
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "types": ["node", "vite/client"],
     // The fixture imports `marking-menu` as a bare specifier, resolved at
     // runtime through the browser import map (see `e2e/fixture/index.html`)


### PR DESCRIPTION
Closes #176

## Summary

Two of the coverage bar's Playwright items (#153), written against the **current, unmodified** RxJS engine so they lock in behaviour that must survive the upcoming engine swap:

- **Concurrent pointers** (`e2e/tests/concurrent-pointers.spec.ts`) — while a touch gesture is in progress, a second finger touching down, dragging across the menu, and lifting produces zero notifications; the log is asserted byte-for-byte unchanged across that whole sequence. The owner then finishes normally, and a fresh gesture afterward still works. Driven through a new `CdpMultiTouchDrag` helper (`e2e/helpers/touch.ts`) that dispatches raw CDP `Input.dispatchTouchEvent` calls with distinct touch ids, so Chromium produces a real second `pointerId`/`isPrimary: false` — the actual thing `src/move/pointer-drag.ts`'s gating logic (`!event.isPrimary`, `event.pointerId !== active?.pointerId`) checks. Two more angles on the same scenario, empirically verified against the current engine before being written as permanent specs:
  - a decoy finger lifted only *after* the gesture it never touched has already ended still produces nothing;
  - three concurrent pointers (not just two) behave the same as two.
- **Multiple controllers on one parent** (`e2e/tests/multiple-controllers.spec.ts`) — two `createMarkingMenu` controllers subscribed on the same (detached) parent element keep `touch-action: none !important` claimed after the first unsubscribes, and only restore the exact prior inline value/priority once the second unsubscribes too. Exercises the reference-counting in `src/move/touch-action.ts` through the full library surface, not just the isolated module (already unit-tested at `src/move/touch-action.test.ts`).

All five scenarios passed against the current engine on first run — no finding to report on #176 or #153.

## Notes

- Test-only change: no `src/` file touched, no changeset added, per #176's acceptance criteria.
- While building the CDP multi-touch helper, found that `Input.dispatchTouchEvent`'s `touchPoints` means different things depending on `type`: `touchStart`/`touchMove` want every currently-active point, but `touchEnd` wants only the point(s) *ending* in that event — passing a still-down finger there too ends it as well. Documented on `CdpMultiTouchDrag`.
- Generalized `CdpMultiTouchDrag` from a fixed primary+secondary pair to arbitrary extra finger ids (`addFinger`/`moveFinger`/`liftFinger(id)`), and split disposing its CDP session out from ending the primary touch, so a decoy can keep being driven after the primary already finished.
- Disposal is exposed as `Symbol.asyncDispose`, so specs open it with `await using` instead of manual try/finally. Bumped `e2e/tsconfig.json`'s `lib` to `ESNext` for the `Symbol.dispose`/`asyncDispose` types (that project is `noEmit`, so there's no separate polyfill concern). `eslint-plugin-unicorn`@72's built-in `Symbol` property list predates that (recently-standardized) proposal, hence the one narrowly-scoped disable comment.
- Extracted `waitForLogGrowth` next to the existing `waitForLogEntry` (`e2e/helpers/log.ts`): a couple of these tests need to wait for a *new* log entry when the log already holds a stale one from an earlier gesture, which `waitForLogEntry` would resolve on immediately.

## Test plan

- [x] `yarn typecheck`
- [x] `yarn lint` (clean besides two pre-existing `import-x/order` errors on `main`, unrelated to this change)
- [x] `yarn format:check`
- [x] `yarn test` (222 unit tests)
- [x] `yarn e2e:build && yarn e2e:test` (32/32 Playwright tests, including the 4 new ones, across chromium/firefox/webkit/chromium-touch)
