### PR TITLE
Split CI job into parallel Lint and Unit Tests jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 jobs:
-  CI:
+  Lint:
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -22,6 +22,13 @@ jobs:
       - run: yarn lint
       - run: yarn format:check
       - run: yarn typecheck
+
+  UnitTests:
+    name: Unit Tests
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: ./.github/actions/setup
       - run: yarn test:coverage
 
   Build:


### PR DESCRIPTION
## Summary

- The `CI` workflow had a job also named `CI` that ran lint, format check, typecheck, and tests sequentially — an ambiguous name alongside sibling jobs `Build`, `Package`, `E2E`.
- Split it into two independent jobs that run in parallel: `Lint` (lint, format:check, typecheck) and `Unit Tests` (test:coverage). Both reuse the same cached setup action, so total wall-clock time should drop.

## Test plan

- [ ] CI passes on this PR (Lint and Unit Tests jobs both run and succeed)
- [ ] After merge, update branch protection required status checks from `CI` to `Lint` and `Unit Tests`

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1ZRvPZVcLXGepgYXXQQ9P)_