### PR TITLE
Reintroduce a parent link on model nodes

### DIFF
--- a/.changeset/item-parent-link.md
+++ b/.changeset/item-parent-link.md
@@ -1,0 +1,8 @@
+---
+'marking-menu': major
+---
+
+Add a `parent` property to menu nodes: `null` at the root, and the immediate
+containing node for every item. `AnyModelNode`, `MarkingMenuModelItem` and
+`ModelRoot` gain the field, so any code implementing or mocking those types
+needs to supply it.

--- a/.changeset/item-parent-link.md
+++ b/.changeset/item-parent-link.md
@@ -2,9 +2,9 @@
 'marking-menu': major
 ---
 
-Menu nodes keep their `parent` property, `null` at the root (previously
-`undefined`), now precisely typed: for a model built from a literal menu
-description, an item's `parent` resolves to the exact ancestor instead of a
-loose one. `AnyModelNode`, `MarkingMenuModelItem` and `ModelRoot` gain the
-field in their types, so any code implementing or mocking one of them needs
-to supply it.
+Return `null` instead of `undefined` from the root's `parent` property.
+Items' `parent` is now precisely typed: for a model built from a literal
+menu description, it resolves to the exact ancestor node instead of a loose
+one. `AnyModelNode`, `MarkingMenuModelItem` and `ModelRoot` gain the field
+in their types, so any code implementing or mocking one of them needs to
+supply it.

--- a/.changeset/item-parent-link.md
+++ b/.changeset/item-parent-link.md
@@ -2,7 +2,9 @@
 'marking-menu': major
 ---
 
-Add a `parent` property to menu nodes: `null` at the root, and the immediate
-containing node for every item. `AnyModelNode`, `MarkingMenuModelItem` and
-`ModelRoot` gain the field, so any code implementing or mocking those types
-needs to supply it.
+Menu nodes keep their `parent` property, `null` at the root (previously
+`undefined`), now precisely typed: for a model built from a literal menu
+description, an item's `parent` resolves to the exact ancestor instead of a
+loose one. `AnyModelNode`, `MarkingMenuModelItem` and `ModelRoot` gain the
+field in their types, so any code implementing or mocking one of them needs
+to supply it.

--- a/.changeset/remove-item-parent.md
+++ b/.changeset/remove-item-parent.md
@@ -1,5 +1,0 @@
----
-'marking-menu': major
----
-
-Remove the `parent` property from emitted menu items.

--- a/src/model.test-d.ts
+++ b/src/model.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, it } from 'vitest';
 import { createModel } from './model.js';
-import type { MarkingMenuItemInput } from './types.js';
+import type { MarkingMenuItemInput, MarkingMenuModelItem } from './types.js';
 
 /*
  Type level tests: they assert what the type system knows about a model built
@@ -50,6 +50,15 @@ describe('createModel', () => {
   it('knows whether a node is the root', () => {
     expectTypeOf(menu.isRoot).toEqualTypeOf<true>();
     expectTypeOf(menu.items[0].isRoot).toEqualTypeOf<false>();
+  });
+
+  it('gives every item a precise parent, and the root none', () => {
+    expectTypeOf(menu.parent).toEqualTypeOf<null>();
+    expectTypeOf(menu.items[0].parent).toEqualTypeOf<typeof menu>();
+    expectTypeOf(menu.items[1].items[0].parent).toEqualTypeOf<
+      (typeof menu.items)[1]
+    >();
+    expectTypeOf(menu.items[1].items[0].parent.label).toEqualTypeOf<'Bottom'>();
   });
 
   it('resolves getChild to the very item bearing the id', () => {
@@ -213,5 +222,9 @@ describe('createModel', () => {
     expectTypeOf(dynamic.getChild('whatever')).toBeNullable();
     expectTypeOf(dynamic.getNearestChild(0)).toBeNullable();
     expectTypeOf(dynamic.getMaxDepth()).toEqualTypeOf<number>();
+    expectTypeOf(dynamic.parent).toEqualTypeOf<null>();
+    expectTypeOf(dynamic.items[0]?.parent).toEqualTypeOf<
+      MarkingMenuModelItem | undefined
+    >();
   });
 });

--- a/src/model.test.ts
+++ b/src/model.test.ts
@@ -83,6 +83,27 @@ describe('createModel', () => {
     expect(menu.items[0].items[0].isRoot).toBe(false);
   });
 
+  it('gives every item a reference back to its parent', () => {
+    const menu = createModel({
+      items: [
+        {
+          id: 'menu',
+          label: 'Menu',
+          items: [{ id: 'sub-1', label: 'Sub 1' }],
+        },
+        { id: 'right', label: 'Right' },
+      ],
+    });
+    expect(menu.items[0].parent).toBe(menu);
+    expect(menu.items[0].items[0].parent).toBe(menu.items[0]);
+    expect(menu.items[1].parent).toBe(menu);
+  });
+
+  it('has no parent at the root', () => {
+    const menu = createModel({ items: [] });
+    expect(menu.parent).toBeNull();
+  });
+
   it('retrieves a direct sub-item by its id', () => {
     const menu = createModel({ items: fourItems });
     expect(menu.getChild('left')).toBe(menu.items[2]);

--- a/src/model.ts
+++ b/src/model.ts
@@ -113,10 +113,9 @@ type ItemsOf<Input> = Input extends {
   : EmptyTuple;
 
 /**
- The raw description of the item at `Path` within `Items`, `Path`'s segments
- being the index to follow at each level, from `Items` down to the item
- itself. `Path` must be non-empty: the root has no input counterpart to look
- up. It *is* {@link MarkingMenuModel}'s `Root`, as a whole.
+ The raw description of the item at `Path` within `Items`, following
+ `Path`'s indices one level at a time. `Path` must be non-empty: the root
+ has no input counterpart to look up, since it *is* the whole of `Root`.
  */
 type InputAt<
   Items extends readonly MarkingMenuItemInput[],
@@ -137,21 +136,18 @@ type InputAt<
  `ParentPath` within `Root`.
 
  Built by real recursion, peeling `Inputs` one element at a time while
- growing `Index` in lockstep, so each child's own path is a distinct literal
- tuple. A mapped type over `keyof Inputs` would substitute the generic
- `number` into every child's path alike instead, collapsing them all into
- one node whose `id` is the union of its siblings' rather than each child's
- own.
+ growing `Index` in lockstep, so each child gets its own literal path. A
+ mapped type over `keyof Inputs` would substitute the generic `number` into
+ every path instead, collapsing all the children into one node whose `id`
+ is the union of its siblings'.
 
- Guarded on {@link IsTuple}: a menu built at runtime has a non-literal
- `items` list, whose length (and hence every descendant's path) is not
- statically known, so it degrades to {@link ToItems} instead of recursing
- forever. The guard has to stay at this one level, rather than have
- {@link ToItems} recurse back into `ItemsAt`. `Root`/`Path` become
- meaningless once a list's length isn't known, and `Inputs` can itself be a
+ Guarded on {@link IsTuple}: once a menu's `items` length isn't known
+ statically, neither is any descendant's path, so this degrades to
+ {@link ToItems} instead of recursing forever. The guard stays at this
+ level rather than inside {@link ToItems}, because `Inputs` can itself be a
  still-unresolved generic (e.g. a menu config not yet narrowed to a literal
- type), so the compiler must be able to check *both* branches structurally
- without one poisoning the other with an unresolvable `Root`.
+ type): the compiler then has to check both branches on their own, without
+ a meaningless `Root` from the tuple branch poisoning the dynamic one.
  */
 type ItemsAt<
   Root extends MarkingMenuInput,
@@ -180,9 +176,9 @@ type ToItems<Inputs extends readonly MarkingMenuItemInput[]> = {
 
 /**
  The model item an input item resolves to, without a `Root`/`Path` to derive
- a precise `parent` from, so `parent` widens to the generic, erased
- {@link MarkingMenuModelItem}. It's the same degradation a dynamic list's
- element type already undergoes for `id`, `label` and `items`.
+ a precise `parent` from: `parent` widens to the generic, erased
+ {@link MarkingMenuModelItem}, the same degradation `id`, `label` and
+ `items` already undergo.
  */
 type ToItem<Input> = Input extends MarkingMenuItemInput
   ? ModelItem<IdOf<Input>, Input['label'], ToItems<ItemsOf<Input>>> & {
@@ -194,12 +190,12 @@ type ToItem<Input> = Input extends MarkingMenuItemInput
  The node the model built from `Root` has at `Path`: the root itself for an
  empty path, or the item found by following `Path`'s indices otherwise.
 
- Parameterizing by `Root` and a `Path` locating the node within it, rather
- than by the node's own literal shape the way {@link ModelItem} is, is what
- lets an item carry a precise `parent` without the type referencing itself:
- the parent is the very same lookup with the last path segment dropped, so
- node and parent are both *derived*, independently, from the one acyclic
- `Root`, instead of one being defined in terms of the other.
+ Parameterizing by `Root` and a `Path`, rather than by the node's own
+ literal shape the way {@link ModelItem} is, lets an item carry a precise
+ `parent` without the type referencing itself: the parent is the same
+ lookup with the last path segment dropped. Node and parent are both
+ derived, independently, from the one acyclic `Root`, instead of one being
+ defined in terms of the other.
  */
 type NodeAt<
   Root extends MarkingMenuInput,
@@ -257,9 +253,7 @@ abstract class MarkingMenuNode {
     parent: MarkingMenuNode | null;
     /**
      Builds the node's items, given the node itself: sub-items need their
-     parent to exist before they can be created, so the node is constructed
-     first and its items second, the reverse of the previous, child-first
-     order.
+     parent to exist before they can be created.
      */
     items: (self: MarkingMenuNode) => readonly MarkingMenuItem[];
   }) {

--- a/src/model.ts
+++ b/src/model.ts
@@ -154,17 +154,18 @@ type ItemsAt<
   ParentPath extends readonly number[],
   Inputs extends readonly MarkingMenuItemInput[],
   Index extends readonly unknown[] = EmptyTuple,
-> = IsTuple<Inputs> extends true
-  ? Inputs extends readonly [
-      infer _Head,
-      ...infer Rest extends readonly MarkingMenuItemInput[],
-    ]
-    ? readonly [
-        NodeAt<Root, readonly [...ParentPath, Index['length']]>,
-        ...ItemsAt<Root, ParentPath, Rest, readonly [...Index, unknown]>,
+> =
+  IsTuple<Inputs> extends true
+    ? Inputs extends readonly [
+        infer _Head,
+        ...infer Rest extends readonly MarkingMenuItemInput[],
       ]
-    : EmptyTuple
-  : ToItems<Inputs>;
+      ? readonly [
+          NodeAt<Root, readonly [...ParentPath, Index['length']]>,
+          ...ItemsAt<Root, ParentPath, Rest, readonly [...Index, unknown]>,
+        ]
+      : EmptyTuple
+    : ToItems<Inputs>;
 
 /**
  The model items an input item list resolves to when its length is not

--- a/src/model.ts
+++ b/src/model.ts
@@ -2,10 +2,11 @@ import type {
   LiteralId,
   MarkingMenuInput,
   MarkingMenuItemInput,
+  MarkingMenuModelItem,
   ModelItem,
   ModelRoot,
 } from './types.js';
-import { deltaAngle, type EmptyTuple } from './utils.js';
+import { deltaAngle, type EmptyTuple, type IsTuple } from './utils.js';
 
 /*
  The marking menu model.
@@ -112,24 +113,124 @@ type ItemsOf<Input> = Input extends {
   : EmptyTuple;
 
 /**
-The model items an input item list resolves to.
-*/
+ The raw description of the item at `Path` within `Items`, `Path`'s segments
+ being the index to follow at each level, from `Items` down to the item
+ itself. `Path` must be non-empty: the root has no input counterpart to look
+ up — it *is* {@link MarkingMenuModel}'s `Root`, as a whole.
+ */
+type InputAt<
+  Items extends readonly MarkingMenuItemInput[],
+  Path extends readonly [number, ...number[]],
+> = Path extends readonly [
+  infer Head extends number,
+  ...infer Tail extends readonly number[],
+]
+  ? Items[Head] extends infer Item extends MarkingMenuItemInput
+    ? Tail extends readonly [number, ...number[]]
+      ? InputAt<ItemsOf<Item>, Tail>
+      : Item
+    : never
+  : never;
+
+/**
+ The model items built for `Inputs`, the sub-items of the node at
+ `ParentPath` within `Root`.
+
+ Built by real recursion — peeling `Inputs` one element at a time while
+ growing `Index` in lockstep, so each child's own path is a distinct literal
+ tuple — rather than a mapped type over `keyof Inputs`: that would substitute
+ the generic `number` into every child's path alike, collapsing them all into
+ one node whose `id` is the union of its siblings' rather than each child's
+ own.
+
+ Guarded on {@link IsTuple}: a menu built at runtime has a non-literal
+ `items` list, whose length — and hence every descendant's path — is not
+ statically known, so it degrades to {@link ToItems} instead of recursing
+ forever. The guard has to stay at this one level, rather than have
+ {@link ToItems} recurse back into `ItemsAt`: `Root`/`Path` become
+ meaningless once a list's length isn't known, and — because `Inputs` can
+ itself be a still-unresolved generic (e.g. a menu config not yet narrowed
+ to a literal type) — the compiler must be able to check *both* branches
+ structurally without one poisoning the other with an unresolvable `Root`.
+ */
+type ItemsAt<
+  Root extends MarkingMenuInput,
+  ParentPath extends readonly number[],
+  Inputs extends readonly MarkingMenuItemInput[],
+  Index extends readonly unknown[] = EmptyTuple,
+> = IsTuple<Inputs> extends true
+  ? Inputs extends readonly [
+      infer _Head,
+      ...infer Rest extends readonly MarkingMenuItemInput[],
+    ]
+    ? readonly [
+        NodeAt<Root, readonly [...ParentPath, Index['length']]>,
+        ...ItemsAt<Root, ParentPath, Rest, readonly [...Index, unknown]>,
+      ]
+    : EmptyTuple
+  : ToItems<Inputs>;
+
+/**
+ The model items an input item list resolves to when its length is not
+ statically known — a menu, or a portion of one, built at runtime.
+ */
 type ToItems<Inputs extends readonly MarkingMenuItemInput[]> = {
   [K in keyof Inputs]: ToItem<Inputs[K]>;
 };
 
 /**
-The model item an input item resolves to.
-*/
+ The model item an input item resolves to, without a `Root`/`Path` to derive
+ a precise `parent` from, so `parent` widens to the generic, erased
+ {@link MarkingMenuModelItem} — the same degradation a dynamic list's
+ element type already undergoes for `id`, `label` and `items`.
+ */
 type ToItem<Input> = Input extends MarkingMenuItemInput
-  ? ModelItem<IdOf<Input>, Input['label'], ToItems<ItemsOf<Input>>>
+  ? ModelItem<IdOf<Input>, Input['label'], ToItems<ItemsOf<Input>>> & {
+      readonly parent: MarkingMenuModelItem;
+    }
+  : never;
+
+/**
+ The node the model built from `Root` has at `Path`: the root itself for an
+ empty path, or the item found by following `Path`'s indices otherwise.
+
+ Parameterizing by `Root` and a `Path` locating the node within it — rather
+ than by the node's own literal shape, the way {@link ModelItem} is — is what
+ lets an item carry a precise `parent` without the type referencing itself:
+ the parent is the very same lookup with the last path segment dropped, so
+ node and parent are both *derived*, independently, from the one acyclic
+ `Root`, instead of one being defined in terms of the other.
+ */
+type NodeAt<
+  Root extends MarkingMenuInput,
+  Path extends readonly number[],
+> = Path extends readonly [number, ...number[]]
+  ? InputAt<Root['items'], Path> extends infer Input extends
+      MarkingMenuItemInput
+    ? ModelItem<
+        IdOf<Input>,
+        Input['label'],
+        ItemsAt<Root, Path, ItemsOf<Input>>
+      > & { readonly parent: ParentAt<Root, Path> }
+    : never
+  : ModelRoot<ItemsAt<Root, EmptyTuple, Root['items']>>;
+
+/**
+ The parent of the node at (non-empty) `Path`: the node one path segment up.
+ */
+type ParentAt<
+  Root extends MarkingMenuInput,
+  Path extends readonly [number, ...number[]],
+> = Path extends readonly [...infer Init extends readonly number[], number]
+  ? NodeAt<Root, Init>
   : never;
 
 /**
  The model {@link createModel} builds from a menu description.
  */
-export type MarkingMenuModel<Input extends MarkingMenuInput> = ModelRoot<
-  ToItems<Input['items']>
+export type MarkingMenuModel<Input extends MarkingMenuInput> = NodeAt<
+  Input,
+  EmptyTuple
 >;
 
 /* -------------------------------------------------------------------------- *
@@ -147,13 +248,31 @@ const getAngleRange = (items: readonly unknown[]): number =>
  */
 abstract class MarkingMenuNode {
   readonly #items: readonly MarkingMenuItem[];
+  readonly #parent: MarkingMenuNode | null;
 
-  constructor({ items }: { items: readonly MarkingMenuItem[] }) {
-    this.#items = items;
+  constructor({
+    parent,
+    items,
+  }: {
+    parent: MarkingMenuNode | null;
+    /**
+     Builds the node's items, given the node itself: sub-items need their
+     parent to exist before they can be created, so the node is constructed
+     first and its items second, the reverse of the previous, child-first
+     order.
+     */
+    items: (self: MarkingMenuNode) => readonly MarkingMenuItem[];
+  }) {
+    this.#parent = parent;
+    this.#items = items(this);
   }
 
   get items(): readonly MarkingMenuItem[] {
     return this.#items;
+  }
+
+  get parent(): MarkingMenuNode | null {
+    return this.#parent;
   }
 
   get isLeaf(): boolean {
@@ -252,15 +371,17 @@ class MarkingMenuItem extends MarkingMenuNode {
     label,
     angle,
     key,
+    parent,
     items,
   }: {
     id: string | undefined;
     label: string;
     angle: number;
     key: string;
-    items: readonly MarkingMenuItem[];
+    parent: MarkingMenuNode;
+    items: (self: MarkingMenuNode) => readonly MarkingMenuItem[];
   }) {
-    super({ items });
+    super({ parent, items });
     this.#id = id;
     this.#label = label;
     this.#angle = angle;
@@ -302,6 +423,7 @@ class MarkingMenuRoot extends MarkingMenuNode {
  Build the (frozen) item list of one menu level.
 
  @param inputs - The description of the level's items.
+ @param parent - The level's own node, i.e. the items' parent.
  @param seenIds - The ids already used elsewhere in the menu. Mutated as the
  items are created.
  @param baseKey - The generated key of the parent level, if any. Joined with
@@ -313,6 +435,7 @@ class MarkingMenuRoot extends MarkingMenuNode {
  */
 const createItems = (
   inputs: readonly MarkingMenuItemInput[],
+  parent: MarkingMenuNode,
   seenIds: Set<string> = new Set(),
   baseKey?: string,
 ): readonly MarkingMenuItem[] => {
@@ -336,9 +459,11 @@ const createItems = (
         label: input.label,
         angle: index * angleRange,
         key,
-        items: input.items
-          ? createItems(input.items, seenIds, key)
-          : Object.freeze([]),
+        parent,
+        items: (self) =>
+          input.items
+            ? createItems(input.items, self, seenIds, key)
+            : Object.freeze([]),
       });
     }),
   );
@@ -359,6 +484,7 @@ export function createModel<const Input extends MarkingMenuInput>(
   // the single point where the precise types are re-attached to the loosely
   // typed implementation classes.
   return new MarkingMenuRoot({
-    items: createItems(input.items),
+    parent: null,
+    items: (self) => createItems(input.items, self),
   }) as unknown as MarkingMenuModel<Input>;
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -116,7 +116,7 @@ type ItemsOf<Input> = Input extends {
  The raw description of the item at `Path` within `Items`, `Path`'s segments
  being the index to follow at each level, from `Items` down to the item
  itself. `Path` must be non-empty: the root has no input counterpart to look
- up — it *is* {@link MarkingMenuModel}'s `Root`, as a whole.
+ up. It *is* {@link MarkingMenuModel}'s `Root`, as a whole.
  */
 type InputAt<
   Items extends readonly MarkingMenuItemInput[],
@@ -136,22 +136,22 @@ type InputAt<
  The model items built for `Inputs`, the sub-items of the node at
  `ParentPath` within `Root`.
 
- Built by real recursion — peeling `Inputs` one element at a time while
+ Built by real recursion, peeling `Inputs` one element at a time while
  growing `Index` in lockstep, so each child's own path is a distinct literal
- tuple — rather than a mapped type over `keyof Inputs`: that would substitute
- the generic `number` into every child's path alike, collapsing them all into
+ tuple. A mapped type over `keyof Inputs` would substitute the generic
+ `number` into every child's path alike instead, collapsing them all into
  one node whose `id` is the union of its siblings' rather than each child's
  own.
 
  Guarded on {@link IsTuple}: a menu built at runtime has a non-literal
- `items` list, whose length — and hence every descendant's path — is not
+ `items` list, whose length (and hence every descendant's path) is not
  statically known, so it degrades to {@link ToItems} instead of recursing
  forever. The guard has to stay at this one level, rather than have
- {@link ToItems} recurse back into `ItemsAt`: `Root`/`Path` become
- meaningless once a list's length isn't known, and — because `Inputs` can
- itself be a still-unresolved generic (e.g. a menu config not yet narrowed
- to a literal type) — the compiler must be able to check *both* branches
- structurally without one poisoning the other with an unresolvable `Root`.
+ {@link ToItems} recurse back into `ItemsAt`. `Root`/`Path` become
+ meaningless once a list's length isn't known, and `Inputs` can itself be a
+ still-unresolved generic (e.g. a menu config not yet narrowed to a literal
+ type), so the compiler must be able to check *both* branches structurally
+ without one poisoning the other with an unresolvable `Root`.
  */
 type ItemsAt<
   Root extends MarkingMenuInput,
@@ -172,7 +172,7 @@ type ItemsAt<
 
 /**
  The model items an input item list resolves to when its length is not
- statically known — a menu, or a portion of one, built at runtime.
+ statically known: a menu, or a portion of one, built at runtime.
  */
 type ToItems<Inputs extends readonly MarkingMenuItemInput[]> = {
   [K in keyof Inputs]: ToItem<Inputs[K]>;
@@ -181,7 +181,7 @@ type ToItems<Inputs extends readonly MarkingMenuItemInput[]> = {
 /**
  The model item an input item resolves to, without a `Root`/`Path` to derive
  a precise `parent` from, so `parent` widens to the generic, erased
- {@link MarkingMenuModelItem} — the same degradation a dynamic list's
+ {@link MarkingMenuModelItem}. It's the same degradation a dynamic list's
  element type already undergoes for `id`, `label` and `items`.
  */
 type ToItem<Input> = Input extends MarkingMenuItemInput
@@ -194,8 +194,8 @@ type ToItem<Input> = Input extends MarkingMenuItemInput
  The node the model built from `Root` has at `Path`: the root itself for an
  empty path, or the item found by following `Path`'s indices otherwise.
 
- Parameterizing by `Root` and a `Path` locating the node within it — rather
- than by the node's own literal shape, the way {@link ModelItem} is — is what
+ Parameterizing by `Root` and a `Path` locating the node within it, rather
+ than by the node's own literal shape the way {@link ModelItem} is, is what
  lets an item carry a precise `parent` without the type referencing itself:
  the parent is the very same lookup with the last path segment dropped, so
  node and parent are both *derived*, independently, from the one acyclic

--- a/src/recognizer/recognize-mm-stroke.test.ts
+++ b/src/recognizer/recognize-mm-stroke.test.ts
@@ -41,7 +41,7 @@ const csvParse = async (
 
 type MockModel = ModelItem<string | undefined, string, readonly MockModel[]> & {
   requestedAngle: number | undefined;
-  parent?: MockModel | undefined;
+  parent: MockModel | null;
   getMaxDepth: Mock<() => number>;
   getMaxBreadth: Mock<() => number>;
   getNearestChild: Mock<(childAngle?: number) => MockModel>;
@@ -62,7 +62,7 @@ const createMockModel = (
   depth = 1,
   breadth = 8,
   requestedAngle?: number,
-  parent?: MockModel,
+  parent: MockModel | null = null,
 ): MockModel => {
   const base = {
     items: [],

--- a/src/types.ts
+++ b/src/types.ts
@@ -154,9 +154,9 @@ type GenericNodeKeys =
  generically rather than through the literal ids described in a specific menu.
 
  `parent` is added outside of {@link GenericNodeKeys}: `ModelItem` itself has
- no such field — a literal-preserving `parent` is exactly the type-level
+ no such field. A literal-preserving `parent` is exactly the type-level
  problem this file works around (see {@link AnyModelNode} and how
- {@link MarkingMenuModel} builds it) — so each variant states its own erased
+ {@link MarkingMenuModel} builds it), so each variant states its own erased
  `parent` type directly. An item's parent is always some node of this same
  union; the root's is always `null`.
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,6 +127,10 @@ export type ModelItem<
 export type ModelRoot<Items extends readonly unknown[] = readonly unknown[]> =
   MenuNode<Items> & {
     readonly isRoot: true;
+    /**
+     The root has no parent: it is never nested within another node.
+     */
+    readonly parent: null;
   };
 
 /**
@@ -148,13 +152,22 @@ type GenericNodeKeys =
 /**
  The shape of a model node — root or item — for callers that walk the model
  generically rather than through the literal ids described in a specific menu.
+
+ `parent` is added outside of {@link GenericNodeKeys}: `ModelItem` itself has
+ no such field — a literal-preserving `parent` is exactly the type-level
+ problem this file works around (see {@link AnyModelNode} and how
+ {@link MarkingMenuModel} builds it) — so each variant states its own erased
+ `parent` type directly. An item's parent is always some node of this same
+ union; the root's is always `null`.
  */
 export type MarkingMenuModelItem =
-  | Pick<
+  | (Pick<
       ModelItem<string | undefined, string, readonly MarkingMenuModelItem[]>,
       GenericNodeKeys
-    >
-  | Pick<ModelRoot<readonly MarkingMenuModelItem[]>, GenericNodeKeys>;
+    > & { readonly parent: MarkingMenuModelItem })
+  | (Pick<ModelRoot<readonly MarkingMenuModelItem[]>, GenericNodeKeys> & {
+      readonly parent: null;
+    });
 
 /* -------------------------------------------------------------------------- *
  * Generic node walking
@@ -175,6 +188,12 @@ export interface AnyModelNode {
   readonly isLeaf: boolean;
   readonly isRoot: boolean;
   readonly items: readonly AnyModelNode[];
+  /**
+   The node one level up, or `null` for the root. Erased, like `items`: the
+   precise, literal-preserving parent lives on the model {@link createModel}
+   returns, not on this generic shape.
+   */
+  readonly parent: AnyModelNode | null;
   getNearestChild(angle: number): this['items'][number] | null;
   getMaxDepth(): number;
   getMaxBreadth(): number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,9 +127,6 @@ export type ModelItem<
 export type ModelRoot<Items extends readonly unknown[] = readonly unknown[]> =
   MenuNode<Items> & {
     readonly isRoot: true;
-    /**
-     The root has no parent: it is never nested within another node.
-     */
     readonly parent: null;
   };
 
@@ -153,12 +150,10 @@ type GenericNodeKeys =
  The shape of a model node — root or item — for callers that walk the model
  generically rather than through the literal ids described in a specific menu.
 
- `parent` is added outside of {@link GenericNodeKeys}: `ModelItem` itself has
- no such field. A literal-preserving `parent` is exactly the type-level
- problem this file works around (see {@link AnyModelNode} and how
- {@link MarkingMenuModel} builds it), so each variant states its own erased
- `parent` type directly. An item's parent is always some node of this same
- union; the root's is always `null`.
+ `parent` is added outside of {@link GenericNodeKeys}, since `ModelItem` has
+ no such field: a literal-preserving `parent` is the very problem this file
+ works around. An item's parent is always some node of this same union; the
+ root's is always `null`.
  */
 export type MarkingMenuModelItem =
   | (Pick<
@@ -189,9 +184,8 @@ export interface AnyModelNode {
   readonly isRoot: boolean;
   readonly items: readonly AnyModelNode[];
   /**
-   The node one level up, or `null` for the root. Erased, like `items`: the
-   precise, literal-preserving parent lives on the model {@link createModel}
-   returns, not on this generic shape.
+   The node one level up, or `null` for the root. Erased, like `items`: see
+   {@link MarkingMenuModel} for the precise version.
    */
   readonly parent: AnyModelNode | null;
   getNearestChild(angle: number): this['items'][number] | null;


### PR DESCRIPTION
Fixes #167

Model nodes expose their sub-items but have no way back up: given an item, there's no way to find the menu it belongs to. This link existed before the TypeScript migration and was dropped there, since restoring it created a circular type: a node's type would reference its parent's type, which references it back.

This restores `parent` by changing how a node's type is described. Instead of a node's own id, label and items, each node is now described by the whole menu it belongs to, plus a path locating it within that menu. `parent` is then the same lookup with the last step of the path dropped, so a node and its parent are derived independently from the menu description rather than one being defined in terms of the other. The root's `parent` is always `null`.

The runtime construction order changes to match: a node is built before its items, which are then built with it as their parent.

A menu built at runtime rather than described as a literal still works, but its items lose the precise typing, the same trade-off `id` and `label` already make in that case.

You can check the new behavior directly:

```ts
const menu = createModel({
  items: [{ id: 'a', label: 'A', items: [{ id: 'b', label: 'B' }] }],
});
menu.items[0].items[0].parent === menu.items[0]; // true
menu.parent; // null
```

Tests cover `parent` at runtime, at every level, with the root having none, and what the type system knows about it for both a literal menu description and one built dynamically.
