### PR TITLE
Use official Playwright container image for E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,15 @@ jobs:
 
   E2E:
     needs: Build
-    # Playwright's browser dependencies need a full runner image, unlike the
-    # other jobs which only need Node and Yarn.
     runs-on: ubuntu-latest
+    # The official Playwright image ships the browsers and their system
+    # dependencies preinstalled, so the job never has to download them (that
+    # step used to hang for tens of minutes when the fetch stalled). Keep the
+    # tag's version in sync with the `@playwright/test` version in
+    # package.json: browsers are pinned per release, and a mismatch makes
+    # Playwright fail with "Executable doesn't exist".
+    container: mcr.microsoft.com/playwright:v1.62.0-noble
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/setup
@@ -70,7 +76,6 @@ jobs:
         with:
           name: dist
           path: dist/
-      - run: yarn playwright install --with-deps chromium firefox webkit
       # The fixture-only build, not `yarn e2e`: `dist/` was already built once
       # by the Build job above, so this avoids building the library again.
       - run: yarn e2e:build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,13 @@ jobs:
     runs-on: ubuntu-latest
     # The official Playwright image ships the browsers and their system
     # dependencies preinstalled, so the job never has to download them (that
-    # step used to hang for tens of minutes when the fetch stalled). Keep the
-    # tag's version in sync with the `@playwright/test` version in
-    # package.json: browsers are pinned per release, and a mismatch makes
-    # Playwright fail with "Executable doesn't exist".
+    # step used to hang for tens of minutes when the fetch stalled).
+    #
+    # This tag has to match the `@playwright/test` version: browsers are
+    # pinned per release, so a mismatch makes Playwright fail with "Executable
+    # doesn't exist". Renovate groups the two into one PR (see the `playwright`
+    # group in renovate.json), so bump them together if you touch either by
+    # hand.
     container: mcr.microsoft.com/playwright:v1.62.0-noble
     timeout-minutes: 20
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,4 +82,11 @@ jobs:
       # The fixture-only build, not `yarn e2e`: `dist/` was already built once
       # by the Build job above, so this avoids building the library again.
       - run: yarn e2e:build
+      # Inside the container the job runs as root, but the runner points $HOME
+      # at /github/home, which the image's `pwuser` owns. Firefox refuses to
+      # launch in that situation ("Running Nightly as root in a regular user's
+      # session is not supported"); the other browsers do not care. Overriding
+      # HOME here is the workaround Playwright's own error message prescribes.
       - run: yarn e2e:test
+        env:
+          HOME: /root

--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,11 @@
     {
       "matchPackageNames": ["/vitest/", "rxjs-marbles"],
       "groupName": "test"
+    },
+    {
+      "matchPackageNames": ["@playwright/test", "mcr.microsoft.com/playwright"],
+      "groupName": "playwright",
+      "rangeStrategy": "update-lockfile"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Switched the E2E test job to use the official Playwright Docker container image instead of manually installing browser dependencies on a standard Ubuntu runner. This eliminates the need for the `playwright install` step and prevents timeout issues during browser downloads.

## Key Changes
- Updated the E2E job to use the official Playwright container image (`mcr.microsoft.com/playwright:v1.62.0-noble`) which comes with browsers and system dependencies preinstalled
- Removed the `yarn playwright install --with-deps chromium firefox webkit` step since browsers are already available in the container
- Added a 20-minute timeout to the E2E job for safety
- Created a new Renovate configuration group for `@playwright/test` and the Playwright container image to ensure they stay in sync during updates (both are pinned per release and must match to avoid "Executable doesn't exist" errors)

## Implementation Details
- The container image tag must match the `@playwright/test` npm package version, as browsers are pinned per release
- Renovate is configured to group these two dependencies together so they're bumped in the same PR, preventing version mismatches
- This approach eliminates the previous issue where browser downloads could hang for tens of minutes when network fetches stalled

https://claude.ai/code/session_018JirK92s2Wbop1kLSEuoer