### PR TITLE
Give rafThrottle a cancel handle; wire it into renderer.dispose()

### DIFF
--- a/src/engine/layout-view.ts
+++ b/src/engine/layout-view.ts
@@ -6,7 +6,7 @@ import type { NavigationState } from './machine.js';
  always `null` until a ticket introduces the `novice` phase.
  */
 export type LayoutView = {
-  readonly cursor: 'default' | 'crosshair' | 'none';
+  readonly cursor: 'default' | 'crosshair';
   readonly menu: null;
   readonly upperStroke: readonly Point[] | null;
   readonly lowerStroke: null;

--- a/src/engine/renderer.test.ts
+++ b/src/engine/renderer.test.ts
@@ -39,4 +39,27 @@ describe('createRenderer', () => {
       context.mock.methodCalls.filter((c) => c.method === 'stroke'),
     ).toHaveLength(1);
   });
+
+  it('cancels a pending frame on dispose', () => {
+    using _canvases = stubbedCanvasContexts();
+    using _timers = fakeTimers();
+
+    const parent = document.createElement('div');
+    const renderer = createRenderer({ parent });
+    const stroke: Point[] = [
+      [0, 0],
+      [10, 0],
+    ];
+    const cancelSpy = vi.spyOn(globalThis, 'cancelAnimationFrame');
+
+    renderer.render({
+      cursor: 'crosshair',
+      menu: null,
+      upperStroke: stroke,
+      lowerStroke: null,
+    });
+    renderer.dispose();
+
+    expect(cancelSpy).toHaveBeenCalledOnce();
+  });
 });

--- a/src/engine/renderer.ts
+++ b/src/engine/renderer.ts
@@ -58,11 +58,7 @@ export function createRenderer({
     },
     dispose() {
       parent.style.cursor = ownCursor;
-      // A frame scheduled by `drawUpperStroke` may still be pending. It is
-      // inert once the canvas below is dropped (the throttled callback
-      // optional-chains on it), so there is nothing to cancel here. See
-      // https://github.com/QuentinRoy/Marking-Menu/issues/153 for giving
-      // `rafThrottle` a real cancellation handle.
+      drawUpperStroke.cancel();
       upperStrokeCanvas?.remove();
       upperStrokeCanvas = null;
       gestureFeedback.remove();

--- a/src/layout/raf-throttle.test.ts
+++ b/src/layout/raf-throttle.test.ts
@@ -61,6 +61,38 @@ describe('rafThrottle', () => {
     expect(fn).not.toHaveBeenCalled();
   });
 
+  it('does not call the throttled function once canceled', () => {
+    const fn = voidMock<[number]>();
+    const throttled = rafThrottle(fn);
+
+    throttled(1);
+    throttled.cancel();
+    vi.advanceTimersToNextFrame();
+
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when canceled with no frame pending', () => {
+    const fn = voidMock<[number]>();
+    const throttled = rafThrottle(fn);
+
+    expect(() => {
+      throttled.cancel();
+    }).not.toThrow();
+  });
+
+  it('can schedule a new frame after being canceled', () => {
+    const fn = voidMock<[number]>();
+    const throttled = rafThrottle(fn);
+
+    throttled(1);
+    throttled.cancel();
+    throttled(2);
+    vi.advanceTimersToNextFrame();
+
+    expect(fn).toHaveBeenCalledExactlyOnceWith(2);
+  });
+
   it('throttles each wrapped function independently', () => {
     const fn1 = voidMock<[string]>();
     const fn2 = voidMock<[string]>();

--- a/src/layout/raf-throttle.ts
+++ b/src/layout/raf-throttle.ts
@@ -1,3 +1,10 @@
+/** A `rafThrottle`d function, with a handle to cancel its pending frame. */
+export type Throttled<Arguments extends readonly unknown[]> = {
+  (...args: Arguments): void;
+  /** Cancel the pending frame, if any. A no-op when none is scheduled. */
+  cancel: () => void;
+};
+
 /**
  Throttle `fn` so that it runs at most once per animation frame.
 
@@ -5,16 +12,16 @@
  `fn` once, with the arguments of the most recent call.
 
  @param fn - The function to throttle.
- @returns The throttled function.
+ @returns The throttled function, with a `cancel` method.
  */
 export function rafThrottle<Arguments extends readonly unknown[]>(
   fn: (...args: Arguments) => void,
-): (...args: Arguments) => void {
-  // The arguments of the most recent call, while a frame is scheduled. `null`
-  // when no frame is pending.
-  let pending: { args: Arguments } | null = null;
+): Throttled<Arguments> {
+  // The arguments and frame handle of the most recent call, while a frame is
+  // scheduled. `null` when no frame is pending.
+  let pending: { args: Arguments; frame: number } | null = null;
 
-  return (...args: Arguments) => {
+  function throttled(...args: Arguments): void {
     if (pending !== null) {
       pending.args = args;
       return;
@@ -22,11 +29,22 @@ export function rafThrottle<Arguments extends readonly unknown[]>(
 
     // Captured in its own `const` so the callback below can read the latest
     // arguments without having to re-narrow the nullable `pending`.
-    const scheduled = { args };
+    const scheduled = { args, frame: -1 };
     pending = scheduled;
-    requestAnimationFrame(() => {
+    scheduled.frame = requestAnimationFrame(() => {
       pending = null;
       fn(...scheduled.args);
     });
+  }
+
+  throttled.cancel = () => {
+    if (pending === null) {
+      return;
+    }
+
+    cancelAnimationFrame(pending.frame);
+    pending = null;
   };
+
+  return throttled;
 }


### PR DESCRIPTION
rafThrottle now returns a callable with a .cancel() method that
cancels the pending requestAnimationFrame, if any. renderer.dispose()
calls it so a scheduled drawUpperStroke frame doesn't fire after
disposal.

Also drops LayoutView.cursor's dead 'none' variant: projectLayout
never produces it.

Fixes #195