### PR TITLE
Merge navigation options into dependencies object

### DIFF
--- a/src/navigation/navigation.test.ts
+++ b/src/navigation/navigation.test.ts
@@ -367,6 +367,10 @@ describe('startup', () => {
 });
 
 describe('navigationFromDrag', () => {
+  // The dependency overrides are picked out of the same object as the
+  // navigation options, so the collaborators receive this rest object.
+  const navigationOptions = { custom: 'mock-options' };
+
   let mockConfirmedExpertNavigationHOO: Mock<
     (...args: unknown[]) => Observable<unknown>
   >;
@@ -388,12 +392,12 @@ describe('navigationFromDrag', () => {
         'mock-drag$' as unknown as Observable<NavigationDrag>,
         'mock-start' as unknown as NavigationDrag,
         'mock-model' as unknown as MarkingMenuModelItem,
-        'mock-options' as unknown as NavigationOptions,
         {
+          ...navigationOptions,
           confirmedExpertNavigationHOO: mockConfirmedExpertNavigationHOO,
           confirmedNoviceNavigationHOO: mockConfirmedNoviceNavigationHOO,
           startup: mockStartup,
-        } as unknown as Parameters<typeof navigationFromDrag>[4],
+        } as unknown as Parameters<typeof navigationFromDrag>[3],
       );
   });
 
@@ -401,10 +405,10 @@ describe('navigationFromDrag', () => {
     callNavigationFromDrag();
     expect(mockStartup.mock.calls).toEqual([['mock-drag$', 'mock-model']]);
     expect(mockConfirmedExpertNavigationHOO.mock.calls).toEqual([
-      ['mock-drag$', 'mock-model', 'mock-options'],
+      ['mock-drag$', 'mock-model', navigationOptions],
     ]);
     expect(mockConfirmedNoviceNavigationHOO.mock.calls).toEqual([
-      ['mock-drag$', 'mock-start', 'mock-model', 'mock-options'],
+      ['mock-drag$', 'mock-start', 'mock-model', navigationOptions],
     ]);
   });
 

--- a/src/navigation/navigation.ts
+++ b/src/navigation/navigation.ts
@@ -136,18 +136,18 @@ export const navigationFromDrag = <D extends NavigationDrag>(
   drag$: Observable<D>,
   start: D | null | undefined,
   model: MarkingMenuModelItem,
-  options: NavigationOptions,
   {
     confirmedExpertNavigationHOO:
       confirmedExpertNavigationHOO_ = confirmedExpertNavigationHOO,
     confirmedNoviceNavigationHOO:
       confirmedNoviceNavigationHOO_ = confirmedNoviceNavigationHOO,
     startup: startup_ = startup,
-  }: {
+    ...options
+  }: NavigationOptions & {
     confirmedExpertNavigationHOO?: typeof confirmedExpertNavigationHOO;
     confirmedNoviceNavigationHOO?: typeof confirmedNoviceNavigationHOO;
     startup?: typeof startup;
-  } = {},
+  },
 ) => {
   // Start up observable (while neither expert or novice are confirmed).
   const startUp$ = startup_(drag$, model);


### PR DESCRIPTION
## Summary
Refactored `navigationFromDrag` to merge `NavigationOptions` into the dependencies object parameter, eliminating a separate options parameter and simplifying the function signature.

## Key Changes
- **Function signature**: Removed the explicit `options: NavigationOptions` parameter from `navigationFromDrag`
- **Parameter consolidation**: Merged `NavigationOptions` into the dependencies object using rest parameter syntax (`...options`)
- **Type definition**: Updated the dependencies parameter type to `NavigationOptions & { ... }` to include both the options and dependency overrides
- **Test updates**: Updated test setup to reflect the new parameter structure, passing `navigationOptions` as part of the dependencies object instead of as a separate argument

## Implementation Details
- The `navigationOptions` are now extracted from the same object as the dependency overrides, reducing parameter count from 5 to 4
- The rest parameter (`...options`) captures all remaining properties from the dependencies object, which are then passed to downstream functions
- This change maintains backward compatibility in behavior while improving the API design by reducing parameter count and grouping related configuration together

https://claude.ai/code/session_019d9vd3KembSEercPV9E5Pb