### PR TITLE
Add pointer cancel handling and improve gesture feedback

### DIFF
--- a/src/engine/controller.test.ts
+++ b/src/engine/controller.test.ts
@@ -5,6 +5,7 @@ import {
   stubbedCanvasContexts,
 } from '../__fixtures__/canvas.js';
 import type {
+  MarkingMenuCancelEvent,
   MarkingMenuSelectEvent,
   MarkingMenuStartEvent,
 } from '../events.js';
@@ -293,6 +294,134 @@ describe('createController', () => {
     // A `select` listener sees fully committed state, and capture ownership is
     // part of that state: a listener may legitimately start its own gesture.
     expect(heldDuringSelect).toBe(false);
+
+    controller.dispose();
+  });
+
+  it('dispatches cancel carrying a null active, not select, for a gesture with no movement at all', () => {
+    using _canvases = stubbedCanvasContexts();
+    const parent = createParent();
+    const controller = createController({ items, parent });
+
+    const selected = voidMock<[MarkingMenuSelectEvent<AnyModelNode>]>();
+    controller.on('select', selected);
+
+    let cancelEvent: MarkingMenuCancelEvent<AnyModelNode> | undefined;
+    controller.on('cancel', (event) => {
+      cancelEvent = event;
+    });
+
+    parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
+    parent.dispatchEvent(pointer('pointerup', { clientX: 0, clientY: 0 }));
+
+    expect(selected).not.toHaveBeenCalled();
+    expect(cancelEvent?.mode).toBe('startup');
+    expect(cancelEvent?.active).toBeNull();
+
+    controller.dispose();
+  });
+
+  it('dispatches cancel, never select, when the native pointer is cancelled mid-gesture, even along a straight line that would otherwise recognize', () => {
+    using _canvases = stubbedCanvasContexts();
+    const parent = createParent();
+    const controller = createController({ items, parent });
+
+    const selected = voidMock<[MarkingMenuSelectEvent<AnyModelNode>]>();
+    controller.on('select', selected);
+
+    let cancelEvent: MarkingMenuCancelEvent<AnyModelNode> | undefined;
+    controller.on('cancel', (event) => {
+      cancelEvent = event;
+    });
+
+    parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
+    parent.dispatchEvent(pointer('pointermove', { clientX: 100, clientY: 0 }));
+    parent.dispatchEvent(
+      pointer('pointercancel', { clientX: 100, clientY: 0 }),
+    );
+
+    expect(selected).not.toHaveBeenCalled();
+    expect(cancelEvent?.mode).toBe('expert');
+    expect(cancelEvent?.active).toBeNull();
+
+    controller.dispose();
+  });
+
+  it('has already released pointer capture by the time cancel is dispatched', () => {
+    using _canvases = stubbedCanvasContexts();
+    const parent = createParent();
+    const controller = createController({ items, parent });
+
+    let heldDuringCancel: boolean | undefined;
+    controller.on('cancel', () => {
+      heldDuringCancel = parent.hasPointerCapture(1);
+    });
+
+    parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
+    parent.dispatchEvent(pointer('pointermove', { clientX: 100, clientY: 0 }));
+    parent.dispatchEvent(
+      pointer('pointercancel', { clientX: 100, clientY: 0 }),
+    );
+
+    expect(heldDuringCancel).toBe(false);
+
+    controller.dispose();
+  });
+
+  it('leaves an earlier gesture-feedback trace untouched when a new gesture completes', () => {
+    using _canvases = stubbedCanvasContexts();
+    const parent = createParent();
+    const controller = createController({ items, parent });
+
+    parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
+    parent.dispatchEvent(pointer('pointermove', { clientX: 100, clientY: 0 }));
+    parent.dispatchEvent(pointer('pointerup', { clientX: 120, clientY: 0 }));
+    expect(parent.querySelectorAll('canvas')).toHaveLength(1);
+
+    parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
+    parent.dispatchEvent(pointer('pointerup', { clientX: 0, clientY: 0 }));
+    expect(parent.querySelectorAll('canvas')).toHaveLength(2);
+
+    controller.dispose();
+  });
+
+  it('lets three overlapping gesture-feedback traces expire independently, on their own schedules', () => {
+    using _canvases = stubbedCanvasContexts();
+    using _timers = fakeTimers();
+    const parent = createParent();
+    const controller = createController({ items, parent });
+
+    const gesture = (x: number) => {
+      parent.dispatchEvent(pointer('pointerdown', { clientX: x, clientY: 0 }));
+      parent.dispatchEvent(
+        pointer('pointermove', { clientX: x + 100, clientY: 0 }),
+      );
+      parent.dispatchEvent(
+        pointer('pointerup', { clientX: x + 120, clientY: 0 }),
+      );
+    };
+
+    // Trace #1 shown at 0ms (expires at 1000ms).
+    gesture(0);
+    vi.advanceTimersByTime(400);
+    // Trace #2 shown at 400ms (expires at 1400ms).
+    gesture(200);
+    vi.advanceTimersByTime(400);
+    // Trace #3 shown at 800ms (expires at 1800ms).
+    gesture(400);
+    expect(parent.querySelectorAll('canvas')).toHaveLength(3);
+
+    // 1000ms since trace #1 was shown: only that one has expired.
+    vi.advanceTimersByTime(200);
+    expect(parent.querySelectorAll('canvas')).toHaveLength(2);
+
+    // 1400ms since trace #1: trace #2 has now expired too.
+    vi.advanceTimersByTime(400);
+    expect(parent.querySelectorAll('canvas')).toHaveLength(1);
+
+    // 1800ms since trace #1: trace #3 has now expired too.
+    vi.advanceTimersByTime(400);
+    expect(parent.querySelectorAll('canvas')).toHaveLength(0);
 
     controller.dispose();
   });

--- a/src/engine/machine.test.ts
+++ b/src/engine/machine.test.ts
@@ -1,5 +1,25 @@
 import { createModel } from '../model.js';
+import { recognizeMarkingMenuStroke } from '../recognizer/recognize-mm-stroke.js';
+import type * as RecognizeModule from '../recognizer/recognize-mm-stroke.js';
 import { transition, type NavigationState } from './machine.js';
+
+// Wraps the real recognizer rather than replacing it: every existing test
+// keeps exercising genuine recognition geometry, and only the tests that
+// need a specific (or impossible-to-construct) outcome override it with
+// `mockReturnValueOnce`/`mockImplementationOnce`.
+vi.mock('../recognizer/recognize-mm-stroke.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof RecognizeModule>();
+  return {
+    ...actual,
+    recognizeMarkingMenuStroke: vi.fn(actual.recognizeMarkingMenuStroke),
+  };
+});
+
+const mockRecognize = vi.mocked(recognizeMarkingMenuStroke);
+
+afterEach(() => {
+  mockRecognize.mockClear();
+});
 
 const model = createModel({
   items: [
@@ -13,6 +33,14 @@ const model = createModel({
 const options = { movementsThreshold: 5 };
 const environment = { model };
 const idle: NavigationState = { phase: 'idle' };
+
+/** Find the `dispatch` command among a transition's commands, if any. */
+const dispatched = (commands: ReturnType<typeof transition>['commands']) =>
+  commands.find((c) => c.type === 'dispatch');
+
+/** Find the `feedback.show` command among a transition's commands, if any. */
+const feedbackShown = (commands: ReturnType<typeof transition>['commands']) =>
+  commands.find((c) => c.type === 'feedback.show');
 
 describe('transition', () => {
   it('recognizes directly from startup on pointer up, without an intermediate move', () => {
@@ -30,10 +58,8 @@ describe('transition', () => {
     );
 
     expect(up.state).toEqual({ phase: 'idle' });
-    const dispatched = up.commands.find((c) => c.type === 'dispatch');
-    expect(dispatched?.type === 'dispatch' && dispatched.event.type).toBe(
-      'select',
-    );
+    const command = dispatched(up.commands);
+    expect(command?.type === 'dispatch' && command.event.type).toBe('select');
   });
 
   it('stays in startup for movement below the threshold', () => {
@@ -98,7 +124,7 @@ describe('transition', () => {
     ).toEqual({ state: idle, commands: [] });
   });
 
-  it('does not select on an unrecognized (zero-length) gesture', () => {
+  it('dispatches cancel, without attempting recognition, for a gesture with no movement at all', () => {
     const down = transition(
       idle,
       { type: 'pointer.down', position: [0, 0] },
@@ -112,6 +138,113 @@ describe('transition', () => {
       options,
     );
 
-    expect(up).toEqual({ state: { phase: 'idle' }, commands: [] });
+    expect(up.state).toEqual({ phase: 'idle' });
+    expect(mockRecognize).not.toHaveBeenCalled();
+
+    const command = dispatched(up.commands);
+    expect(command?.type === 'dispatch' && command.event.type).toBe('cancel');
+    expect(
+      command?.type === 'dispatch' &&
+        command.event.type === 'cancel' &&
+        command.event.active,
+    ).toBeNull();
+    expect(feedbackShown(up.commands)).toMatchObject({ canceled: true });
+  });
+
+  it('dispatches cancel for a completed gesture that recognition does not match', () => {
+    mockRecognize.mockReturnValueOnce(null);
+
+    const down = transition(
+      idle,
+      { type: 'pointer.down', position: [0, 0] },
+      environment,
+      options,
+    );
+    const move = transition(
+      down.state,
+      { type: 'pointer.move', position: [100, 0] },
+      environment,
+      options,
+    );
+    const up = transition(
+      move.state,
+      { type: 'pointer.up', position: [120, 0] },
+      environment,
+      options,
+    );
+
+    expect(up.state).toEqual({ phase: 'idle' });
+    expect(mockRecognize).toHaveBeenCalledTimes(1);
+
+    const command = dispatched(up.commands);
+    expect(command?.type === 'dispatch' && command.event.type).toBe('cancel');
+    expect(feedbackShown(up.commands)).toMatchObject({ canceled: true });
+  });
+
+  it('dispatches cancel, never select, when the pointer is cancelled mid-gesture, even though the stroke would otherwise have recognized', () => {
+    const down = transition(
+      idle,
+      { type: 'pointer.down', position: [0, 0] },
+      environment,
+      options,
+    );
+    const move = transition(
+      down.state,
+      { type: 'pointer.move', position: [100, 0] },
+      environment,
+      options,
+    );
+    expect(move.state.phase).toBe('expert');
+
+    const canceled = transition(
+      move.state,
+      { type: 'pointer.cancel', position: [100, 0] },
+      environment,
+      options,
+    );
+
+    expect(canceled.state).toEqual({ phase: 'idle' });
+    expect(mockRecognize).not.toHaveBeenCalled();
+
+    const command = dispatched(canceled.commands);
+    expect(command?.type === 'dispatch' && command.event.type).toBe('cancel');
+    expect(
+      command?.type === 'dispatch' &&
+        command.event.type === 'cancel' &&
+        command.event.active,
+    ).toBeNull();
+    expect(feedbackShown(canceled.commands)).toMatchObject({ canceled: true });
+  });
+
+  it('dispatches cancel when the pointer is cancelled during startup, before any movement crossed the threshold', () => {
+    const down = transition(
+      idle,
+      { type: 'pointer.down', position: [0, 0] },
+      environment,
+      options,
+    );
+
+    const canceled = transition(
+      down.state,
+      { type: 'pointer.cancel', position: [0, 0] },
+      environment,
+      options,
+    );
+
+    expect(canceled.state).toEqual({ phase: 'idle' });
+    expect(mockRecognize).not.toHaveBeenCalled();
+    const command = dispatched(canceled.commands);
+    expect(command?.type === 'dispatch' && command.event.type).toBe('cancel');
+  });
+
+  it('ignores a stray pointer.cancel while idle', () => {
+    expect(
+      transition(
+        idle,
+        { type: 'pointer.cancel', position: [1, 1] },
+        environment,
+        options,
+      ),
+    ).toEqual({ state: idle, commands: [] });
   });
 });

--- a/src/engine/machine.ts
+++ b/src/engine/machine.ts
@@ -1,10 +1,12 @@
 import {
+  MarkingMenuCancelEvent,
   MarkingMenuSelectEvent,
   MarkingMenuStartEvent,
   type MarkingMenuEvent,
   type MarkingMenuMode,
 } from '../events.js';
 import { recognizeMarkingMenuStroke } from '../recognizer/recognize-mm-stroke.js';
+import { strokeLength } from '../recognizer/stroke-length.js';
 import type { AnyModelNode } from '../types.js';
 import { dist, type Point } from '../utils.js';
 
@@ -27,7 +29,8 @@ export type NavigationState =
 export type NavigationInput =
   | { readonly type: 'pointer.down'; readonly position: Point }
   | { readonly type: 'pointer.move'; readonly position: Point }
-  | { readonly type: 'pointer.up'; readonly position: Point };
+  | { readonly type: 'pointer.up'; readonly position: Point }
+  | { readonly type: 'pointer.cancel'; readonly position: Point };
 
 export type NavigationEnvironment<M extends AnyModelNode> = {
   readonly model: M;
@@ -51,23 +54,33 @@ export type Transition<M extends AnyModelNode> = {
 };
 
 /**
- The shared terminal transition: recognize the gesture drawn so far and
- return to idle. Owns the one place `select`/`feedback.show` are built so
- `startup` and `expert` don't each repeat this policy.
+ The shared terminal transition: recognize the gesture drawn so far (unless
+ `skipRecognition`) and return to idle, either selecting the recognized item
+ or cancelling. Owns the one place `select`/`cancel`/`feedback.show` are
+ built so `startup` and `expert` don't each repeat this policy.
+
+ `skipRecognition` covers the two paths that must never select regardless of
+ what the stroke looks like: a pointer that was cancelled outright, and a
+ gesture that never moved at all (so there is nothing to recognize).
  */
 function finish<M extends AnyModelNode>(
   {
     mode,
     stroke,
     position,
+    skipRecognition = false,
   }: {
     mode: MarkingMenuMode;
     stroke: readonly Point[];
     position: Point;
+    skipRecognition?: boolean;
   },
   environment: NavigationEnvironment<M>,
 ): Transition<M> {
-  const selection = recognizeMarkingMenuStroke(stroke, environment.model);
+  const selection = skipRecognition
+    ? null
+    : recognizeMarkingMenuStroke(stroke, environment.model);
+
   if (selection !== null) {
     return {
       state: { phase: 'idle' },
@@ -86,7 +99,21 @@ function finish<M extends AnyModelNode>(
     };
   }
 
-  return { state: { phase: 'idle' }, commands: [] };
+  return {
+    state: { phase: 'idle' },
+    commands: [
+      { type: 'feedback.show', stroke, canceled: true },
+      {
+        type: 'dispatch',
+        event: new MarkingMenuCancelEvent<M>({
+          mode,
+          position,
+          active: null,
+          menu: null,
+        }),
+      },
+    ],
+  };
 }
 
 function transitionStartup<M extends AnyModelNode>(
@@ -106,11 +133,28 @@ function transitionStartup<M extends AnyModelNode>(
     }
 
     case 'pointer.up': {
+      const stroke = [...state.stroke, input.position];
+      return finish(
+        {
+          mode: 'startup',
+          stroke,
+          position: input.position,
+          // The pointer never moved at all: every recorded point (down,
+          // any moves below the threshold, and this up) sits at the same
+          // position, so there is nothing to recognize.
+          skipRecognition: strokeLength(stroke) === 0,
+        },
+        environment,
+      );
+    }
+
+    case 'pointer.cancel': {
       return finish(
         {
           mode: 'startup',
           stroke: [...state.stroke, input.position],
           position: input.position,
+          skipRecognition: true,
         },
         environment,
       );
@@ -141,6 +185,18 @@ function transitionExpert<M extends AnyModelNode>(
           mode: 'expert',
           stroke: [...state.stroke, input.position],
           position: input.position,
+        },
+        environment,
+      );
+    }
+
+    case 'pointer.cancel': {
+      return finish(
+        {
+          mode: 'expert',
+          stroke: [...state.stroke, input.position],
+          position: input.position,
+          skipRecognition: true,
         },
         environment,
       );

--- a/src/engine/pointer-source.test.ts
+++ b/src/engine/pointer-source.test.ts
@@ -22,4 +22,43 @@ describe('createPointerSource', () => {
 
     expect(send).not.toHaveBeenCalled();
   });
+
+  it('sends pointer.cancel for a native pointercancel on the active gesture, and releases capture beforehand', () => {
+    const parent = createParent();
+    const send = vi.fn<(input: NavigationInput) => void>();
+    createPointerSource({ parent, runtime: { send } });
+
+    parent.dispatchEvent(
+      pointer('pointerdown', { pointerId: 1, clientX: 0, clientY: 0 }),
+    );
+    expect(parent.hasPointerCapture(1)).toBe(true);
+    send.mockClear();
+
+    parent.dispatchEvent(
+      pointer('pointercancel', { pointerId: 1, clientX: 10, clientY: 10 }),
+    );
+
+    expect(parent.hasPointerCapture(1)).toBe(false);
+    expect(send).toHaveBeenCalledExactlyOnceWith({
+      type: 'pointer.cancel',
+      position: [10, 10],
+    });
+  });
+
+  it('ignores a pointercancel from a pointer that is not the active gesture owner', () => {
+    const parent = createParent();
+    const send = vi.fn<(input: NavigationInput) => void>();
+    createPointerSource({ parent, runtime: { send } });
+
+    parent.dispatchEvent(
+      pointer('pointerdown', { pointerId: 1, clientX: 0, clientY: 0 }),
+    );
+    send.mockClear();
+
+    parent.dispatchEvent(
+      pointer('pointercancel', { pointerId: 99, clientX: 10, clientY: 10 }),
+    );
+
+    expect(send).not.toHaveBeenCalled();
+  });
 });

--- a/src/engine/pointer-source.ts
+++ b/src/engine/pointer-source.ts
@@ -70,14 +70,26 @@ export function createPointerSource({
     runtime.send({ type: 'pointer.up', position: toPosition(event) });
   };
 
+  const onPointerCancel = (event: PointerEvent): void => {
+    if (event.pointerId !== activePointerId) {
+      return;
+    }
+
+    // Same ordering rationale as `onPointerUp`: release before dispatching.
+    releaseCapture();
+    runtime.send({ type: 'pointer.cancel', position: toPosition(event) });
+  };
+
   parent.addEventListener('pointerdown', onPointerDown);
   parent.addEventListener('pointermove', onPointerMove);
   parent.addEventListener('pointerup', onPointerUp);
+  parent.addEventListener('pointercancel', onPointerCancel);
 
   const dispose = (): void => {
     parent.removeEventListener('pointerdown', onPointerDown);
     parent.removeEventListener('pointermove', onPointerMove);
     parent.removeEventListener('pointerup', onPointerUp);
+    parent.removeEventListener('pointercancel', onPointerCancel);
     // Disposing mid-gesture: the listeners that would have released the
     // capture are gone, so nothing else ever would.
     releaseCapture();

--- a/src/engine/runtime.test.ts
+++ b/src/engine/runtime.test.ts
@@ -104,4 +104,50 @@ describe('createRuntime', () => {
 
     expect(renderer.dispose).toHaveBeenCalledTimes(1);
   });
+
+  it('emits cancel, not select, for a gesture with no movement at all', () => {
+    const runtime = createRuntime({
+      model,
+      options,
+      renderer: createFakeRenderer(),
+    });
+    const emitted = recordEmitted(runtime);
+
+    runtime.send({ type: 'pointer.down', position: [0, 0] });
+    runtime.send({ type: 'pointer.up', position: [0, 0] });
+
+    expect(emitted).toEqual(['start', 'cancel']);
+  });
+
+  it('emits cancel, not select, when the pointer is cancelled mid-gesture', () => {
+    const runtime = createRuntime({
+      model,
+      options,
+      renderer: createFakeRenderer(),
+    });
+    const emitted = recordEmitted(runtime);
+
+    runtime.send({ type: 'pointer.down', position: [0, 0] });
+    runtime.send({ type: 'pointer.move', position: [100, 0] });
+    runtime.send({ type: 'pointer.cancel', position: [100, 0] });
+
+    expect(emitted).toEqual(['start', 'cancel']);
+  });
+
+  it('shows the canceled feedback style for cancel, and the normal style for select', () => {
+    const renderer = createFakeRenderer();
+    const runtime = createRuntime({ model, options, renderer });
+
+    runtime.send({ type: 'pointer.down', position: [0, 0] });
+    runtime.send({ type: 'pointer.up', position: [100, 0] });
+    expect(renderer.showFeedback).toHaveBeenLastCalledWith(
+      expect.objectContaining({ canceled: false }),
+    );
+
+    runtime.send({ type: 'pointer.down', position: [0, 0] });
+    runtime.send({ type: 'pointer.up', position: [0, 0] });
+    expect(renderer.showFeedback).toHaveBeenLastCalledWith(
+      expect.objectContaining({ canceled: true }),
+    );
+  });
 });


### PR DESCRIPTION
Closes #178

## Summary
This PR adds support for handling pointer cancellation events and improves gesture feedback by distinguishing between successful selections and cancelled gestures. The system now properly handles cases where a pointer is cancelled mid-gesture or when a gesture has no movement at all.

## Key Changes

- **Pointer cancellation support**: Added `pointer.cancel` event handling throughout the state machine, pointer source, and controller layers. When a pointer is cancelled, the gesture is immediately terminated and a cancel event is dispatched instead of attempting recognition.

- **Zero-movement gesture handling**: Gestures with no movement (pointer down and up at the same position) now dispatch a cancel event rather than attempting recognition. This is detected using the new `strokeLength` utility.

- **Cancel event implementation**: Introduced `MarkingMenuCancelEvent` to distinguish cancelled gestures from selections. Cancel events carry `active: null` and `menu: null` to indicate no item was selected.

- **Feedback styling**: Added `canceled` flag to feedback display to visually distinguish cancelled gestures from successful selections.

- **Improved test infrastructure**: 
  - Added mocking of the recognizer module in machine tests while preserving real geometry testing for existing tests
  - Helper functions `dispatched()` and `feedbackShown()` for cleaner test assertions
  - Comprehensive test coverage for cancel scenarios across all layers

- **Pointer capture management**: Ensured pointer capture is released before dispatching cancel events, maintaining consistent behavior with pointer up handling.

## Implementation Details

- The `finish()` function in the state machine now accepts a `skipRecognition` parameter to handle paths that must never select (cancelled pointers and zero-movement gestures)
- Both `startup` and `expert` phases handle `pointer.cancel` by calling `finish()` with `skipRecognition: true`
- The pointer source properly validates that cancel events belong to the active gesture before processing
- Multiple overlapping gesture feedback traces can now coexist and expire independently on their own schedules

https://claude.ai/code/session_01P4uGN8WaWrt4mNZnN2srns