### PR TITLE
Commit or cancel novice gestures on release

### DIFF
--- a/src/engine/controller.test.ts
+++ b/src/engine/controller.test.ts
@@ -576,6 +576,133 @@ describe('createController', () => {
     controller.dispose();
   });
 
+  it('dispatches select carrying the leaf and the open menu when releasing on a leaf active item (objective 7)', () => {
+    using _canvases = stubbedCanvasContexts();
+    using _timers = fakeTimers();
+    const parent = createParent();
+    const controller = createController({
+      items,
+      parent,
+      noviceDwellingTime: 100,
+      minSelectionDist: 40,
+    });
+
+    const canceled = voidMock<[MarkingMenuCancelEvent<AnyModelNode>]>();
+    controller.on('cancel', canceled);
+    let openedMenu: unknown;
+    controller.on('open', (event) => {
+      openedMenu = event.menu;
+    });
+    let selectedId: string | undefined;
+    let selectedMenu: unknown;
+    controller.on('select', (event) => {
+      selectedId = event.selection.id;
+      selectedMenu = event.menu;
+    });
+
+    parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
+    vi.advanceTimersByTime(100);
+    parent.dispatchEvent(pointer('pointermove', { clientX: 100, clientY: 0 }));
+    parent.dispatchEvent(pointer('pointerup', { clientX: 100, clientY: 0 }));
+
+    expect(canceled).not.toHaveBeenCalled();
+    expect(selectedId).toBe('right');
+    // `select.menu` is the same root menu that opened this gesture, not
+    // merely non-null.
+    expect(openedMenu).not.toBeNull();
+    expect(selectedMenu).toBe(openedMenu);
+    expect(parent.querySelector('.marking-menu')).toBeNull();
+    // A completed novice gesture shows feedback on the same terms as an
+    // expert one: the stroke canvases are gone, and exactly one trace
+    // remains.
+    expect(parent.querySelectorAll('canvas')).toHaveLength(1);
+
+    controller.dispose();
+  });
+
+  it('dispatches cancel, never select, when releasing on a non-leaf active item, carrying that item as active (objective 7)', () => {
+    using _canvases = stubbedCanvasContexts();
+    using _timers = fakeTimers();
+    const parent = createParent();
+    const controller = createController({
+      items: [
+        {
+          id: 'right',
+          label: 'Right',
+          items: [
+            { id: 'rightUp', label: 'Right Up' },
+            { id: 'rightDown', label: 'Right Down' },
+          ],
+        },
+        { id: 'down', label: 'Down' },
+        { id: 'left', label: 'Left' },
+        { id: 'up', label: 'Up' },
+      ],
+      parent,
+      noviceDwellingTime: 100,
+      minSelectionDist: 40,
+    });
+
+    const selected = voidMock<[MarkingMenuSelectEvent<AnyModelNode>]>();
+    controller.on('select', selected);
+    let openedMenu: unknown;
+    controller.on('open', (event) => {
+      openedMenu = event.menu;
+    });
+    let canceledActiveId: string | undefined;
+    let cancelMenu: unknown;
+    controller.on('cancel', (event) => {
+      canceledActiveId = event.active?.id;
+      cancelMenu = event.menu;
+    });
+
+    parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
+    vi.advanceTimersByTime(100);
+    parent.dispatchEvent(pointer('pointermove', { clientX: 100, clientY: 0 }));
+    parent.dispatchEvent(pointer('pointerup', { clientX: 100, clientY: 0 }));
+
+    expect(selected).not.toHaveBeenCalled();
+    expect(canceledActiveId).toBe('right');
+    // `cancel.menu` is the same root menu that opened this gesture, not
+    // merely non-null.
+    expect(openedMenu).not.toBeNull();
+    expect(cancelMenu).toBe(openedMenu);
+    expect(parent.querySelectorAll('canvas')).toHaveLength(1);
+
+    controller.dispose();
+  });
+
+  it('dispatches cancel, carrying the active item, when the native pointer is cancelled on a leaf active item (objective 8)', () => {
+    using _canvases = stubbedCanvasContexts();
+    using _timers = fakeTimers();
+    const parent = createParent();
+    const controller = createController({
+      items,
+      parent,
+      noviceDwellingTime: 100,
+      minSelectionDist: 40,
+    });
+
+    const selected = voidMock<[MarkingMenuSelectEvent<AnyModelNode>]>();
+    controller.on('select', selected);
+    let canceledActiveId: string | undefined;
+    controller.on('cancel', (event) => {
+      canceledActiveId = event.active?.id;
+    });
+
+    parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
+    vi.advanceTimersByTime(100);
+    parent.dispatchEvent(pointer('pointermove', { clientX: 100, clientY: 0 }));
+    parent.dispatchEvent(
+      pointer('pointercancel', { clientX: 100, clientY: 0 }),
+    );
+
+    expect(selected).not.toHaveBeenCalled();
+    expect(canceledActiveId).toBe('right');
+
+    controller.dispose();
+  });
+
   it('does not recreate the menu DOM or redraw the lower stroke when a render repeats with the same identity', () => {
     using _canvases = stubbedCanvasContexts();
     using _timers = fakeTimers();

--- a/src/engine/machine.test.ts
+++ b/src/engine/machine.test.ts
@@ -31,6 +31,24 @@ const model = createModel({
   ],
 });
 
+// A second fixture, with "right" as a submenu rather than a leaf, for the
+// tests that need to end a gesture on a non-leaf active item.
+const submenuModel = createModel({
+  items: [
+    {
+      id: 'right',
+      label: 'Right',
+      items: [
+        { id: 'rightUp', label: 'Right Up' },
+        { id: 'rightDown', label: 'Right Down' },
+      ],
+    },
+    { id: 'down', label: 'Down' },
+    { id: 'left', label: 'Left' },
+    { id: 'up', label: 'Up' },
+  ],
+});
+
 const options = {
   movementsThreshold: 5,
   noviceDwellingTime: 300,
@@ -41,6 +59,14 @@ const options = {
 Start a fresh host with the shared fixture model and options.
 */
 const startHost = () => navigationMachine.start({ model, options });
+
+/**
+Dwell into novice mode at the origin, from a fresh host.
+*/
+const openNovice = (host: ReturnType<typeof startHost>): void => {
+  host.send('down', { position: [0, 0] });
+  host.send('dwell');
+};
 
 /**
 Record every public output a host emits, in order, by name.
@@ -264,11 +290,6 @@ describe('navigationMachine', () => {
   });
 
   describe('novice phase: pointing at items', () => {
-    const openNovice = (host: ReturnType<typeof startHost>) => {
-      host.send('down', { position: [0, 0] });
-      host.send('dwell');
-    };
-
     it('stays inactive while the pointer is within minSelectionDist of the menu center (objective 5)', () => {
       const host = startHost();
       const moved = vi.fn<(event: { active: unknown }) => void>();
@@ -367,6 +388,89 @@ describe('navigationMachine', () => {
 
       host.send('dwell');
       expect(host.current).toEqual(inNovice);
+    });
+  });
+
+  describe('novice phase: committing or abandoning the gesture (objectives 7, 8)', () => {
+    it('dispatches select carrying the leaf and the open menu when releasing on a leaf', () => {
+      const host = startHost();
+      const canceled = vi.fn<() => void>();
+      host.on('cancel', canceled);
+      let selectData: { selection: unknown; menu: unknown } | undefined;
+      host.on('select', ({ data }) => {
+        selectData = data;
+      });
+
+      openNovice(host);
+      host.send('move', { position: [100, 0] }); // Activates "right"
+      host.send('up', { position: [100, 0] });
+
+      expect(host.current.name).toBe('idle');
+      expect(canceled).not.toHaveBeenCalled();
+      expect((selectData?.selection as { id: string }).id).toBe('right');
+      expect(selectData?.menu).toBe(model);
+    });
+
+    it('dispatches cancel, never select, when releasing on a non-leaf active item, carrying that item as active', () => {
+      const host = navigationMachine.start({ model: submenuModel, options });
+      const selected = vi.fn<() => void>();
+      host.on('select', selected);
+      let cancelData: { active: unknown; menu: unknown } | undefined;
+      host.on('cancel', ({ data }) => {
+        cancelData = data;
+      });
+
+      openNovice(host);
+      host.send('move', { position: [100, 0] }); // Activates "right", a submenu
+      expect(
+        host.current.name === 'novice' &&
+          (host.current.data.active as { isLeaf: boolean } | null)?.isLeaf,
+      ).toBe(false);
+
+      host.send('up', { position: [100, 0] });
+
+      expect(host.current.name).toBe('idle');
+      expect(selected).not.toHaveBeenCalled();
+      expect((cancelData?.active as { id: string } | null)?.id).toBe('right');
+      expect(cancelData?.menu).toBe(submenuModel);
+    });
+
+    it('dispatches cancel regardless of the active item being a leaf when the pointer is cancelled at the terminal sample (objective 8)', () => {
+      const host = startHost();
+      const selected = vi.fn<() => void>();
+      host.on('select', selected);
+      let cancelData: { active: unknown } | undefined;
+      host.on('cancel', ({ data }) => {
+        cancelData = data;
+      });
+
+      openNovice(host);
+      host.send('move', { position: [100, 0] }); // Activates "right", a leaf
+
+      host.send('cancel', { position: [100, 0] });
+
+      expect(host.current.name).toBe('idle');
+      expect(selected).not.toHaveBeenCalled();
+      expect((cancelData?.active as { id: string } | null)?.id).toBe('right');
+    });
+
+    it('dispatches cancel when the pointer is cancelled on a non-leaf active item too (objective 8)', () => {
+      const host = navigationMachine.start({ model: submenuModel, options });
+      const selected = vi.fn<() => void>();
+      host.on('select', selected);
+      let cancelData: { active: unknown } | undefined;
+      host.on('cancel', ({ data }) => {
+        cancelData = data;
+      });
+
+      openNovice(host);
+      host.send('move', { position: [100, 0] }); // Activates "right", a submenu
+
+      host.send('cancel', { position: [100, 0] });
+
+      expect(host.current.name).toBe('idle');
+      expect(selected).not.toHaveBeenCalled();
+      expect((cancelData?.active as { id: string } | null)?.id).toBe('right');
     });
   });
 });

--- a/src/engine/machine.ts
+++ b/src/engine/machine.ts
@@ -238,34 +238,47 @@ function selectEvent<N extends AnyModelNode>(data: {
 function cancelEvent<N extends AnyModelNode>(data: {
   readonly mode: MarkingMenuMode;
   readonly position: Point;
+  readonly active: N | null;
   readonly menu: N | null;
 }): MarkingMenuCancelEvent<N> {
-  return new MarkingMenuCancelEvent<N>({ ...data, active: null } as unknown as {
-    mode: MarkingMenuMode;
-    position: Point;
-    active: null;
-    menu: ModelMenus<N> | null;
-  });
+  return new MarkingMenuCancelEvent<N>(
+    data as unknown as {
+      mode: MarkingMenuMode;
+      position: Point;
+      active: ModelItems<N> | null;
+      menu: ModelMenus<N> | null;
+    },
+  );
 }
 
 /**
  The context every termination action needs: the stroke drawn so far
- (including the release/cancel position) and the menu open when it ended, if
- any. Narrows structurally on `'lowerStroke' in fromData` rather than taking
- `from` as a parameter: `from` and `fromData` are only correlated inside
- totorobot's own transition record, and splitting them across two parameters
- here decorrelates them, so novice is picked out by the field only it has.
+ (including the release/cancel position), the menu open when it ended (if
+ any), and the item that was active (if any) — precisely the thing that is
+ not selected once a termination action decides not to select it. Narrows
+ structurally on `'lowerStroke' in fromData` rather than taking `from` as a
+ parameter: `from` and `fromData` are only correlated inside totorobot's own
+ transition record, and splitting them across two parameters here
+ decorrelates them, so novice is picked out by the field only it has.
  */
 function terminationContext(
   fromData: NavigationStates['startup' | 'expert' | 'novice'],
   position: Point,
-): { readonly stroke: readonly Point[]; readonly menu: AnyModelNode | null } {
+): {
+  readonly stroke: readonly Point[];
+  readonly menu: AnyModelNode | null;
+  readonly active: AnyModelNode | null;
+} {
   if ('lowerStroke' in fromData) {
-    const { lowerStroke, upperStroke, menu } = fromData;
-    return { stroke: [...lowerStroke, ...upperStroke, position], menu };
+    const { lowerStroke, upperStroke, menu, active } = fromData;
+    return {
+      stroke: [...lowerStroke, ...upperStroke, position],
+      menu,
+      active,
+    };
   }
 
-  return { stroke: [...fromData.stroke, position], menu: null };
+  return { stroke: [...fromData.stroke, position], menu: null, active: null };
 }
 
 export const navigationMachine = machine({
@@ -443,41 +456,47 @@ export const navigationMachine = machine({
       }
 
       const { position } = inputData;
-      const { stroke, menu } = terminationContext(fromData, position);
-      // Startup: the pointer never moved at all when the stroke has zero
-      // length, so there is nothing to recognize. Novice selection is
-      // proximity-based hit-testing against the active item, not
-      // expert-style stroke recognition, and that wiring belongs to a later
-      // ticket: every release cancels for now, regardless of `active`.
-      // Expert always attempts recognition.
-      const isSkipRecognition =
-        from === 'startup' ? strokeLength(stroke) === 0 : from === 'novice';
+      const { stroke, menu, active } = terminationContext(fromData, position);
 
-      const selection = isSkipRecognition
-        ? null
-        : recognizeMarkingMenuStroke(stroke, fromData.model);
+      // Novice release hit-tests the item already tracked as active rather
+      // than running stroke recognition: only a leaf can be selected, and a
+      // non-leaf (or absent) active item carries straight through to
+      // `cancel.active` unchanged — it is precisely the thing that was not
+      // selected. Startup with zero movement has nothing to recognize;
+      // expert, and startup with sub-threshold movement, always attempt it.
+      let selection: AnyModelNode | null;
+      if (from === 'novice') {
+        selection = active?.isLeaf === true ? active : null;
+      } else if (from === 'startup' && strokeLength(stroke) === 0) {
+        selection = null;
+      } else {
+        selection = recognizeMarkingMenuStroke(stroke, fromData.model);
+      }
+
       emit('feedback', { stroke, canceled: selection === null });
 
       if (selection === null) {
-        emit('cancel', cancelEvent({ mode: from, position, menu }));
+        emit('cancel', cancelEvent({ mode: from, position, active, menu }));
       } else {
         emit('select', selectEvent({ mode: from, position, selection, menu }));
       }
     },
 
-    // A pointer cancelled outright never selects, regardless of what the
-    // stroke looks like: recognition never runs. Same `idle` narrowing as
-    // the `-up>` action above.
+    // A pointer cancelled outright never selects, regardless of what was
+    // active or what the stroke looks like: recognition never runs, and a
+    // novice active item — leaf or not — carries through to `cancel.active`
+    // unchanged (objective 8). Same `idle` narrowing as the `-up>` action
+    // above.
     '* -cancel> idle'({ from, fromData, inputData, emit }) {
       if (from === 'idle') {
         return;
       }
 
       const { position } = inputData;
-      const { stroke, menu } = terminationContext(fromData, position);
+      const { stroke, menu, active } = terminationContext(fromData, position);
 
       emit('feedback', { stroke, canceled: true });
-      emit('cancel', cancelEvent({ mode: from, position, menu }));
+      emit('cancel', cancelEvent({ mode: from, position, active, menu }));
     },
   },
 });

--- a/src/engine/machine.ts
+++ b/src/engine/machine.ts
@@ -254,12 +254,13 @@ function cancelEvent<N extends AnyModelNode>(data: {
 /**
  The context every termination action needs: the stroke drawn so far
  (including the release/cancel position), the menu open when it ended (if
- any), and the item that was active (if any) — precisely the thing that is
- not selected once a termination action decides not to select it. Narrows
- structurally on `'lowerStroke' in fromData` rather than taking `from` as a
- parameter: `from` and `fromData` are only correlated inside totorobot's own
- transition record, and splitting them across two parameters here
- decorrelates them, so novice is picked out by the field only it has.
+ any), and the item that was active (if any). That active item is precisely
+ the thing that is not selected once a termination action decides not to
+ select it. Narrows structurally on `'lowerStroke' in fromData` rather than
+ taking `from` as a parameter: `from` and `fromData` are only correlated
+ inside totorobot's own transition record, and splitting them across two
+ parameters here decorrelates them, so novice is picked out by the field
+ only it has.
  */
 function terminationContext(
   fromData: NavigationStates['startup' | 'expert' | 'novice'],
@@ -461,8 +462,8 @@ export const navigationMachine = machine({
       // Novice release hit-tests the item already tracked as active rather
       // than running stroke recognition: only a leaf can be selected, and a
       // non-leaf (or absent) active item carries straight through to
-      // `cancel.active` unchanged — it is precisely the thing that was not
-      // selected. Startup with zero movement has nothing to recognize;
+      // `cancel.active` unchanged, since it is precisely the thing that was
+      // not selected. Startup with zero movement has nothing to recognize;
       // expert, and startup with sub-threshold movement, always attempt it.
       let selection: AnyModelNode | null;
       if (from === 'novice') {
@@ -484,7 +485,7 @@ export const navigationMachine = machine({
 
     // A pointer cancelled outright never selects, regardless of what was
     // active or what the stroke looks like: recognition never runs, and a
-    // novice active item — leaf or not — carries through to `cancel.active`
+    // novice active item, leaf or not, carries through to `cancel.active`
     // unchanged (objective 8). Same `idle` narrowing as the `-up>` action
     // above.
     '* -cancel> idle'({ from, fromData, inputData, emit }) {


### PR DESCRIPTION
Releasing the pointer in novice mode always dispatched `cancel`, regardless of what was under it. Hit-testing landed in `src/engine/machine.ts` for [Pointing at items in the open menu](https://github.com/QuentinRoy/Marking-Menu/issues/180), but the release itself never consulted the result: the terminal action hardcoded a null active item and skipped recognition outright.

Closes #181.

The two termination actions in the navigation machine now use the item already tracked as active instead of re-running stroke recognition. Releasing on a leaf dispatches `select` with that leaf and the open menu. Releasing on a non-leaf item, or with nothing active, dispatches `cancel` carrying that item (or `null`) as `active` — the thing that was not selected. A pointer cancelled outright behaves the same way regardless of whether the active item was a leaf, since cancellation never attempts a selection either way.

`cancel.active` was already typed to allow this; it had just never been given a real value. `terminationContext`, the shared helper both termination actions call, now threads the tracked active item through alongside the stroke and open menu it already carried.

Run `yarn test` to see the new behavior covered at both the machine level (`src/engine/machine.test.ts`) and the controller level (`src/engine/controller.test.ts`), including a menu with a submenu item to exercise the non-leaf case. `yarn typecheck` and `yarn lint` are both clean.

No public API changed and no consumer can reach this code path yet (`createController` is not wired into `createMarkingMenu` until a later step of the migration), so no changeset is included.