### PR TITLE
Flatten and rename deps on the navigation machine

### DIFF
--- a/src/engine/machine.test-d.ts
+++ b/src/engine/machine.test-d.ts
@@ -31,21 +31,28 @@ describe('StatesOf<typeof navigationMachine>', () => {
     >();
   });
 
-  it('threads deps through every phase', () => {
+  it('threads model and options through every phase', () => {
     expectTypeOf<States['idle']>().toEqualTypeOf<{
-      readonly deps: {
-        readonly model: AnyModelNode;
-        readonly options: NavigationOptions;
-      };
+      readonly model: AnyModelNode;
+      readonly options: NavigationOptions;
     }>();
-    expectTypeOf<States['startup']['deps']>().toEqualTypeOf<
-      States['idle']['deps']
+    expectTypeOf<States['startup']['model']>().toEqualTypeOf<
+      States['idle']['model']
     >();
-    expectTypeOf<States['expert']['deps']>().toEqualTypeOf<
-      States['idle']['deps']
+    expectTypeOf<States['startup']['options']>().toEqualTypeOf<
+      States['idle']['options']
     >();
-    expectTypeOf<States['novice']['deps']>().toEqualTypeOf<
-      States['idle']['deps']
+    expectTypeOf<States['expert']['model']>().toEqualTypeOf<
+      States['idle']['model']
+    >();
+    expectTypeOf<States['expert']['options']>().toEqualTypeOf<
+      States['idle']['options']
+    >();
+    expectTypeOf<States['novice']['model']>().toEqualTypeOf<
+      States['idle']['model']
+    >();
+    expectTypeOf<States['novice']['options']>().toEqualTypeOf<
+      States['idle']['options']
     >();
   });
 
@@ -59,22 +66,21 @@ describe('StatesOf<typeof navigationMachine>', () => {
     expectTypeOf<States['novice']['menu']>().toEqualTypeOf<AnyModelNode>();
   });
 
-  it("is generic-safe: a caller's own model still threads through `deps.model`", () => {
+  it("is generic-safe: a caller's own model still threads through `model`", () => {
     // The exact pattern `runtime.ts` relies on: a real `M` is narrower than
-    // `AnyModelNode`, so it is always assignable into the erased `deps.model`
-    // this file declares, for any `M` a caller instantiates `createRuntime`
-    // with — never just the fixture model this suite happens to use.
-    const carryDeps = <M extends AnyModelNode>(model: M): States['idle'] => ({
-      deps: {
-        model,
-        options: {
-          movementsThreshold: 5,
-          noviceDwellingTime: 1,
-          minSelectionDist: 40,
-        },
+    // `AnyModelNode`, so it is always assignable into the erased `model`
+    // field this file declares, for any `M` a caller instantiates
+    // `createRuntime` with — never just the fixture model this suite happens
+    // to use.
+    const carryModel = <M extends AnyModelNode>(model: M): States['idle'] => ({
+      model,
+      options: {
+        movementsThreshold: 5,
+        noviceDwellingTime: 1,
+        minSelectionDist: 40,
       },
     });
-    expectTypeOf(carryDeps).toBeFunction();
+    expectTypeOf(carryModel).toBeFunction();
   });
 });
 

--- a/src/engine/machine.test.ts
+++ b/src/engine/machine.test.ts
@@ -40,7 +40,7 @@ const options = {
 /**
 Start a fresh host with the shared fixture model and options.
 */
-const startHost = () => navigationMachine.start({ deps: { model, options } });
+const startHost = () => navigationMachine.start({ model, options });
 
 /**
 Record every public output a host emits, in order, by name.

--- a/src/engine/machine.ts
+++ b/src/engine/machine.ts
@@ -40,11 +40,6 @@ export type NavigationOptions = {
   readonly minSelectionDist: number;
 };
 
-type Deps = {
-  readonly model: AnyModelNode;
-  readonly options: NavigationOptions;
-};
-
 /**
  The boundary input shape `pointer-source.ts` sends: unrelated to the
  machine's own (shorter) input vocabulary, so that layer never has to know
@@ -88,15 +83,21 @@ type NavigationInputs = {
 };
 
 type NavigationStates = {
-  idle: { readonly deps: Deps };
+  idle: { readonly model: AnyModelNode; readonly options: NavigationOptions };
   startup: {
-    readonly deps: Deps;
+    readonly model: AnyModelNode;
+    readonly options: NavigationOptions;
     readonly origin: Point;
     readonly stroke: readonly Point[];
   };
-  expert: { readonly deps: Deps; readonly stroke: readonly Point[] };
+  expert: {
+    readonly model: AnyModelNode;
+    readonly options: NavigationOptions;
+    readonly stroke: readonly Point[];
+  };
   novice: {
-    readonly deps: Deps;
+    readonly model: AnyModelNode;
+    readonly options: NavigationOptions;
     readonly menu: AnyModelNode;
     readonly menuCenter: Point;
     readonly active: AnyModelNode | null;
@@ -142,7 +143,7 @@ type NavigationOutputs = {
  Reassemble the boundary `NavigationState` from a committed `{ to, toData }`
  pair, for `projectLayout`. The cast is the same erasure-crossing every
  model-shaped field in this file needs: `toData`'s real shape already matches
- one of `NavigationState`'s variants field-for-field, `deps` aside.
+ one of `NavigationState`'s variants field-for-field, `model`/`options` aside.
  */
 function toNavigationState(
   to: keyof NavigationStates,
@@ -275,33 +276,45 @@ export const navigationMachine = machine({
   initial: 'idle',
 
   transitions: {
-    'idle -down> startup': ({ fromData, inputData }) => ({
-      deps: fromData.deps,
-      origin: inputData.position,
-      stroke: [inputData.position],
+    'idle -down> startup': ({
+      fromData: { model, options },
+      inputData: { position },
+    }) => ({
+      model,
+      options,
+      origin: position,
+      stroke: [position],
     }),
 
-    'startup -move> expert'({ fromData, inputData, skip }) {
-      const stroke = [...fromData.stroke, inputData.position];
-      return dist(fromData.origin, inputData.position) >=
-        fromData.deps.options.movementsThreshold
-        ? { deps: fromData.deps, stroke }
+    'startup -move> expert'({
+      fromData: { model, options, origin, stroke },
+      inputData: { position },
+      skip,
+    }) {
+      const newStroke = [...stroke, position];
+      return dist(origin, position) >= options.movementsThreshold
+        ? { model, options, stroke: newStroke }
         : skip();
     },
+
     'startup -move> startup': ({ fromData, inputData }) => ({
       ...fromData,
       stroke: [...fromData.stroke, inputData.position],
     }),
+
     // The dwell wins the startup race: open novice mode at the root menu,
     // centered on the gesture's origin. The pointer is still well within
     // `movementsThreshold` of it, so nothing is active yet.
-    'startup -dwell> novice': ({ fromData }) => ({
-      deps: fromData.deps,
-      menu: fromData.deps.model,
-      menuCenter: fromData.origin,
+    'startup -dwell> novice': ({
+      fromData: { model, options, origin, stroke },
+    }) => ({
+      model,
+      options,
+      menu: model,
+      menuCenter: origin,
       active: null,
-      upperStroke: [fromData.origin],
-      lowerStroke: fromData.stroke,
+      upperStroke: [origin],
+      lowerStroke: stroke,
     }),
 
     'expert -move> expert': ({ fromData, inputData }) => ({
@@ -309,31 +322,32 @@ export const navigationMachine = machine({
       stroke: [...fromData.stroke, inputData.position],
     }),
 
-    'novice -move> novice'({ fromData, inputData }) {
-      const { azymuth, radius } = toPolar(
-        inputData.position,
-        fromData.menuCenter,
-      );
+    'novice -move> novice'({ fromData, inputData: { position } }) {
+      const { menuCenter, options, menu } = fromData;
+      const { azymuth, radius } = toPolar(position, menuCenter);
       const active =
-        radius < fromData.deps.options.minSelectionDist
+        radius < options.minSelectionDist
           ? null
-          : fromData.menu.getNearestChild(azymuth);
+          : menu.getNearestChild(azymuth);
       return {
         ...fromData,
         active,
-        upperStroke: [...fromData.upperStroke, inputData.position],
+        upperStroke: [...fromData.upperStroke, position],
       };
     },
 
     // Idle has no gesture to end, so both decline there; every other state
     // (startup, expert, novice) resets to idle's own shape.
-    '* -up> idle': ({ from, fromData, skip }) =>
-      from === 'idle' ? skip() : { deps: fromData.deps },
-    '* -cancel> idle': ({ from, fromData, skip }) =>
-      from === 'idle' ? skip() : { deps: fromData.deps },
+    '* -up> idle': ({ from, fromData: { model, options }, skip }) =>
+      from === 'idle' ? skip() : { model, options },
+    '* -cancel> idle': ({ from, fromData: { model, options }, skip }) =>
+      from === 'idle' ? skip() : { model, options },
     // Dispose resets to idle's shape from anywhere, idle included: every
-    // state already carries `deps`, so one row covers all four.
-    '* -dispose> idle': ({ fromData }) => ({ deps: fromData.deps }),
+    // state already carries `model`/`options`, so one row covers all four.
+    '* -dispose> idle': ({ fromData: { model, options } }) => ({
+      model,
+      options,
+    }),
   },
 
   actions: {
@@ -347,7 +361,7 @@ export const navigationMachine = machine({
       run({ toData, send }) {
         const timer = setTimeout(() => {
           send('dwell');
-        }, toData.deps.options.noviceDwellingTime);
+        }, toData.options.noviceDwellingTime);
         return () => {
           clearTimeout(timer);
         };
@@ -441,7 +455,7 @@ export const navigationMachine = machine({
 
       const selection = isSkipRecognition
         ? null
-        : recognizeMarkingMenuStroke(stroke, fromData.deps.model);
+        : recognizeMarkingMenuStroke(stroke, fromData.model);
       emit('feedback', { stroke, canceled: selection === null });
 
       if (selection === null) {

--- a/src/engine/runtime.ts
+++ b/src/engine/runtime.ts
@@ -62,7 +62,7 @@ export function createRuntime<M extends AnyModelNode>({
     Array<{ listener: (event: never) => void; wrapper: EventListener }>
   >();
 
-  const host = navigationMachine.start({ deps: { model, options } });
+  const host = navigationMachine.start({ model, options });
 
   const offLayout = host.on('layout', ({ data }) => {
     renderer.render(data as unknown as LayoutView<M>);


### PR DESCRIPTION
The navigation state machine in `machine.ts` carried its shared dependencies, a model and a set of options, under a state field named `deps`. The name gave no hint of what it held, and nesting it added a level of indirection every read site had to reach through, without buying anything: most transitions that carry the field forward already spread the rest of the state (`...fromData`), so the nesting only mattered for the handful of transitions that build a fresh object.

`model` and `options` now live directly on each state's data instead of behind `deps`. Transitions and actions read `fromData.model` and `fromData.options` (or destructure them) instead of `fromData.deps.model` and `fromData.deps.options`, and starting the machine takes `{ model, options }` instead of `{ deps: { model, options } }`.

Run `yarn typecheck`, `yarn lint`, and `yarn test` to verify; all three pass with no changes to behavior.