### PR TITLE
Implement novice-mode pointer hit-testing

### DIFF
--- a/src/engine/controller.test.ts
+++ b/src/engine/controller.test.ts
@@ -6,6 +6,8 @@ import {
 } from '../__fixtures__/canvas.js';
 import type {
   MarkingMenuCancelEvent,
+  MarkingMenuChangeEvent,
+  MarkingMenuMoveEvent,
   MarkingMenuOpenEvent,
   MarkingMenuSelectEvent,
   MarkingMenuStartEvent,
@@ -590,12 +592,173 @@ describe('createController', () => {
     const menuBefore = parent.querySelector('.marking-menu');
     expect(menuBefore).not.toBeNull();
 
-    // Still novice mode, no hit-testing yet: this is a no-op transition at
-    // the machine level, but still triggers a render pass.
+    // Still within `minSelectionDist`, so the active item stays null and the
+    // menu identity is unchanged: no DOM to patch, but a render pass still
+    // runs.
     parent.dispatchEvent(pointer('pointermove', { clientX: 1, clientY: 0 }));
 
     expect(parent.querySelector('.marking-menu')).toBe(menuBefore);
     expect(parent.querySelectorAll('.marking-menu')).toHaveLength(1);
+
+    controller.dispose();
+  });
+
+  it('activates no item while the pointer stays within minSelectionDist of the menu center', () => {
+    using _canvases = stubbedCanvasContexts();
+    using _timers = fakeTimers();
+    const parent = createParent();
+    const controller = createController({
+      items,
+      parent,
+      noviceDwellingTime: 100,
+      minSelectionDist: 40,
+    });
+
+    const moved = voidMock<[MarkingMenuMoveEvent<AnyModelNode>]>();
+    controller.on('move', moved);
+    const changed = voidMock<[MarkingMenuChangeEvent<AnyModelNode>]>();
+    controller.on('change', changed);
+
+    parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
+    vi.advanceTimersByTime(100);
+    parent.dispatchEvent(pointer('pointermove', { clientX: 10, clientY: 0 }));
+
+    expect(moved).toHaveBeenCalledTimes(1);
+    expect(moved.mock.calls[0]?.[0].active).toBeNull();
+    expect(changed).not.toHaveBeenCalled();
+    expect(parent.querySelectorAll('.marking-menu-item.active')).toHaveLength(
+      0,
+    );
+
+    controller.dispose();
+  });
+
+  it('activates the nearest item by angle once beyond minSelectionDist, patching the DOM without recreating the menu, and distinguishes continued pointing at the same item from moving to a new one', () => {
+    using _canvases = stubbedCanvasContexts();
+    using _timers = fakeTimers();
+    const parent = createParent();
+    const controller = createController({
+      items,
+      parent,
+      noviceDwellingTime: 100,
+      minSelectionDist: 40,
+    });
+
+    const moved = vi.fn<() => void>();
+    let lastMoveActiveId: string | undefined;
+    controller.on('move', (event) => {
+      moved();
+      lastMoveActiveId = event.active?.id;
+    });
+    const changed = vi.fn<() => void>();
+    let lastChangeActiveId: string | undefined;
+    let lastChangePreviousActive: unknown;
+    controller.on('change', (event) => {
+      changed();
+      lastChangeActiveId = event.active?.id;
+      lastChangePreviousActive = event.previousActive;
+    });
+
+    parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
+    vi.advanceTimersByTime(100);
+    const menuBefore = parent.querySelector('.marking-menu');
+
+    parent.dispatchEvent(pointer('pointermove', { clientX: 100, clientY: 0 }));
+
+    expect(moved).toHaveBeenCalledTimes(1);
+    expect(lastMoveActiveId).toBe('right');
+    expect(changed).toHaveBeenCalledTimes(1);
+    expect(lastChangeActiveId).toBe('right');
+    expect(lastChangePreviousActive).toBeNull();
+
+    // The menu DOM is patched in place, not recreated.
+    expect(parent.querySelector('.marking-menu')).toBe(menuBefore);
+    const activeItems = parent.querySelectorAll('.marking-menu-item.active');
+    expect(activeItems).toHaveLength(1);
+    // "right" is the first described item, so its library-assigned key is
+    // "0" — `dataset.itemId` is keyed on that, not on the caller's own `id`.
+    expect((activeItems[0] as HTMLElement).dataset.itemId).toBe('0');
+
+    // Continued pointing at the same item: another `move`, no further `change`.
+    parent.dispatchEvent(pointer('pointermove', { clientX: 110, clientY: 0 }));
+    expect(moved).toHaveBeenCalledTimes(2);
+    expect(changed).toHaveBeenCalledTimes(1);
+    expect(parent.querySelectorAll('.marking-menu-item.active')).toHaveLength(
+      1,
+    );
+
+    controller.dispose();
+  });
+
+  it('dispatches change carrying the new and previous active item, in one batch with move, when the nearest item changes', () => {
+    using _canvases = stubbedCanvasContexts();
+    using _timers = fakeTimers();
+    const parent = createParent();
+    const controller = createController({
+      items,
+      parent,
+      noviceDwellingTime: 100,
+      minSelectionDist: 40,
+    });
+
+    const seen: string[] = [];
+    controller.on('move', () => {
+      seen.push('move');
+    });
+    let lastChangeActiveId: string | undefined;
+    let lastChangePreviousActive: unknown;
+    controller.on('change', (event) => {
+      seen.push('change');
+      lastChangeActiveId = event.active?.id;
+      lastChangePreviousActive = event.previousActive;
+    });
+
+    parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
+    vi.advanceTimersByTime(100);
+    // First activates "right".
+    parent.dispatchEvent(pointer('pointermove', { clientX: 100, clientY: 0 }));
+    const previousActive = lastChangePreviousActive;
+    const firstActive = lastChangeActiveId;
+    expect(seen).toEqual(['move', 'change']);
+    expect(firstActive).toBe('right');
+    expect(previousActive).toBeNull();
+
+    // Moving to "down" produces a second, distinct change in the same batch
+    // as its move.
+    seen.length = 0;
+    parent.dispatchEvent(pointer('pointermove', { clientX: 0, clientY: 100 }));
+
+    expect(seen).toEqual(['move', 'change']);
+    expect(lastChangeActiveId).toBe('down');
+    expect(lastChangePreviousActive).not.toBeNull();
+
+    controller.dispose();
+  });
+
+  it('never fires change, and always reports a null active, for move events dispatched in startup and expert', () => {
+    using _canvases = stubbedCanvasContexts();
+    const parent = createParent();
+    const controller = createController({ items, parent });
+
+    const moved: Array<MarkingMenuMoveEvent<AnyModelNode>> = [];
+    controller.on('move', (event) => {
+      moved.push(event);
+    });
+    const changed = voidMock<[MarkingMenuChangeEvent<AnyModelNode>]>();
+    controller.on('change', changed);
+
+    parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
+    parent.dispatchEvent(pointer('pointermove', { clientX: 1, clientY: 0 }));
+    parent.dispatchEvent(pointer('pointermove', { clientX: 100, clientY: 0 }));
+
+    expect(moved).toHaveLength(2);
+    expect(moved[0]?.mode).toBe('startup');
+    expect(moved[0]?.active).toBeNull();
+    expect(moved[0]?.menu).toBeNull();
+    expect(moved[1]?.mode).toBe('expert');
+    expect(moved[1]?.active).toBeNull();
+    expect(moved[1]?.menu).toBeNull();
+    expect(changed).not.toHaveBeenCalled();
 
     controller.dispose();
   });

--- a/src/engine/controller.ts
+++ b/src/engine/controller.ts
@@ -17,6 +17,7 @@ export type EngineConfig = MarkingMenuInput & {
   readonly parent: HTMLElement;
   readonly movementsThreshold?: number;
   readonly noviceDwellingTime?: number;
+  readonly minSelectionDist?: number;
 };
 
 /*
@@ -74,6 +75,7 @@ class Controller<Config extends EngineConfig> implements MarkingMenuController<
       options: {
         movementsThreshold: config.movementsThreshold ?? 5,
         noviceDwellingTime: config.noviceDwellingTime ?? 1000 / 3,
+        minSelectionDist: config.minSelectionDist ?? 40,
       },
       renderer,
     });

--- a/src/engine/layout-view.ts
+++ b/src/engine/layout-view.ts
@@ -3,8 +3,7 @@ import type { Point } from '../utils.js';
 import type { NavigationState } from './machine.js';
 
 /**
- The DOM-free, state-derived layout projection. `activeKey` is always `null`
- until a ticket implements novice hit-testing.
+ The DOM-free, state-derived layout projection.
  */
 export type LayoutView<M extends AnyModelNode> = {
   readonly cursor: 'default' | 'crosshair' | 'none';
@@ -46,7 +45,12 @@ export function projectLayout<M extends AnyModelNode>(
         menu: {
           model: state.menu,
           center: state.menuCenter,
-          activeKey: null,
+          // `ModelItems<M>` is erased to a bare node at the machine's own
+          // boundary (see machine.ts's module comment); every real item
+          // built by `model.ts` carries `key`, the same reason `renderer.ts`
+          // casts `view.menu.model` to `MenuLayoutModel`.
+          activeKey:
+            (state.active as { readonly key: string } | null)?.key ?? null,
         },
         upperStroke: state.upperStroke,
         lowerStroke: state.lowerStroke,

--- a/src/engine/machine.test-d.ts
+++ b/src/engine/machine.test-d.ts
@@ -67,7 +67,11 @@ describe('StatesOf<typeof navigationMachine>', () => {
     const carryDeps = <M extends AnyModelNode>(model: M): States['idle'] => ({
       deps: {
         model,
-        options: { movementsThreshold: 5, noviceDwellingTime: 1 },
+        options: {
+          movementsThreshold: 5,
+          noviceDwellingTime: 1,
+          minSelectionDist: 40,
+        },
       },
     });
     expectTypeOf(carryDeps).toBeFunction();

--- a/src/engine/machine.test.ts
+++ b/src/engine/machine.test.ts
@@ -31,7 +31,11 @@ const model = createModel({
   ],
 });
 
-const options = { movementsThreshold: 5, noviceDwellingTime: 300 };
+const options = {
+  movementsThreshold: 5,
+  noviceDwellingTime: 300,
+  minSelectionDist: 40,
+};
 
 /**
 Start a fresh host with the shared fixture model and options.
@@ -259,11 +263,67 @@ describe('navigationMachine', () => {
     });
   });
 
-  describe('novice phase (minimal: hit-testing is not implemented yet)', () => {
+  describe('novice phase: pointing at items', () => {
     const openNovice = (host: ReturnType<typeof startHost>) => {
       host.send('down', { position: [0, 0] });
       host.send('dwell');
     };
+
+    it('stays inactive while the pointer is within minSelectionDist of the menu center (objective 5)', () => {
+      const host = startHost();
+      const moved = vi.fn<(event: { active: unknown }) => void>();
+      host.on('move', ({ data }) => {
+        moved(data);
+      });
+      const changed = vi.fn<() => void>();
+      host.on('change', changed);
+
+      openNovice(host);
+      host.send('move', { position: [10, 0] });
+
+      expect(host.current.name).toBe('novice');
+      expect(
+        host.current.name === 'novice' && host.current.data.active,
+      ).toBeNull();
+      expect(moved).toHaveBeenCalledTimes(1);
+      expect(moved.mock.calls[0]?.[0].active).toBeNull();
+      expect(changed).not.toHaveBeenCalled();
+    });
+
+    it('activates the nearest item by angle once beyond minSelectionDist, and distinguishes a changed nearest item from continued pointing at the same one (objective 6)', () => {
+      const host = startHost();
+      const moved: unknown[] = [];
+      host.on('move', ({ data }) => {
+        moved.push(data.active);
+      });
+      const changed =
+        vi.fn<(event: { active: unknown; previousActive: unknown }) => void>();
+      host.on('change', ({ data }) => {
+        changed(data);
+      });
+
+      openNovice(host);
+      host.send('move', { position: [100, 0] });
+
+      expect(host.current.name).toBe('novice');
+      const active =
+        host.current.name === 'novice' ? host.current.data.active : null;
+      expect(active).not.toBeNull();
+      expect((active as unknown as { id: string }).id).toBe('right');
+      expect(moved).toEqual([active]);
+      expect(changed).toHaveBeenCalledTimes(1);
+      const changeData = changed.mock.calls[0]?.[0] as {
+        active: unknown;
+        previousActive: unknown;
+      };
+      expect(changeData.active).toBe(active);
+      expect(changeData.previousActive).toBeNull();
+
+      // Continued pointing at the same item: another `move`, no further `change`.
+      host.send('move', { position: [110, 0] });
+      expect(moved).toEqual([active, active]);
+      expect(changed).toHaveBeenCalledTimes(1);
+    });
 
     it('cancels on pointer up, carrying the currently open menu and no active item', () => {
       const host = startHost();
@@ -297,15 +357,12 @@ describe('navigationMachine', () => {
       expect(canceled).toHaveBeenCalledTimes(1);
     });
 
-    it('ignores down, move, and a stray dwell', () => {
+    it('ignores down and a stray dwell', () => {
       const host = startHost();
       openNovice(host);
       const inNovice = host.current;
 
       host.send('down', { position: [1, 1] });
-      expect(host.current).toEqual(inNovice);
-
-      host.send('move', { position: [1, 1] });
       expect(host.current).toEqual(inNovice);
 
       host.send('dwell');

--- a/src/engine/machine.ts
+++ b/src/engine/machine.ts
@@ -1,17 +1,22 @@
 import { machine, type } from 'totorobot';
 import {
   MarkingMenuCancelEvent,
+  MarkingMenuChangeEvent,
+  MarkingMenuMoveEvent,
   MarkingMenuOpenEvent,
   MarkingMenuSelectEvent,
   MarkingMenuStartEvent,
-  type MarkingMenuChangeEvent,
   type MarkingMenuMode,
-  type MarkingMenuMoveEvent,
 } from '../events.js';
 import { recognizeMarkingMenuStroke } from '../recognizer/recognize-mm-stroke.js';
 import { strokeLength } from '../recognizer/stroke-length.js';
-import type { AnyModelNode, ModelLeaves, ModelMenus } from '../types.js';
-import { dist, type Point } from '../utils.js';
+import type {
+  AnyModelNode,
+  ModelItems,
+  ModelLeaves,
+  ModelMenus,
+} from '../types.js';
+import { dist, toPolar, type Point } from '../utils.js';
 import { projectLayout } from './layout-view.js';
 
 /*
@@ -32,6 +37,7 @@ import { projectLayout } from './layout-view.js';
 export type NavigationOptions = {
   readonly movementsThreshold: number;
   readonly noviceDwellingTime: number;
+  readonly minSelectionDist: number;
 };
 
 type Deps = {
@@ -67,6 +73,7 @@ export type NavigationState<M extends AnyModelNode> =
       readonly phase: 'novice';
       readonly menu: ModelMenus<M>;
       readonly menuCenter: Point;
+      readonly active: ModelItems<M> | null;
       readonly upperStroke: readonly Point[];
       readonly lowerStroke: readonly Point[];
     };
@@ -92,6 +99,7 @@ type NavigationStates = {
     readonly deps: Deps;
     readonly menu: AnyModelNode;
     readonly menuCenter: Point;
+    readonly active: AnyModelNode | null;
     readonly upperStroke: readonly Point[];
     readonly lowerStroke: readonly Point[];
   };
@@ -162,6 +170,50 @@ function openEvent<N extends AnyModelNode>(data: {
       position: Point;
       menu: ModelMenus<N>;
       menuCenter: Point;
+    },
+  );
+}
+
+function moveEvent<N extends AnyModelNode>(data: {
+  readonly mode: MarkingMenuMode;
+  readonly position: Point;
+  readonly active: N | null;
+  readonly menu: N | null;
+}): MarkingMenuMoveEvent<N> {
+  return new MarkingMenuMoveEvent<N>(
+    data as unknown as {
+      mode: MarkingMenuMode;
+      position: Point;
+      active: ModelItems<N> | null;
+      menu: ModelMenus<N> | null;
+    },
+  );
+}
+
+/**
+ Shared body of the three startup/expert move actions: no menu is open in
+ either state, so `move` always carries a null `active` and `menu` there.
+ */
+function emitNullActiveMove(
+  emit: (name: 'move', data: MarkingMenuMoveEvent<AnyModelNode>) => void,
+  mode: 'startup' | 'expert',
+  position: Point,
+): void {
+  emit('move', moveEvent({ mode, position, active: null, menu: null }));
+}
+
+function changeEvent<N extends AnyModelNode>(data: {
+  readonly position: Point;
+  readonly active: N | null;
+  readonly previousActive: N | null;
+  readonly menu: N;
+}): MarkingMenuChangeEvent<N> {
+  return new MarkingMenuChangeEvent<N>(
+    data as unknown as {
+      position: Point;
+      active: ModelItems<N> | null;
+      previousActive: ModelItems<N> | null;
+      menu: ModelMenus<N>;
     },
   );
 }
@@ -247,6 +299,7 @@ export const navigationMachine = machine({
       deps: fromData.deps,
       menu: fromData.deps.model,
       menuCenter: fromData.origin,
+      active: null,
       upperStroke: [fromData.origin],
       lowerStroke: fromData.stroke,
     }),
@@ -255,6 +308,22 @@ export const navigationMachine = machine({
       ...fromData,
       stroke: [...fromData.stroke, inputData.position],
     }),
+
+    'novice -move> novice'({ fromData, inputData }) {
+      const { azymuth, radius } = toPolar(
+        inputData.position,
+        fromData.menuCenter,
+      );
+      const active =
+        radius < fromData.deps.options.minSelectionDist
+          ? null
+          : fromData.menu.getNearestChild(azymuth);
+      return {
+        ...fromData,
+        active,
+        upperStroke: [...fromData.upperStroke, inputData.position],
+      };
+    },
 
     // Idle has no gesture to end, so both decline there; every other state
     // (startup, expert, novice) resets to idle's own shape.
@@ -292,6 +361,16 @@ export const navigationMachine = machine({
       emit('start', new MarkingMenuStartEvent({ position: toData.origin }));
     },
 
+    // No menu is open in startup or expert, so nothing can be active: `move`
+    // always carries `active: null` and `menu: null` here, and `change` never
+    // fires outside novice.
+    'startup -move> expert'({ inputData, emit }) {
+      emitNullActiveMove(emit, 'expert', inputData.position);
+    },
+    'startup -move> startup'({ inputData, emit }) {
+      emitNullActiveMove(emit, 'startup', inputData.position);
+    },
+
     'startup -dwell> novice'({ fromData, toData, emit }) {
       emit(
         'open',
@@ -304,6 +383,36 @@ export const navigationMachine = machine({
           menuCenter: toData.menuCenter,
         }),
       );
+    },
+
+    'expert -move> expert'({ inputData, emit }) {
+      emitNullActiveMove(emit, 'expert', inputData.position);
+    },
+
+    // `move` always fires; `change` only when the nearest item differs from
+    // the one the previous commit landed on.
+    'novice -move> novice'({ fromData, toData, inputData, emit }) {
+      emit(
+        'move',
+        moveEvent({
+          mode: 'novice',
+          position: inputData.position,
+          active: toData.active,
+          menu: toData.menu,
+        }),
+      );
+
+      if (toData.active !== fromData.active) {
+        emit(
+          'change',
+          changeEvent({
+            position: inputData.position,
+            active: toData.active,
+            previousActive: fromData.active,
+            menu: toData.menu,
+          }),
+        );
+      }
     },
 
     // The shared termination policy: recognize the gesture drawn so far
@@ -323,9 +432,10 @@ export const navigationMachine = machine({
       const { stroke, menu } = terminationContext(fromData, position);
       // Startup: the pointer never moved at all when the stroke has zero
       // length, so there is nothing to recognize. Novice selection is
-      // proximity-based hit-testing, not expert-style stroke recognition,
-      // and hit-testing isn't implemented yet: every release cancels for
-      // now. Expert always attempts recognition.
+      // proximity-based hit-testing against the active item, not
+      // expert-style stroke recognition, and that wiring belongs to a later
+      // ticket: every release cancels for now, regardless of `active`.
+      // Expert always attempts recognition.
       const isSkipRecognition =
         from === 'startup' ? strokeLength(stroke) === 0 : from === 'novice';
 

--- a/src/engine/runtime.test.ts
+++ b/src/engine/runtime.test.ts
@@ -3,7 +3,11 @@ import { createModel } from '../model.js';
 import { createRuntime } from './runtime.js';
 
 const model = createModel({ items: [{ id: 'right', label: 'Right' }] });
-const options = { movementsThreshold: 5, noviceDwellingTime: 300 };
+const options = {
+  movementsThreshold: 5,
+  noviceDwellingTime: 300,
+  minSelectionDist: 40,
+};
 
 const createFakeRenderer = () => ({
   render: vi.fn(),


### PR DESCRIPTION
Once novice mode opens a menu, the navigation engine has no way to know which item the pointer is pointing at. It can draw the stroke, but it can't highlight an item or tell a consumer what's under the pointer, because nothing in the state machine tracks it (#180).

This adds that tracking. On each move in novice mode, the pointer's position is converted to an angle around the menu's center and matched to the nearest item via the model's own `getNearestChild` lookup. Within `minSelectionDist` of the center, nothing is active; beyond it, the nearest item is. Every qualifying move emits a `move` event, and when the active item changes, a `change` event follows it in the same batch, so a consumer never has to diff two `move` events itself. Startup and expert mode, where no menu is open, now emit `move` too, with a `null` active item, so the event fires everywhere a pointer can move.

The renderer already knew how to patch a single active item into the menu's DOM without rebuilding it; it just never received a real value to patch with. This is what feeds it one, so the highlight now updates in place as the pointer crosses between items.

To verify, run `yarn test`. The behavior is covered at two levels: state-machine tests exercise the hit-testing and event sequencing directly, and controller tests drive real pointer events through a document and check the resulting DOM, including that the menu element is reused rather than recreated when only the active item changes.

Selecting an item on release, and opening submenus by dwelling on a branch, are separate and remain open.
