### PR TITLE
Dwelling in startup opens the novice menu

### DIFF
--- a/src/engine/controller.test.ts
+++ b/src/engine/controller.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../__fixtures__/canvas.js';
 import type {
   MarkingMenuCancelEvent,
+  MarkingMenuOpenEvent,
   MarkingMenuSelectEvent,
   MarkingMenuStartEvent,
 } from '../events.js';
@@ -424,5 +425,195 @@ describe('createController', () => {
     expect(parent.querySelectorAll('canvas')).toHaveLength(0);
 
     controller.dispose();
+  });
+
+  it('opens novice mode at the gesture origin after the pointer dwells without moving', () => {
+    using _canvases = stubbedCanvasContexts();
+    using _timers = fakeTimers();
+    const parent = createParent();
+    const controller = createController({
+      items,
+      parent,
+      noviceDwellingTime: 100,
+    });
+
+    let openEvent: MarkingMenuOpenEvent<AnyModelNode> | undefined;
+    controller.on('open', (event) => {
+      openEvent = event;
+    });
+
+    parent.dispatchEvent(pointer('pointerdown', { clientX: 50, clientY: 60 }));
+    vi.advanceTimersByTime(100);
+
+    expect(openEvent?.mode).toBe('novice');
+    expect(openEvent?.menuCenter).toEqual([50, 60]);
+    expect(openEvent?.position).toEqual([50, 60]);
+    expect(parent.querySelector('.marking-menu')).not.toBeNull();
+
+    controller.dispose();
+  });
+
+  it('renders the menu at its center in local coordinates, converting from client coordinates itself', () => {
+    using _canvases = stubbedCanvasContexts();
+    using _timers = fakeTimers();
+    const parent = createParent();
+    parent.getBoundingClientRect = vi.fn(
+      () => ({ left: 10, top: 20 }) as unknown as DOMRect,
+    );
+    const controller = createController({
+      items,
+      parent,
+      noviceDwellingTime: 100,
+    });
+
+    parent.dispatchEvent(pointer('pointerdown', { clientX: 50, clientY: 60 }));
+    vi.advanceTimersByTime(100);
+
+    const menu = parent.querySelector<HTMLElement>('.marking-menu');
+    expect(menu?.style.getPropertyValue('--center-x')).toBe('40px');
+    expect(menu?.style.getPropertyValue('--center-y')).toBe('40px');
+
+    controller.dispose();
+  });
+
+  it('does not open novice mode when movement crosses movementsThreshold before the dwell time elapses', () => {
+    using _canvases = stubbedCanvasContexts();
+    using _timers = fakeTimers();
+    const parent = createParent();
+    const controller = createController({
+      items,
+      parent,
+      noviceDwellingTime: 100,
+    });
+
+    const opened = voidMock<[MarkingMenuOpenEvent<AnyModelNode>]>();
+    controller.on('open', opened);
+
+    parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
+    parent.dispatchEvent(pointer('pointermove', { clientX: 100, clientY: 0 }));
+    vi.advanceTimersByTime(200);
+
+    expect(opened).not.toHaveBeenCalled();
+    expect(parent.querySelector('.marking-menu')).toBeNull();
+
+    controller.dispose();
+  });
+
+  it('splits the stroke into an upper (current) and lower (accumulated) region once novice mode opens', () => {
+    using _canvases = stubbedCanvasContexts();
+    using _timers = fakeTimers();
+    const parent = createParent();
+    const controller = createController({
+      items,
+      parent,
+      noviceDwellingTime: 100,
+    });
+
+    parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
+    parent.dispatchEvent(pointer('pointermove', { clientX: 1, clientY: 0 }));
+    vi.advanceTimersByTime(100);
+    vi.advanceTimersToNextFrame();
+
+    // The upper stroke (fresh, starting at the menu center) and the lower
+    // stroke (the accumulated startup stroke) are drawn on two separate
+    // canvases.
+    expect(parent.querySelectorAll('canvas')).toHaveLength(2);
+
+    controller.dispose();
+  });
+
+  it('sets the cursor to none once novice mode opens', () => {
+    using _canvases = stubbedCanvasContexts();
+    using _timers = fakeTimers();
+    const parent = createParent();
+    const controller = createController({
+      items,
+      parent,
+      noviceDwellingTime: 100,
+    });
+
+    parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
+    expect(parent.style.cursor).toBe('crosshair');
+
+    vi.advanceTimersByTime(100);
+    expect(parent.style.cursor).toBe('none');
+
+    controller.dispose();
+  });
+
+  it('cancels, carrying the open menu and no active item, when the pointer releases right after novice mode opens', () => {
+    using _canvases = stubbedCanvasContexts();
+    using _timers = fakeTimers();
+    const parent = createParent();
+    const controller = createController({
+      items,
+      parent,
+      noviceDwellingTime: 100,
+    });
+
+    const selected = voidMock<[MarkingMenuSelectEvent<AnyModelNode>]>();
+    controller.on('select', selected);
+
+    let cancelEvent: MarkingMenuCancelEvent<AnyModelNode> | undefined;
+    controller.on('cancel', (event) => {
+      cancelEvent = event;
+    });
+
+    parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
+    vi.advanceTimersByTime(100);
+    parent.dispatchEvent(pointer('pointerup', { clientX: 0, clientY: 0 }));
+
+    expect(selected).not.toHaveBeenCalled();
+    expect(cancelEvent?.mode).toBe('novice');
+    expect(cancelEvent?.active).toBeNull();
+    expect(cancelEvent?.menu).not.toBeNull();
+    expect(parent.querySelector('.marking-menu')).toBeNull();
+
+    controller.dispose();
+  });
+
+  it('does not recreate the menu DOM or redraw the lower stroke when a render repeats with the same identity', () => {
+    using _canvases = stubbedCanvasContexts();
+    using _timers = fakeTimers();
+    const parent = createParent();
+    const controller = createController({
+      items,
+      parent,
+      noviceDwellingTime: 100,
+    });
+
+    parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
+    vi.advanceTimersByTime(100);
+
+    const menuBefore = parent.querySelector('.marking-menu');
+    expect(menuBefore).not.toBeNull();
+
+    // Still novice mode, no hit-testing yet: this is a no-op transition at
+    // the machine level, but still triggers a render pass.
+    parent.dispatchEvent(pointer('pointermove', { clientX: 1, clientY: 0 }));
+
+    expect(parent.querySelector('.marking-menu')).toBe(menuBefore);
+    expect(parent.querySelectorAll('.marking-menu')).toHaveLength(1);
+
+    controller.dispose();
+  });
+
+  it('removes the menu DOM on dispose while novice mode is open', () => {
+    using _canvases = stubbedCanvasContexts();
+    using _timers = fakeTimers();
+    const parent = createParent();
+    const controller = createController({
+      items,
+      parent,
+      noviceDwellingTime: 100,
+    });
+
+    parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
+    vi.advanceTimersByTime(100);
+    expect(parent.querySelector('.marking-menu')).not.toBeNull();
+
+    controller.dispose();
+
+    expect(parent.querySelector('.marking-menu')).toBeNull();
   });
 });

--- a/src/engine/controller.ts
+++ b/src/engine/controller.ts
@@ -16,6 +16,7 @@ import { createRuntime, type NavigationRuntime } from './runtime.js';
 export type EngineConfig = MarkingMenuInput & {
   readonly parent: HTMLElement;
   readonly movementsThreshold?: number;
+  readonly noviceDwellingTime?: number;
 };
 
 /*
@@ -61,10 +62,15 @@ class Controller<Config extends EngineConfig> implements MarkingMenuController<
     // inference would pick up the `Config & ValidateInput<Config>` parameter
     // type as `Input`, and `MarkingMenuModel` of that is a different type.
     const model = createModel<Config>(config);
-    const renderer = createRenderer({ parent: config.parent });
+    const renderer = createRenderer<MarkingMenuModel<Config>>({
+      parent: config.parent,
+    });
     this.#runtime = createRuntime<MarkingMenuModel<Config>>({
       model,
-      options: { movementsThreshold: config.movementsThreshold ?? 5 },
+      options: {
+        movementsThreshold: config.movementsThreshold ?? 5,
+        noviceDwellingTime: config.noviceDwellingTime ?? 1000 / 3,
+      },
       renderer,
     });
     this.#pointerSource = createPointerSource({

--- a/src/engine/layout-view.ts
+++ b/src/engine/layout-view.ts
@@ -1,31 +1,56 @@
+import type { AnyModelNode, ModelMenus } from '../types.js';
 import type { Point } from '../utils.js';
 import type { NavigationState } from './machine.js';
 
 /**
- The DOM-free, state-derived layout projection. `menu` and `lowerStroke` are
- always `null` until a ticket introduces the `novice` phase.
+ The DOM-free, state-derived layout projection. `activeKey` is always `null`
+ until a ticket implements novice hit-testing.
  */
-export type LayoutView = {
-  readonly cursor: 'default' | 'crosshair';
-  readonly menu: null;
+export type LayoutView<M extends AnyModelNode> = {
+  readonly cursor: 'default' | 'crosshair' | 'none';
+  readonly menu: null | {
+    readonly model: ModelMenus<M>;
+    readonly center: Point;
+    readonly activeKey: string | null;
+  };
   readonly upperStroke: readonly Point[] | null;
-  readonly lowerStroke: null;
+  readonly lowerStroke: readonly Point[] | null;
 };
 
-export function projectLayout(state: NavigationState): LayoutView {
-  if (state.phase === 'idle') {
-    return {
-      cursor: 'default',
-      menu: null,
-      upperStroke: null,
-      lowerStroke: null,
-    };
-  }
+export function projectLayout<M extends AnyModelNode>(
+  state: NavigationState<M>,
+): LayoutView<M> {
+  switch (state.phase) {
+    case 'idle': {
+      return {
+        cursor: 'default',
+        menu: null,
+        upperStroke: null,
+        lowerStroke: null,
+      };
+    }
 
-  return {
-    cursor: 'crosshair',
-    menu: null,
-    upperStroke: state.stroke,
-    lowerStroke: null,
-  };
+    case 'startup':
+    case 'expert': {
+      return {
+        cursor: 'crosshair',
+        menu: null,
+        upperStroke: state.stroke,
+        lowerStroke: null,
+      };
+    }
+
+    case 'novice': {
+      return {
+        cursor: 'none',
+        menu: {
+          model: state.menu,
+          center: state.menuCenter,
+          activeKey: null,
+        },
+        upperStroke: state.upperStroke,
+        lowerStroke: state.lowerStroke,
+      };
+    }
+  }
 }

--- a/src/engine/machine.test.ts
+++ b/src/engine/machine.test.ts
@@ -30,9 +30,12 @@ const model = createModel({
   ],
 });
 
-const options = { movementsThreshold: 5 };
+const options = { movementsThreshold: 5, noviceDwellingTime: 300 };
 const environment = { model };
-const idle: NavigationState = { phase: 'idle' };
+const idle: NavigationState<typeof model> = {
+  phase: 'idle',
+  nextTimerToken: 0,
+};
 
 /** Find the `dispatch` command among a transition's commands, if any. */
 const dispatched = (commands: ReturnType<typeof transition>['commands']) =>
@@ -57,7 +60,7 @@ describe('transition', () => {
       options,
     );
 
-    expect(up.state).toEqual({ phase: 'idle' });
+    expect(up.state).toEqual({ phase: 'idle', nextTimerToken: 1 });
     const command = dispatched(up.commands);
     expect(command?.type === 'dispatch' && command.event.type).toBe('select');
   });
@@ -138,7 +141,7 @@ describe('transition', () => {
       options,
     );
 
-    expect(up.state).toEqual({ phase: 'idle' });
+    expect(up.state).toEqual({ phase: 'idle', nextTimerToken: 1 });
     expect(mockRecognize).not.toHaveBeenCalled();
 
     const command = dispatched(up.commands);
@@ -173,7 +176,7 @@ describe('transition', () => {
       options,
     );
 
-    expect(up.state).toEqual({ phase: 'idle' });
+    expect(up.state).toEqual({ phase: 'idle', nextTimerToken: 1 });
     expect(mockRecognize).toHaveBeenCalledTimes(1);
 
     const command = dispatched(up.commands);
@@ -203,7 +206,7 @@ describe('transition', () => {
       options,
     );
 
-    expect(canceled.state).toEqual({ phase: 'idle' });
+    expect(canceled.state).toEqual({ phase: 'idle', nextTimerToken: 1 });
     expect(mockRecognize).not.toHaveBeenCalled();
 
     const command = dispatched(canceled.commands);
@@ -231,7 +234,7 @@ describe('transition', () => {
       options,
     );
 
-    expect(canceled.state).toEqual({ phase: 'idle' });
+    expect(canceled.state).toEqual({ phase: 'idle', nextTimerToken: 1 });
     expect(mockRecognize).not.toHaveBeenCalled();
     const command = dispatched(canceled.commands);
     expect(command?.type === 'dispatch' && command.event.type).toBe('cancel');
@@ -246,5 +249,189 @@ describe('transition', () => {
         options,
       ),
     ).toEqual({ state: idle, commands: [] });
+  });
+
+  it('dispatches start as the very first command a gesture ever produces', () => {
+    const down = transition(
+      idle,
+      { type: 'pointer.down', position: [0, 0] },
+      environment,
+      options,
+    );
+
+    expect(down.commands[0]).toMatchObject({
+      type: 'dispatch',
+      event: { type: 'start' },
+    });
+  });
+
+  describe('startup dwelling into novice mode (objective 12)', () => {
+    it('opens novice mode at the gesture origin when the mode-dwell timer elapses without significant movement', () => {
+      const down = transition(
+        idle,
+        { type: 'pointer.down', position: [0, 0] },
+        environment,
+        options,
+      );
+      expect(down.state.phase).toBe('startup');
+      // The armed timer's token, asserted once here so every later use of
+      // the literal `0` below is justified.
+      expect(down.state.phase === 'startup' && down.state.timer).toEqual({
+        kind: 'mode-dwell',
+        token: 0,
+      });
+
+      const move = transition(
+        down.state,
+        { type: 'pointer.move', position: [1, 0] },
+        environment,
+        options,
+      );
+
+      const elapsed = transition(
+        move.state,
+        { type: 'timer.elapsed', kind: 'mode-dwell', token: 0 },
+        environment,
+        options,
+      );
+
+      expect(elapsed.state).toEqual({
+        phase: 'novice',
+        menu: model,
+        menuCenter: [0, 0],
+        upperStroke: [[0, 0]],
+        lowerStroke: [
+          [0, 0],
+          [1, 0],
+        ],
+        nextTimerToken: 1,
+      });
+
+      const command = dispatched(elapsed.commands);
+      expect(command?.type === 'dispatch' && command.event.type).toBe('open');
+      const event =
+        command?.type === 'dispatch' && command.event.type === 'open'
+          ? command.event
+          : undefined;
+      expect(event?.mode).toBe('novice');
+      expect(event?.menu).toBe(model);
+      expect(event?.menuCenter).toEqual([0, 0]);
+      // The position is the last committed one, despite `timer.elapsed`
+      // itself carrying no position of its own.
+      expect(event?.position).toEqual([1, 0]);
+    });
+
+    it('crossing movementsThreshold cancels the mode-dwell timer and switches to expert instead, mutually exclusive with the dwell', () => {
+      const down = transition(
+        idle,
+        { type: 'pointer.down', position: [0, 0] },
+        environment,
+        options,
+      );
+      expect(down.state.phase === 'startup' && down.state.timer).toEqual({
+        kind: 'mode-dwell',
+        token: 0,
+      });
+
+      const move = transition(
+        down.state,
+        { type: 'pointer.move', position: [100, 0] },
+        environment,
+        options,
+      );
+
+      expect(move.state.phase).toBe('expert');
+      expect(move.commands).toEqual([
+        { type: 'timer.cancel', kind: 'mode-dwell', token: 0 },
+      ]);
+
+      // The now-cancelled timer firing anyway is a no-op: expert owns no
+      // timer, so the dwell can never open novice mode after the fact.
+      const elapsed = transition(
+        move.state,
+        { type: 'timer.elapsed', kind: 'mode-dwell', token: 0 },
+        environment,
+        options,
+      );
+      expect(elapsed).toEqual({ state: move.state, commands: [] });
+    });
+
+    it('treats a timer.elapsed carrying a superseded token as a no-op at the machine level (objective 10)', () => {
+      const startupState: NavigationState<typeof model> = {
+        phase: 'startup',
+        origin: [0, 0],
+        stroke: [[0, 0]],
+        timer: { kind: 'mode-dwell', token: 5 },
+        nextTimerToken: 6,
+      };
+
+      const result = transition(
+        startupState,
+        { type: 'timer.elapsed', kind: 'mode-dwell', token: 4 },
+        environment,
+        options,
+      );
+
+      expect(result).toEqual({ state: startupState, commands: [] });
+    });
+  });
+
+  describe('novice phase (minimal: hit-testing is not implemented yet)', () => {
+    const noviceState: NavigationState<typeof model> = {
+      phase: 'novice',
+      menu: model,
+      menuCenter: [0, 0],
+      upperStroke: [[0, 0]],
+      lowerStroke: [[0, 0]],
+      nextTimerToken: 1,
+    };
+
+    it('cancels on pointer up, carrying the currently open menu and no active item', () => {
+      const up = transition(
+        noviceState,
+        { type: 'pointer.up', position: [0, 0] },
+        environment,
+        options,
+      );
+
+      expect(up.state).toEqual({ phase: 'idle', nextTimerToken: 1 });
+      const command = dispatched(up.commands);
+      expect(command?.type === 'dispatch' && command.event.type).toBe('cancel');
+      const event =
+        command?.type === 'dispatch' && command.event.type === 'cancel'
+          ? command.event
+          : undefined;
+      expect(event?.active).toBeNull();
+      expect(event?.menu).toBe(model);
+      expect(event?.mode).toBe('novice');
+      expect(mockRecognize).not.toHaveBeenCalled();
+    });
+
+    it('cancels on pointer cancel the same way as pointer up', () => {
+      const canceled = transition(
+        noviceState,
+        { type: 'pointer.cancel', position: [0, 0] },
+        environment,
+        options,
+      );
+
+      const command = dispatched(canceled.commands);
+      expect(command?.type === 'dispatch' && command.event.type).toBe('cancel');
+    });
+
+    it('ignores pointer.down, pointer.move, and a stray timer.elapsed', () => {
+      const inputs = [
+        { type: 'pointer.down', position: [1, 1] },
+        { type: 'pointer.move', position: [1, 1] },
+        { type: 'timer.elapsed', kind: 'mode-dwell', token: 0 },
+      ] as const;
+
+      for (const input of inputs) {
+        expect(transition(noviceState, input, environment, options)).toEqual({
+          state: noviceState,
+          commands: [],
+        });
+      }
+    });
   });
 });

--- a/src/engine/machine.ts
+++ b/src/engine/machine.ts
@@ -13,14 +13,11 @@ import { dist, type Point } from '../utils.js';
 
 /*
  The pure navigation state machine: one entry point dispatching to a private
- handler per phase (idle/startup/expert/novice), per the architecture settled
- on https://github.com/QuentinRoy/Marking-Menu/issues/153.
+ handler per phase (idle/startup/expert/novice).
  */
 
 /**
  The only timer kind a phase can own yet: startup/expert dwelling into novice.
- `submenu-dwell` (novice dwelling into a sub-menu) has no ticket driving it
- into existence.
  */
 export type TimerKind = 'mode-dwell';
 
@@ -109,8 +106,7 @@ export type Transition<M extends AnyModelNode> = {
  `skipRecognition`) and return to idle, either selecting the recognized item
  or cancelling. Owns the one place `select`/`cancel`/`feedback.show` are
  built so every phase doesn't repeat this policy, and the one place a
- phase's owned timer is cancelled before rendering and dispatching, per
- https://github.com/QuentinRoy/Marking-Menu/issues/153's batch guarantee.
+ phase's owned timer is cancelled before rendering and dispatching.
 
  `skipRecognition` covers the paths that must never select regardless of what
  the stroke looks like: a pointer that was cancelled outright, a gesture that

--- a/src/engine/machine.ts
+++ b/src/engine/machine.ts
@@ -1,5 +1,6 @@
 import {
   MarkingMenuCancelEvent,
+  MarkingMenuOpenEvent,
   MarkingMenuSelectEvent,
   MarkingMenuStartEvent,
   type MarkingMenuEvent,
@@ -7,30 +8,68 @@ import {
 } from '../events.js';
 import { recognizeMarkingMenuStroke } from '../recognizer/recognize-mm-stroke.js';
 import { strokeLength } from '../recognizer/stroke-length.js';
-import type { AnyModelNode } from '../types.js';
+import type { AnyModelNode, ModelMenus } from '../types.js';
 import { dist, type Point } from '../utils.js';
 
 /*
  The pure navigation state machine: one entry point dispatching to a private
- handler per phase (idle/startup/expert), per the architecture settled on
- https://github.com/QuentinRoy/Marking-Menu/issues/153. `novice` is not a
- phase yet: no ticket has driven it into existence.
+ handler per phase (idle/startup/expert/novice), per the architecture settled
+ on https://github.com/QuentinRoy/Marking-Menu/issues/153.
  */
 
-export type NavigationState =
-  | { readonly phase: 'idle' }
+/**
+ The only timer kind a phase can own yet: startup/expert dwelling into novice.
+ `submenu-dwell` (novice dwelling into a sub-menu) has no ticket driving it
+ into existence.
+ */
+export type TimerKind = 'mode-dwell';
+
+/**
+ A timer's identity: monotonically increasing across the controller's
+ lifetime (including returns to idle), so a `timer.elapsed` input can never be
+ confused with a timer armed earlier for the same kind.
+ */
+export type TimerToken = number;
+
+/** What a phase holding an armed timer needs to remember about it. */
+export type TimerRef = {
+  readonly kind: TimerKind;
+  readonly token: TimerToken;
+};
+
+export type NavigationState<M extends AnyModelNode> =
+  | { readonly phase: 'idle'; readonly nextTimerToken: TimerToken }
   | {
       readonly phase: 'startup';
       readonly origin: Point;
       readonly stroke: readonly Point[];
+      readonly timer: TimerRef;
+      readonly nextTimerToken: TimerToken;
     }
-  | { readonly phase: 'expert'; readonly stroke: readonly Point[] };
+  | {
+      readonly phase: 'expert';
+      readonly stroke: readonly Point[];
+      readonly nextTimerToken: TimerToken;
+    }
+  | {
+      readonly phase: 'novice';
+      readonly menu: ModelMenus<M>;
+      readonly menuCenter: Point;
+      readonly upperStroke: readonly Point[];
+      readonly lowerStroke: readonly Point[];
+      readonly nextTimerToken: TimerToken;
+    };
 
 export type NavigationInput =
   | { readonly type: 'pointer.down'; readonly position: Point }
   | { readonly type: 'pointer.move'; readonly position: Point }
   | { readonly type: 'pointer.up'; readonly position: Point }
-  | { readonly type: 'pointer.cancel'; readonly position: Point };
+  | { readonly type: 'pointer.cancel'; readonly position: Point }
+  | {
+      readonly type: 'timer.elapsed';
+      readonly kind: TimerKind;
+      readonly token: TimerToken;
+    };
 
 export type NavigationEnvironment<M extends AnyModelNode> = {
   readonly model: M;
@@ -38,6 +77,7 @@ export type NavigationEnvironment<M extends AnyModelNode> = {
 
 export type NavigationOptions = {
   readonly movementsThreshold: number;
+  readonly noviceDwellingTime: number;
 };
 
 export type MachineCommand<M extends AnyModelNode> =
@@ -46,10 +86,21 @@ export type MachineCommand<M extends AnyModelNode> =
       readonly type: 'feedback.show';
       readonly stroke: readonly Point[];
       readonly canceled: boolean;
+    }
+  | {
+      readonly type: 'timer.schedule';
+      readonly kind: TimerKind;
+      readonly token: TimerToken;
+      readonly delay: number;
+    }
+  | {
+      readonly type: 'timer.cancel';
+      readonly kind: TimerKind;
+      readonly token: TimerToken;
     };
 
 export type Transition<M extends AnyModelNode> = {
-  readonly state: NavigationState;
+  readonly state: NavigationState<M>;
   readonly commands: ReadonlyArray<MachineCommand<M>>;
 };
 
@@ -57,34 +108,56 @@ export type Transition<M extends AnyModelNode> = {
  The shared terminal transition: recognize the gesture drawn so far (unless
  `skipRecognition`) and return to idle, either selecting the recognized item
  or cancelling. Owns the one place `select`/`cancel`/`feedback.show` are
- built so `startup` and `expert` don't each repeat this policy.
+ built so every phase doesn't repeat this policy, and the one place a
+ phase's owned timer is cancelled before rendering and dispatching, per
+ https://github.com/QuentinRoy/Marking-Menu/issues/153's batch guarantee.
 
- `skipRecognition` covers the two paths that must never select regardless of
- what the stroke looks like: a pointer that was cancelled outright, and a
- gesture that never moved at all (so there is nothing to recognize).
+ `skipRecognition` covers the paths that must never select regardless of what
+ the stroke looks like: a pointer that was cancelled outright, a gesture that
+ never moved at all (so there is nothing to recognize), and novice mode, whose
+ selection is proximity-based hit-testing rather than expert-style stroke
+ recognition (not implemented yet, so novice always cancels).
  */
 function finish<M extends AnyModelNode>(
   {
     mode,
     stroke,
     position,
+    menu = null,
     skipRecognition = false,
+    cancelTimer,
+    nextTimerToken,
   }: {
     mode: MarkingMenuMode;
     stroke: readonly Point[];
     position: Point;
+    menu?: ModelMenus<M> | null;
     skipRecognition?: boolean;
+    cancelTimer?: TimerRef;
+    nextTimerToken: TimerToken;
   },
   environment: NavigationEnvironment<M>,
 ): Transition<M> {
+  const timerCommands: Array<MachineCommand<M>> =
+    cancelTimer === undefined
+      ? []
+      : [
+          {
+            type: 'timer.cancel',
+            kind: cancelTimer.kind,
+            token: cancelTimer.token,
+          },
+        ];
+
   const selection = skipRecognition
     ? null
     : recognizeMarkingMenuStroke(stroke, environment.model);
 
   if (selection !== null) {
     return {
-      state: { phase: 'idle' },
+      state: { phase: 'idle', nextTimerToken },
       commands: [
+        ...timerCommands,
         { type: 'feedback.show', stroke, canceled: false },
         {
           type: 'dispatch',
@@ -92,7 +165,7 @@ function finish<M extends AnyModelNode>(
             mode,
             position,
             selection,
-            menu: null,
+            menu,
           }),
         },
       ],
@@ -100,8 +173,9 @@ function finish<M extends AnyModelNode>(
   }
 
   return {
-    state: { phase: 'idle' },
+    state: { phase: 'idle', nextTimerToken },
     commands: [
+      ...timerCommands,
       { type: 'feedback.show', stroke, canceled: true },
       {
         type: 'dispatch',
@@ -109,7 +183,7 @@ function finish<M extends AnyModelNode>(
           mode,
           position,
           active: null,
-          menu: null,
+          menu,
         }),
       },
     ],
@@ -117,7 +191,7 @@ function finish<M extends AnyModelNode>(
 }
 
 function transitionStartup<M extends AnyModelNode>(
-  state: Extract<NavigationState, { phase: 'startup' }>,
+  state: Extract<NavigationState<M>, { phase: 'startup' }>,
   input: NavigationInput,
   environment: NavigationEnvironment<M>,
   options: NavigationOptions,
@@ -126,7 +200,22 @@ function transitionStartup<M extends AnyModelNode>(
     case 'pointer.move': {
       const stroke = [...state.stroke, input.position];
       if (dist(state.origin, input.position) >= options.movementsThreshold) {
-        return { state: { phase: 'expert', stroke }, commands: [] };
+        // Significant movement wins the startup race outright: cancel the
+        // mode-dwell timer so it can never fire novice mode open afterwards.
+        return {
+          state: {
+            phase: 'expert',
+            stroke,
+            nextTimerToken: state.nextTimerToken,
+          },
+          commands: [
+            {
+              type: 'timer.cancel',
+              kind: state.timer.kind,
+              token: state.timer.token,
+            },
+          ],
+        };
       }
 
       return { state: { ...state, stroke }, commands: [] };
@@ -143,6 +232,8 @@ function transitionStartup<M extends AnyModelNode>(
           // any moves below the threshold, and this up) sits at the same
           // position, so there is nothing to recognize.
           skipRecognition: strokeLength(stroke) === 0,
+          cancelTimer: state.timer,
+          nextTimerToken: state.nextTimerToken,
         },
         environment,
       );
@@ -155,6 +246,8 @@ function transitionStartup<M extends AnyModelNode>(
           stroke: [...state.stroke, input.position],
           position: input.position,
           skipRecognition: true,
+          cancelTimer: state.timer,
+          nextTimerToken: state.nextTimerToken,
         },
         environment,
       );
@@ -163,18 +256,66 @@ function transitionStartup<M extends AnyModelNode>(
     case 'pointer.down': {
       return { state, commands: [] };
     }
+
+    case 'timer.elapsed': {
+      if (
+        input.kind !== state.timer.kind ||
+        input.token !== state.timer.token
+      ) {
+        // Superseded: this timer was already replaced or cancelled. A total
+        // function, not an exception, per objective 10.
+        return { state, commands: [] };
+      }
+
+      // The dwell wins the startup race: open novice mode at the root menu,
+      // centered on the gesture's origin. The pointer is still well within
+      // `movementsThreshold` of it, so nothing is active yet.
+      //
+      // The cast is safe: the root is always a menu, never a leaf. `M`'s
+      // `isLeaf` is an unresolved `boolean` here, so `ModelMenus<M>` cannot
+      // express that generically.
+      const menu = environment.model as unknown as ModelMenus<M>;
+      const menuCenter = state.origin;
+      // `timer.elapsed` carries no position of its own; the machine holds
+      // the last committed one instead. `state.stroke` always starts with
+      // the origin and is only ever appended to, so it is never empty; the
+      // cast avoids a disallowed non-null assertion for a case that cannot
+      // happen.
+      const position = state.stroke.at(-1) as Point;
+
+      return {
+        state: {
+          phase: 'novice',
+          menu,
+          menuCenter,
+          upperStroke: [menuCenter],
+          lowerStroke: state.stroke,
+          nextTimerToken: state.nextTimerToken,
+        },
+        commands: [
+          {
+            type: 'dispatch',
+            event: new MarkingMenuOpenEvent<M>({ position, menu, menuCenter }),
+          },
+        ],
+      };
+    }
   }
 }
 
 function transitionExpert<M extends AnyModelNode>(
-  state: Extract<NavigationState, { phase: 'expert' }>,
+  state: Extract<NavigationState<M>, { phase: 'expert' }>,
   input: NavigationInput,
   environment: NavigationEnvironment<M>,
 ): Transition<M> {
   switch (input.type) {
     case 'pointer.move': {
       return {
-        state: { phase: 'expert', stroke: [...state.stroke, input.position] },
+        state: {
+          phase: 'expert',
+          stroke: [...state.stroke, input.position],
+          nextTimerToken: state.nextTimerToken,
+        },
         commands: [],
       };
     }
@@ -185,6 +326,7 @@ function transitionExpert<M extends AnyModelNode>(
           mode: 'expert',
           stroke: [...state.stroke, input.position],
           position: input.position,
+          nextTimerToken: state.nextTimerToken,
         },
         environment,
       );
@@ -197,6 +339,7 @@ function transitionExpert<M extends AnyModelNode>(
           stroke: [...state.stroke, input.position],
           position: input.position,
           skipRecognition: true,
+          nextTimerToken: state.nextTimerToken,
         },
         environment,
       );
@@ -205,44 +348,100 @@ function transitionExpert<M extends AnyModelNode>(
     case 'pointer.down': {
       return { state, commands: [] };
     }
+
+    case 'timer.elapsed': {
+      // Expert owns no timer yet: any that arrives here is stale.
+      return { state, commands: [] };
+    }
+  }
+}
+
+function transitionNovice<M extends AnyModelNode>(
+  state: Extract<NavigationState<M>, { phase: 'novice' }>,
+  input: NavigationInput,
+  environment: NavigationEnvironment<M>,
+): Transition<M> {
+  switch (input.type) {
+    case 'pointer.down':
+    case 'timer.elapsed': {
+      // No sub-menu timer yet, and a second concurrent gesture is rejected
+      // upstream: both are no-ops here.
+      return { state, commands: [] };
+    }
+
+    case 'pointer.move': {
+      // Hit-testing the menu is not implemented yet: movement inside novice
+      // mode has no ticket driving it into existence.
+      return { state, commands: [] };
+    }
+
+    case 'pointer.up':
+    case 'pointer.cancel': {
+      return finish(
+        {
+          mode: 'novice',
+          stroke: [...state.lowerStroke, ...state.upperStroke, input.position],
+          position: input.position,
+          menu: state.menu,
+          // Novice selection is proximity-based hit-testing, not expert-style
+          // stroke recognition, and hit-testing isn't implemented yet: every
+          // release cancels for now.
+          skipRecognition: true,
+          nextTimerToken: state.nextTimerToken,
+        },
+        environment,
+      );
+    }
   }
 }
 
 function transitionIdle<M extends AnyModelNode>(
+  state: Extract<NavigationState<M>, { phase: 'idle' }>,
   input: NavigationInput,
+  options: NavigationOptions,
 ): Transition<M> {
   if (input.type === 'pointer.down') {
+    const token = state.nextTimerToken;
     return {
       state: {
         phase: 'startup',
         origin: input.position,
         stroke: [input.position],
+        timer: { kind: 'mode-dwell', token },
+        nextTimerToken: token + 1,
       },
       commands: [
         {
           type: 'dispatch',
           event: new MarkingMenuStartEvent({ position: input.position }),
         },
+        {
+          type: 'timer.schedule',
+          kind: 'mode-dwell',
+          token,
+          delay: options.noviceDwellingTime,
+        },
       ],
     };
   }
 
-  return { state: { phase: 'idle' }, commands: [] };
+  return { state, commands: [] };
 }
 
 /**
  The machine's single entry point: dispatches to one private handler per
- phase. Pure: no DOM, no timers.
+ phase. Pure: no DOM, no timers, no side effects — arming and cancelling a
+ timer is a command the runtime interprets, not something this function does.
  */
 export function transition<M extends AnyModelNode>(
-  state: NavigationState,
+  state: NavigationState<M>,
   input: NavigationInput,
   environment: NavigationEnvironment<M>,
   options: NavigationOptions,
 ): Transition<M> {
   switch (state.phase) {
     case 'idle': {
-      return transitionIdle(input);
+      return transitionIdle(state, input, options);
     }
 
     case 'startup': {
@@ -251,6 +450,10 @@ export function transition<M extends AnyModelNode>(
 
     case 'expert': {
       return transitionExpert(state, input, environment);
+    }
+
+    case 'novice': {
+      return transitionNovice(state, input, environment);
     }
   }
 }

--- a/src/engine/machine.ts
+++ b/src/engine/machine.ts
@@ -138,54 +138,23 @@ function finish<M extends AnyModelNode>(
   },
   environment: NavigationEnvironment<M>,
 ): Transition<M> {
-  const timerCommands: Array<MachineCommand<M>> =
-    cancelTimer === undefined
-      ? []
-      : [
-          {
-            type: 'timer.cancel',
-            kind: cancelTimer.kind,
-            token: cancelTimer.token,
-          },
-        ];
-
   const selection = skipRecognition
     ? null
     : recognizeMarkingMenuStroke(stroke, environment.model);
+  const event =
+    selection === null
+      ? new MarkingMenuCancelEvent<M>({ mode, position, active: null, menu })
+      : new MarkingMenuSelectEvent<M>({ mode, position, selection, menu });
 
-  if (selection !== null) {
-    return {
-      state: { phase: 'idle', nextTimerToken },
-      commands: [
-        ...timerCommands,
-        { type: 'feedback.show', stroke, canceled: false },
-        {
-          type: 'dispatch',
-          event: new MarkingMenuSelectEvent<M>({
-            mode,
-            position,
-            selection,
-            menu,
-          }),
-        },
-      ],
-    };
-  }
+  const timerCommands: Array<MachineCommand<M>> =
+    cancelTimer === undefined ? [] : [{ type: 'timer.cancel', ...cancelTimer }];
 
   return {
     state: { phase: 'idle', nextTimerToken },
     commands: [
       ...timerCommands,
-      { type: 'feedback.show', stroke, canceled: true },
-      {
-        type: 'dispatch',
-        event: new MarkingMenuCancelEvent<M>({
-          mode,
-          position,
-          active: null,
-          menu,
-        }),
-      },
+      { type: 'feedback.show', stroke, canceled: selection === null },
+      { type: 'dispatch', event },
     ],
   };
 }
@@ -208,13 +177,7 @@ function transitionStartup<M extends AnyModelNode>(
             stroke,
             nextTimerToken: state.nextTimerToken,
           },
-          commands: [
-            {
-              type: 'timer.cancel',
-              kind: state.timer.kind,
-              token: state.timer.token,
-            },
-          ],
+          commands: [{ type: 'timer.cancel', ...state.timer }],
         };
       }
 

--- a/src/engine/renderer.test.ts
+++ b/src/engine/renderer.test.ts
@@ -3,8 +3,16 @@ import {
   queryCanvasContext,
   stubbedCanvasContexts,
 } from '../__fixtures__/canvas.js';
+import { createModel } from '../model.js';
 import type { Point } from '../utils.js';
 import { createRenderer } from './renderer.js';
+
+const model = createModel({
+  items: [
+    { id: 'a', label: 'A' },
+    { id: 'b', label: 'B' },
+  ],
+});
 
 describe('createRenderer', () => {
   it('skips the redraw when the upper stroke is reference-equal to the previous frame', () => {
@@ -61,5 +69,47 @@ describe('createRenderer', () => {
     renderer.dispose();
 
     expect(cancelSpy).toHaveBeenCalledOnce();
+  });
+
+  it('updates the active item only when activeKey changes, skipping the redundant DOM scan otherwise', () => {
+    using _canvases = stubbedCanvasContexts();
+    const parent = document.createElement('div');
+    const renderer = createRenderer<typeof model>({ parent });
+    const activeCount = () =>
+      parent.querySelectorAll('.marking-menu-item.active').length;
+
+    renderer.render({
+      cursor: 'none',
+      menu: { model, center: [0, 0], activeKey: '0' },
+      upperStroke: null,
+      lowerStroke: null,
+    });
+    expect(activeCount()).toBe(1);
+    expect(parent.querySelector('[data-item-id="0"]')?.classList).toContain(
+      'active',
+    );
+
+    // Same activeKey, same menu identity: the skip branch.
+    renderer.render({
+      cursor: 'none',
+      menu: { model, center: [0, 0], activeKey: '0' },
+      upperStroke: null,
+      lowerStroke: null,
+    });
+    expect(activeCount()).toBe(1);
+
+    // A different activeKey: the changed branch moves the active item.
+    renderer.render({
+      cursor: 'none',
+      menu: { model, center: [0, 0], activeKey: '1' },
+      upperStroke: null,
+      lowerStroke: null,
+    });
+    expect(activeCount()).toBe(1);
+    expect(parent.querySelector('[data-item-id="1"]')?.classList).toContain(
+      'active',
+    );
+
+    renderer.dispose();
   });
 });

--- a/src/engine/renderer.ts
+++ b/src/engine/renderer.ts
@@ -1,6 +1,8 @@
 import { createGestureFeedback } from '../layout/gesture-feedback.js';
+import { createMenu, type Menu, type MenuLayoutModel } from '../layout/menu.js';
 import { rafThrottle } from '../layout/raf-throttle.js';
 import { createStrokeCanvas, type StrokeCanvas } from '../layout/stroke.js';
+import type { AnyModelNode, ModelMenus } from '../types.js';
 import type { Point } from '../utils.js';
 import type { LayoutView } from './layout-view.js';
 
@@ -9,20 +11,33 @@ export type FeedbackEffect = {
   readonly canceled: boolean;
 };
 
-export type LayoutRenderer = {
-  render: (view: LayoutView) => void;
+export type LayoutRenderer<M extends AnyModelNode> = {
+  render: (view: LayoutView<M>) => void;
   showFeedback: (effect: FeedbackEffect) => void;
   dispose: () => void;
 };
 
-export function createRenderer({
+/**
+ The menu DOM the renderer currently owns, keyed by the model reference it
+ was built from: reference equality on `model` is enough to decide
+ recreate-vs-patch, since the model tree is built once and frozen.
+ */
+type MenuHandle<M extends AnyModelNode> = {
+  model: ModelMenus<M>;
+  menu: Menu;
+};
+
+export function createRenderer<M extends AnyModelNode = AnyModelNode>({
   parent,
 }: {
   parent: HTMLElement;
-}): LayoutRenderer {
+}): LayoutRenderer<M> {
   let upperStrokeCanvas: StrokeCanvas | null = null;
-  // Reference-equality cache: an unchanged stroke array skips the redraw.
+  let lowerStrokeCanvas: StrokeCanvas | null = null;
+  // Reference-equality caches: an unchanged array skips the redraw.
   let previousUpperStroke: readonly Point[] | null = null;
+  let previousLowerStroke: readonly Point[] | null = null;
+  let menuHandle: MenuHandle<M> | null = null;
   // The parent's own inline cursor, read before the renderer writes one, and
   // restored rather than cleared whenever the view asks for `default`: what
   // the renderer did not set, it does not get to throw away.
@@ -34,24 +49,63 @@ export function createRenderer({
     upperStrokeCanvas?.drawStroke(stroke);
   });
 
+  const drawLowerStroke = rafThrottle((stroke: readonly Point[]) => {
+    lowerStrokeCanvas?.clear();
+    lowerStrokeCanvas?.drawStroke(stroke);
+  });
+
   return {
     render(view) {
       parent.style.cursor = view.cursor === 'default' ? ownCursor : view.cursor;
+
+      if (view.menu === null) {
+        menuHandle?.menu.remove();
+        menuHandle = null;
+      } else if (menuHandle?.model !== view.menu.model) {
+        menuHandle?.menu.remove();
+        // `LayoutView.menu.center` is in client coordinates; the menu layout
+        // wants it relative to `parent`. This is the one DOM-dependent
+        // conversion the projector deliberately leaves to the renderer.
+        const cbr = parent.getBoundingClientRect();
+        menuHandle = {
+          model: view.menu.model,
+          menu: createMenu({
+            parent,
+            // `ModelMenus<M>`'s `items` are generically erased to
+            // `AnyModelNode` inside this function body, the same reason
+            // `recognize-mm-stroke.ts`'s `walkModelLoose` needs a cast: the
+            // compiler cannot prove genericness away. Every real menu item
+            // built by `model.ts` carries `key`/`label`/`angle`.
+            model: view.menu.model as unknown as MenuLayoutModel,
+            center: [
+              view.menu.center[0] - cbr.left,
+              view.menu.center[1] - cbr.top,
+            ],
+          }),
+        };
+      }
+
+      menuHandle?.menu.setActive(view.menu?.activeKey ?? null);
 
       if (view.upperStroke === null) {
         upperStrokeCanvas?.remove();
         upperStrokeCanvas = null;
         previousUpperStroke = null;
-        return;
+      } else if (view.upperStroke !== previousUpperStroke) {
+        previousUpperStroke = view.upperStroke;
+        upperStrokeCanvas ??= createStrokeCanvas({ parent });
+        drawUpperStroke(view.upperStroke);
       }
 
-      if (view.upperStroke === previousUpperStroke) {
-        return;
+      if (view.lowerStroke === null) {
+        lowerStrokeCanvas?.remove();
+        lowerStrokeCanvas = null;
+        previousLowerStroke = null;
+      } else if (view.lowerStroke !== previousLowerStroke) {
+        previousLowerStroke = view.lowerStroke;
+        lowerStrokeCanvas ??= createStrokeCanvas({ parent });
+        drawLowerStroke(view.lowerStroke);
       }
-
-      previousUpperStroke = view.upperStroke;
-      upperStrokeCanvas ??= createStrokeCanvas({ parent });
-      drawUpperStroke(view.upperStroke);
     },
     showFeedback(effect) {
       gestureFeedback.show(effect.stroke, { canceled: effect.canceled });
@@ -59,8 +113,13 @@ export function createRenderer({
     dispose() {
       parent.style.cursor = ownCursor;
       drawUpperStroke.cancel();
+      drawLowerStroke.cancel();
       upperStrokeCanvas?.remove();
       upperStrokeCanvas = null;
+      lowerStrokeCanvas?.remove();
+      lowerStrokeCanvas = null;
+      menuHandle?.menu.remove();
+      menuHandle = null;
       gestureFeedback.remove();
     },
   };

--- a/src/engine/renderer.ts
+++ b/src/engine/renderer.ts
@@ -3,7 +3,7 @@ import { createMenu, type Menu, type MenuLayoutModel } from '../layout/menu.js';
 import { rafThrottle } from '../layout/raf-throttle.js';
 import { createStrokeCanvas, type StrokeCanvas } from '../layout/stroke.js';
 import type { AnyModelNode, ModelMenus } from '../types.js';
-import type { Point } from '../utils.js';
+import { toLocalPoint, type Point } from '../utils.js';
 import type { LayoutView } from './layout-view.js';
 
 export type FeedbackEffect = {
@@ -27,32 +27,59 @@ type MenuHandle<M extends AnyModelNode> = {
   menu: Menu;
 };
 
+/**
+ One stroke canvas (upper or lower), owning its own reference-equality cache
+ so an unchanged stroke array skips the redraw. `upperStroke` and
+ `lowerStroke` are two independent instances of the exact same behavior.
+ */
+function createStrokeLayer({ parent }: { parent: HTMLElement }): {
+  sync: (stroke: readonly Point[] | null) => void;
+  dispose: () => void;
+} {
+  let canvas: StrokeCanvas | null = null;
+  let previousStroke: readonly Point[] | null = null;
+
+  const draw = rafThrottle((stroke: readonly Point[]) => {
+    canvas?.clear();
+    canvas?.drawStroke(stroke);
+  });
+
+  return {
+    sync(stroke) {
+      if (stroke === null) {
+        canvas?.remove();
+        canvas = null;
+        previousStroke = null;
+      } else if (stroke !== previousStroke) {
+        previousStroke = stroke;
+        canvas ??= createStrokeCanvas({ parent });
+        draw(stroke);
+      }
+    },
+    dispose() {
+      draw.cancel();
+      canvas?.remove();
+      canvas = null;
+    },
+  };
+}
+
 export function createRenderer<M extends AnyModelNode = AnyModelNode>({
   parent,
 }: {
   parent: HTMLElement;
 }): LayoutRenderer<M> {
-  let upperStrokeCanvas: StrokeCanvas | null = null;
-  let lowerStrokeCanvas: StrokeCanvas | null = null;
-  // Reference-equality caches: an unchanged array skips the redraw.
-  let previousUpperStroke: readonly Point[] | null = null;
-  let previousLowerStroke: readonly Point[] | null = null;
   let menuHandle: MenuHandle<M> | null = null;
+  // Reference-equality cache: an unchanged active key skips the DOM scan
+  // `Menu.setActive` performs.
+  let previousActiveKey: string | null = null;
+  const upperStroke = createStrokeLayer({ parent });
+  const lowerStroke = createStrokeLayer({ parent });
   // The parent's own inline cursor, read before the renderer writes one, and
   // restored rather than cleared whenever the view asks for `default`: what
   // the renderer did not set, it does not get to throw away.
   const ownCursor = parent.style.cursor;
   const gestureFeedback = createGestureFeedback({ parent, duration: 1000 });
-
-  const drawUpperStroke = rafThrottle((stroke: readonly Point[]) => {
-    upperStrokeCanvas?.clear();
-    upperStrokeCanvas?.drawStroke(stroke);
-  });
-
-  const drawLowerStroke = rafThrottle((stroke: readonly Point[]) => {
-    lowerStrokeCanvas?.clear();
-    lowerStrokeCanvas?.drawStroke(stroke);
-  });
 
   return {
     render(view) {
@@ -61,63 +88,47 @@ export function createRenderer<M extends AnyModelNode = AnyModelNode>({
       if (view.menu === null) {
         menuHandle?.menu.remove();
         menuHandle = null;
-      } else if (menuHandle?.model !== view.menu.model) {
-        menuHandle?.menu.remove();
-        // `LayoutView.menu.center` is in client coordinates; the menu layout
-        // wants it relative to `parent`. This is the one DOM-dependent
-        // conversion the projector deliberately leaves to the renderer.
-        const cbr = parent.getBoundingClientRect();
-        menuHandle = {
-          model: view.menu.model,
-          menu: createMenu({
-            parent,
-            // `ModelMenus<M>`'s `items` are generically erased to
-            // `AnyModelNode` inside this function body, the same reason
-            // `recognize-mm-stroke.ts`'s `walkModelLoose` needs a cast: the
-            // compiler cannot prove genericness away. Every real menu item
-            // built by `model.ts` carries `key`/`label`/`angle`.
-            model: view.menu.model as unknown as MenuLayoutModel,
-            center: [
-              view.menu.center[0] - cbr.left,
-              view.menu.center[1] - cbr.top,
-            ],
-          }),
-        };
+        previousActiveKey = null;
+      } else {
+        if (menuHandle?.model !== view.menu.model) {
+          menuHandle?.menu.remove();
+          // `LayoutView.menu.center` is in client coordinates; the menu
+          // layout wants it relative to `parent`. This is the one
+          // DOM-dependent conversion the projector deliberately leaves to
+          // the renderer.
+          const cbr = parent.getBoundingClientRect();
+          menuHandle = {
+            model: view.menu.model,
+            menu: createMenu({
+              parent,
+              // `ModelMenus<M>`'s `items` are generically erased to
+              // `AnyModelNode` inside this function body, the same reason
+              // `recognize-mm-stroke.ts`'s `walkModelLoose` needs a cast:
+              // the compiler cannot prove genericness away. Every real menu
+              // item built by `model.ts` carries `key`/`label`/`angle`.
+              model: view.menu.model as unknown as MenuLayoutModel,
+              center: toLocalPoint(view.menu.center, cbr),
+            }),
+          };
+          previousActiveKey = null;
+        }
+
+        if (view.menu.activeKey !== previousActiveKey) {
+          previousActiveKey = view.menu.activeKey;
+          menuHandle.menu.setActive(view.menu.activeKey);
+        }
       }
 
-      menuHandle?.menu.setActive(view.menu?.activeKey ?? null);
-
-      if (view.upperStroke === null) {
-        upperStrokeCanvas?.remove();
-        upperStrokeCanvas = null;
-        previousUpperStroke = null;
-      } else if (view.upperStroke !== previousUpperStroke) {
-        previousUpperStroke = view.upperStroke;
-        upperStrokeCanvas ??= createStrokeCanvas({ parent });
-        drawUpperStroke(view.upperStroke);
-      }
-
-      if (view.lowerStroke === null) {
-        lowerStrokeCanvas?.remove();
-        lowerStrokeCanvas = null;
-        previousLowerStroke = null;
-      } else if (view.lowerStroke !== previousLowerStroke) {
-        previousLowerStroke = view.lowerStroke;
-        lowerStrokeCanvas ??= createStrokeCanvas({ parent });
-        drawLowerStroke(view.lowerStroke);
-      }
+      upperStroke.sync(view.upperStroke);
+      lowerStroke.sync(view.lowerStroke);
     },
     showFeedback(effect) {
       gestureFeedback.show(effect.stroke, { canceled: effect.canceled });
     },
     dispose() {
       parent.style.cursor = ownCursor;
-      drawUpperStroke.cancel();
-      drawLowerStroke.cancel();
-      upperStrokeCanvas?.remove();
-      upperStrokeCanvas = null;
-      lowerStrokeCanvas?.remove();
-      lowerStrokeCanvas = null;
+      upperStroke.dispose();
+      lowerStroke.dispose();
       menuHandle?.menu.remove();
       menuHandle = null;
       gestureFeedback.remove();

--- a/src/engine/runtime.test.ts
+++ b/src/engine/runtime.test.ts
@@ -2,7 +2,7 @@ import { createModel } from '../model.js';
 import { createRuntime } from './runtime.js';
 
 const model = createModel({ items: [{ id: 'right', label: 'Right' }] });
-const options = { movementsThreshold: 5 };
+const options = { movementsThreshold: 5, noviceDwellingTime: 300 };
 
 const createFakeRenderer = () => ({
   render: vi.fn(),

--- a/src/engine/runtime.ts
+++ b/src/engine/runtime.ts
@@ -11,6 +11,7 @@ import {
   type NavigationInput,
   type NavigationOptions,
   type NavigationState,
+  type TimerKind,
 } from './machine.js';
 import type { LayoutRenderer } from './renderer.js';
 
@@ -40,18 +41,43 @@ export function createRuntime<M extends AnyModelNode>({
 }: {
   model: M;
   options: NavigationOptions;
-  renderer: LayoutRenderer;
+  renderer: LayoutRenderer<M>;
 }): NavigationRuntime<M> {
   const emitter = mitt<MarkingMenuEventMap<M>>();
-  let state: NavigationState = { phase: 'idle' };
+  let state: NavigationState<M> = { phase: 'idle', nextTimerToken: 0 };
   let isDisposed = false;
   let isDraining = false;
   const pending: NavigationInput[] = [];
+  // The named timer registry: at most one live native handle per kind, since
+  // a kind's timer is always replaced or cancelled, never left to run
+  // alongside a newer one of the same kind.
+  const timers = new Map<TimerKind, ReturnType<typeof setTimeout>>();
 
-  // Two passes, not one: every visual effect lands before the first listener
-  // runs, so a listener always observes fully committed state. See
-  // `pointer-source.ts`'s `onPointerUp` for the same rule applied to capture.
+  // Three passes, not one: timers are armed/cancelled during commit (before
+  // layout is even projected), then every visual effect lands before the
+  // first listener runs, so a listener always observes fully committed
+  // state. See `pointer-source.ts`'s `onPointerUp` for the same rule applied
+  // to capture.
   const runCommands = (commands: ReadonlyArray<MachineCommand<M>>) => {
+    for (const command of commands) {
+      if (command.type === 'timer.schedule') {
+        const handle = setTimeout(() => {
+          timers.delete(command.kind);
+          send({
+            type: 'timer.elapsed',
+            kind: command.kind,
+            token: command.token,
+          });
+        }, command.delay);
+        timers.set(command.kind, handle);
+      } else if (command.type === 'timer.cancel') {
+        // `clearTimeout` is a no-op for `undefined` or an already-fired
+        // handle, so no guard is needed here.
+        clearTimeout(timers.get(command.kind));
+        timers.delete(command.kind);
+      }
+    }
+
     for (const command of commands) {
       if (command.type === 'feedback.show') {
         renderer.showFeedback({
@@ -109,6 +135,11 @@ export function createRuntime<M extends AnyModelNode>({
     }
 
     isDisposed = true;
+    for (const handle of timers.values()) {
+      clearTimeout(handle);
+    }
+
+    timers.clear();
     renderer.dispose();
   };
 

--- a/src/engine/runtime.ts
+++ b/src/engine/runtime.ts
@@ -53,14 +53,12 @@ export function createRuntime<M extends AnyModelNode>({
   // alongside a newer one of the same kind.
   const timers = new Map<TimerKind, ReturnType<typeof setTimeout>>();
 
-  // Three passes, not one: timers are armed/cancelled during commit (before
-  // layout is even projected), then every visual effect lands before the
-  // first listener runs, so a listener always observes fully committed
-  // state. See `pointer-source.ts`'s `onPointerUp` for the same rule applied
-  // to capture.
-  const runCommands = (commands: ReadonlyArray<MachineCommand<M>>) => {
-    for (const command of commands) {
-      if (command.type === 'timer.schedule') {
+  // Commit-time interpretation of one command: timers are armed/cancelled
+  // and feedback is shown before layout is even projected. `dispatch` is
+  // handled separately, only after rendering.
+  const commitCommand = (command: MachineCommand<M>): void => {
+    switch (command.type) {
+      case 'timer.schedule': {
         const handle = setTimeout(() => {
           timers.delete(command.kind);
           send({
@@ -70,21 +68,39 @@ export function createRuntime<M extends AnyModelNode>({
           });
         }, command.delay);
         timers.set(command.kind, handle);
-      } else if (command.type === 'timer.cancel') {
+        break;
+      }
+
+      case 'timer.cancel': {
         // `clearTimeout` is a no-op for `undefined` or an already-fired
         // handle, so no guard is needed here.
         clearTimeout(timers.get(command.kind));
         timers.delete(command.kind);
+        break;
       }
-    }
 
-    for (const command of commands) {
-      if (command.type === 'feedback.show') {
+      case 'feedback.show': {
         renderer.showFeedback({
           stroke: command.stroke,
           canceled: command.canceled,
         });
+        break;
       }
+
+      case 'dispatch': {
+        // Dispatched only after rendering, in a later pass.
+        break;
+      }
+    }
+  };
+
+  // Two passes, not one: every visual effect lands before the first
+  // listener runs, so a listener always observes fully committed state. See
+  // `pointer-source.ts`'s `onPointerUp` for the same rule applied to
+  // capture.
+  const runCommands = (commands: ReadonlyArray<MachineCommand<M>>) => {
+    for (const command of commands) {
+      commitCommand(command);
     }
 
     renderer.render(projectLayout(state));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -136,6 +136,22 @@ export const toPolar = (
   };
 };
 
+/**
+ Convert a point in client coordinates to coordinates relative to a bounding
+ rectangle's top-left corner (e.g. an element's own
+ `getBoundingClientRect()`).
+
+ @param point - A point in client coordinates.
+ @param rect - The rectangle to make the point relative to.
+ @param rect.left - The rectangle's left edge, in client coordinates.
+ @param rect.top - The rectangle's top edge, in client coordinates.
+ @returns The point, relative to `rect`'s top-left corner.
+ */
+export const toLocalPoint = (
+  point: Point,
+  rect: { left: number; top: number },
+): Point => [point[0] - rect.left, point[1] - rect.top];
+
 /** A function that does nothing. Useful as a default callback. */
 export const noOp = (): void => {
   // Intentionally empty.


### PR DESCRIPTION
Closes #179

## Summary

Adds the `novice` phase to the navigation state machine: dwelling without significant movement during startup now opens novice mode at the root menu, dispatching `open`. This is the other branch of the decision the tracer bullet (#177) already made — movement past `movementsThreshold` goes to expert, dwelling goes to novice, and the two stay mutually exclusive, with the first qualifying input winning.

This also introduces the runtime's first real timer: a named registry with monotonically increasing tokens, armed and cancelled strictly during commit (never during dispatch), so a superseded timer firing later is a no-op at the machine level.

## Key changes

- **`machine.ts`**: new `novice` phase, `timer.elapsed` input, and `timer.schedule`/`timer.cancel` commands. `transitionIdle` arms a `mode-dwell` timer on `pointer.down`; `transitionStartup` cancels it on significant movement (→ expert) or opens novice mode when it elapses. The shared `finish()` helper now also cancels a phase's owned timer and carries the currently-open menu, so novice's `pointer.up`/`pointer.cancel` (always `cancel` for now — hit-testing isn't implemented yet) reuse the same terminal-transition logic as `startup`/`expert`.
- **`runtime.ts`**: a named timer registry (`Map<TimerKind, handle>`) interprets `timer.schedule`/`timer.cancel` during commit, before layout is projected or anything is dispatched.
- **`layout-view.ts`**: `LayoutView` gains the `menu` region and a `cursor: 'none'` state, and the stroke splits into `upperStroke` (fresh, starting at the menu center) and `lowerStroke` (the accumulated startup stroke).
- **`renderer.ts`**: renders the menu DOM (recreated only when the menu's model reference changes) and a second stroke canvas for `lowerStroke`. The renderer performs the one DOM-dependent client-to-parent coordinate conversion the projector deliberately leaves to it.
- **`controller.ts`**: new `noviceDwellingTime` config option (default `1000 / 3`, matching the legacy engine).

## Scope

Novice hit-testing, submenu descent, and the `submenu-dwell` timer are out of scope — no ticket drives them into existence yet. Every release in novice mode cancels for now, since nothing can be active without hit-testing.

## Test plan

- [x] `yarn test` — 279 tests passing
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn format:check`
- [x] `yarn test:coverage` — all files touched by this change are at 100%; overall coverage is above the repo's thresholds (95%/90%/95%/95%)
- [x] No changeset (per the ticket's acceptance criteria — this doesn't touch the public API yet)

https://claude.ai/code/session_014FTh6HiCg6Sr9pa9eV5UAe

---
_Generated by [Claude Code](https://claude.ai/code/session_014FTh6HiCg6Sr9pa9eV5UAe)_