### PR TITLE
Make tsc flag unused locals and parameters

### DIFF
--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,8 +1,6 @@
 {
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2024",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
     // ESNext over ES2024 to get `Symbol.dispose`/`Symbol.asyncDispose`
     // (explicit resource management) for `using`/`await using` in the specs
     // and CDP helpers — this project is `noEmit`, so the down-level codegen
@@ -15,23 +13,7 @@
     // rather than from `node_modules` (the package doesn't depend on
     // itself). Point the type-checker at the same source the map ultimately
     // serves, unbundled.
-    "paths": { "marking-menu": ["../src/index.ts"] },
-    "strict": true,
-    "erasableSyntaxOnly": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "moduleDetection": "force",
-    "noUncheckedIndexedAccess": true,
-    "exactOptionalPropertyTypes": true,
-    "noImplicitOverride": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true
+    "paths": { "marking-menu": ["../src/index.ts"] }
   },
   "include": ["**/*.ts"]
 }

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -27,6 +27,8 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true

--- a/src/marking-menu.ts
+++ b/src/marking-menu.ts
@@ -16,7 +16,6 @@ import { navigation } from './navigation/navigation.js';
 import type {
   AnyModelNode,
   MarkingMenuInput,
-  MarkingMenuItemInput,
   ModelItems,
   ModelLeaves,
   ModelMenus,

--- a/src/move/long-move.test.ts
+++ b/src/move/long-move.test.ts
@@ -20,7 +20,7 @@ describe('longMove', () => {
   // prettier-ignore
   it('filters out movements smaller than its threshold', marbles(m => {
       // Mock distance from current with current's value.
-      vi.mocked(dist).mockImplementation((previous, cur) => cur[0] ?? 0);
+      vi.mocked(dist).mockImplementation((_previous, cur) => cur[0] ?? 0);
 
       const drag$     = m.hot('^a-ba--b-xbaa--by-aa--x-b(e|)', values);
       const expected$ = m.hot('^--------x------y-----x--|',    values);
@@ -30,7 +30,7 @@ describe('longMove', () => {
   // prettier-ignore
   it('the threshold is null by default (i.e. almost everything goes through)', marbles(m => {
     // Mock distance from current with current's value.
-    vi.mocked(dist).mockImplementation((previous, cur) => cur[0] ?? 0);
+    vi.mocked(dist).mockImplementation((_previous, cur) => cur[0] ?? 0);
 
     const drag$     = m.hot('^a-ba--b-xbaa--by-aa--x-b(e|)', values);
     const expected$ = m.hot('^--ba--b-xbaa--by-aa--x-b|',    values);

--- a/src/recognizer/recognize-mm-stroke.test.ts
+++ b/src/recognizer/recognize-mm-stroke.test.ts
@@ -4,7 +4,7 @@ import { promisify } from 'node:util';
 import angles from 'angles';
 import { parse as csvParseCallback } from 'csv-parse';
 import { type Mock } from 'vitest';
-import type { ModelItem, ModelRoot } from '../types.js';
+import type { ModelItem } from '../types.js';
 import type { Point } from '../utils.js';
 import {
   divideLongestSegment,

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,26 +1,8 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2024",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
-    "types": ["vite/client"],
-    "strict": true,
-    "erasableSyntaxOnly": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "moduleDetection": "force",
-    "noUncheckedIndexedAccess": true,
-    "exactOptionalPropertyTypes": true,
-    "noImplicitOverride": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true
+    "types": ["vite/client"]
   },
   "include": ["src"],
   "exclude": ["src/**/*.test.ts", "src/**/*.test-d.ts"]

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -16,6 +16,8 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  }
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,26 +1,8 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2024",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
     "lib": ["ES2024"],
-    "types": ["node"],
-    "strict": true,
-    "erasableSyntaxOnly": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "moduleDetection": "force",
-    "noUncheckedIndexedAccess": true,
-    "exactOptionalPropertyTypes": true,
-    "noImplicitOverride": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true
+    "types": ["node"]
   },
   "include": ["*.config.ts", "scripts/**/*.ts"]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -16,6 +16,8 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,26 +1,8 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2024",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
-    "types": ["node", "vite/client", "vitest/globals"],
-    "strict": true,
-    "erasableSyntaxOnly": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "moduleDetection": "force",
-    "noUncheckedIndexedAccess": true,
-    "exactOptionalPropertyTypes": true,
-    "noImplicitOverride": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true
+    "types": ["node", "vite/client", "vitest/globals"]
   },
   "include": ["src/**/*.test.ts", "src/**/*.test-d.ts"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -16,6 +16,8 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true


### PR DESCRIPTION
## Summary

- `tsc` currently stays silent on dead imports/locals/parameters (e.g. the unused `MarkingMenuItemInput` import in `src/marking-menu.ts`), leaving that class of bug to whatever happens to run ESLint. Enable `noUnusedLocals` and `noUnusedParameters` in every project's tsconfig so `tsc -b`/`yarn typecheck` catches it directly.
- Fix the handful of spots the new flags surfaced: the unused `MarkingMenuItemInput` import in `src/marking-menu.ts`, an unused `ModelRoot` import in `src/recognizer/recognize-mm-stroke.test.ts`, and two unused `previous` mock parameters in `src/move/long-move.test.ts` (renamed to `_previous`, the conventional opt-out for an intentionally-unused parameter).
- While at it, extracted the shared `compilerOptions` block (previously duplicated across `tsconfig.app.json`, `tsconfig.test.json`, `tsconfig.node.json`, and `e2e/tsconfig.json`) into a new `tsconfig.base.json`, so each project config now only lists what's actually project-specific (`lib`, `types`, `paths`, `include`/`exclude`).

## Test plan

- [x] `yarn typecheck` (`tsc -b --force`) passes with no errors
- [x] `yarn lint` — no new issues (pre-existing unrelated warning in `navigation.ts` untouched)
- [x] `yarn test` — all 222 tests pass, including in-source type tests
- [x] `yarn format:check` on the touched tsconfig files

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLVkjQ35DHCcayeAd3r83N)_