### PR TITLE
Disable import-x/order in favor of prettier's import sorting

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,17 @@ export default defineConfig([
       // C.f. https://github.com/xojs/xo/issues/889.
       '@stylistic/no-mixed-operators': 'off',
 
+      // Import order is owned by @ianvs/prettier-plugin-sort-imports (c.f.
+      // prettier.config.ts) and enforced by `yarn format:check`. This rule
+      // disagrees with it: `marking-menu` is this package's own name, so once
+      // dist/ is built, Node self-reference resolution makes import-x classify
+      // it as an `internal` import and sort it last (behind third-party and
+      // even relative imports), while prettier sorts it with third-party
+      // modules. Keeping both means `eslint --fix` and `prettier --write` undo
+      // each other, and that lint results depend on whether dist/ exists —
+      // which is why this only ever failed locally, never on CI.
+      'import-x/order': 'off',
+
       // This repo uses many factory functions, that starts with a capital letter, but are not classes.
       'new-cap': 'off',
 


### PR DESCRIPTION
## Problem

`yarn lint` fails on a clean `main` locally, while CI's Lint job passes on the exact same commit:

```
e2e/fixture/event-shim.ts  17:1  error  `rxjs` type import should occur before import of `marking-menu`  import-x/order
e2e/fixture/main.ts         2:1  error  `./event-shim.js` import should occur before import of `marking-menu`  import-x/order
```

## Why it diverges

- `e2e/fixture/*.ts` import `marking-menu` — the package's own name, resolved at runtime by the fixture's import map (`e2e/fixture/index.html`), not from `node_modules`.
- When `dist/` exists locally, Node self-reference resolution resolves that specifier to `dist/index.js`. xo registers `createNodeResolver()` first.
- import-x's `typeTest` classifies a resolved path inside the package but outside `node_modules` as `internal`. xo sets `groups: ['builtin','external','parent','sibling','index']` — `internal` is omitted, so it sorts **last**, behind third-party and even relative imports.
- CI's Lint job never builds (`yarn install --immutable` doesn't run the root `prepare`), so `dist/` is absent, resolution fails, and the same specifier falls back to `external` → no error. `import-x/no-unresolved` is disabled in xo, so nothing else flags it.

## Why it kept coming back

`yarn format:check` passes on the committed order, because `@ianvs/prettier-plugin-sort-imports` sorts `marking-menu` with third-party modules. So `eslint --fix` wrote an order that `prettier --write` immediately reverted — a deadlock, re-triggered every time `dist/` happened to be built.

## Change

One rule disable in `eslint.config.js`, in the block that already holds the `@stylistic/no-mixed-operators` prettier-conflict disable, with a comment explaining the mechanism.

Import ordering was already fully owned by `@ianvs/prettier-plugin-sort-imports` (`prettier.config.ts`) and gated in CI by `yarn format:check`, so no coverage is lost — two tools ordering imports under different group models was the conflict itself. No source imports touched, no CI change.

## Verification

- `yarn lint` → 0 errors both with `dist/` present and with it moved aside; identical output either way, so lint no longer depends on whether the library has been built.
- `yarn format:check` → clean.

No changeset: tooling-only, nothing changes for consumers of the published package.

Out of scope: the pre-existing `max-params` **warning** at `src/navigation/navigation.ts:151`. It reports the same on CI (`eslint .` exits 0 on warnings) and is unrelated to this divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)