### PR TITLE
Open a submenu when the pointer dwells on it in novice mode

### DIFF
--- a/src/engine/controller.test.ts
+++ b/src/engine/controller.test.ts
@@ -890,6 +890,142 @@ describe('createController', () => {
     controller.dispose();
   });
 
+  describe('dwelling into a submenu (objectives 9, 11)', () => {
+    const submenuItems = [
+      {
+        id: 'right',
+        label: 'Right',
+        items: [
+          { id: 'subRight', label: 'Sub Right' },
+          { id: 'subDown', label: 'Sub Down' },
+          { id: 'subLeft', label: 'Sub Left' },
+          { id: 'subUp', label: 'Sub Up' },
+        ],
+      },
+      { id: 'down', label: 'Down' },
+      { id: 'left', label: 'Left' },
+      { id: 'up', label: 'Up' },
+    ] as const;
+
+    it('dispatches open for the submenu and recreates the menu DOM for it, once the pointer dwells beyond minMenuSelectionDist on it', () => {
+      using _canvases = stubbedCanvasContexts();
+      using _timers = fakeTimers();
+      const parent = createParent();
+      const controller = createController({
+        items: submenuItems,
+        parent,
+        noviceDwellingTime: 100,
+        minSelectionDist: 40,
+        minMenuSelectionDist: 80,
+        submenuOpeningDelay: 100,
+      });
+
+      const openedMenus: unknown[] = [];
+      controller.on('open', (event) => {
+        openedMenus.push(event.menu);
+      });
+
+      parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
+      vi.advanceTimersByTime(100); // Opens the root menu
+      const rootMenuDom = parent.querySelector('.marking-menu');
+
+      // Beyond minMenuSelectionDist (80) on "right", a submenu.
+      parent.dispatchEvent(
+        pointer('pointermove', { clientX: 100, clientY: 0 }),
+      );
+      vi.advanceTimersByTime(100); // The submenu dwell fires
+
+      expect(openedMenus).toHaveLength(2);
+      expect(openedMenus[1]).not.toBe(openedMenus[0]);
+      // A different menu identity: the DOM is recreated, not patched.
+      expect(parent.querySelector('.marking-menu')).not.toBe(rootMenuDom);
+      expect(parent.querySelectorAll('.marking-menu')).toHaveLength(1);
+
+      controller.dispose();
+    });
+
+    it('selects a leaf inside the submenu', () => {
+      using _canvases = stubbedCanvasContexts();
+      using _timers = fakeTimers();
+      const parent = createParent();
+      const controller = createController({
+        items: submenuItems,
+        parent,
+        noviceDwellingTime: 100,
+        minSelectionDist: 40,
+        minMenuSelectionDist: 80,
+        submenuOpeningDelay: 100,
+      });
+
+      let selectedId: string | undefined;
+      controller.on('select', (event) => {
+        selectedId = event.selection.id;
+      });
+
+      parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
+      vi.advanceTimersByTime(100);
+      parent.dispatchEvent(
+        pointer('pointermove', { clientX: 100, clientY: 0 }),
+      );
+      vi.advanceTimersByTime(100); // Opens the submenu, centered at [100, 0]
+
+      // Relative to the submenu's own centre, the same geometry that
+      // activates "right" from the root activates "subRight" here.
+      parent.dispatchEvent(
+        pointer('pointermove', { clientX: 200, clientY: 0 }),
+      );
+      parent.dispatchEvent(pointer('pointerup', { clientX: 200, clientY: 0 }));
+
+      expect(selectedId).toBe('subRight');
+
+      controller.dispose();
+    });
+
+    it('cancels a gesture that ends inside the submenu without a leaf active', () => {
+      using _canvases = stubbedCanvasContexts();
+      using _timers = fakeTimers();
+      const parent = createParent();
+      const controller = createController({
+        items: submenuItems,
+        parent,
+        noviceDwellingTime: 100,
+        minSelectionDist: 40,
+        minMenuSelectionDist: 80,
+        submenuOpeningDelay: 100,
+      });
+
+      const selected = voidMock<[MarkingMenuSelectEvent<AnyModelNode>]>();
+      controller.on('select', selected);
+      let cancelEvent: MarkingMenuCancelEvent<AnyModelNode> | undefined;
+      controller.on('cancel', (event) => {
+        cancelEvent = event;
+      });
+      let openedMenu: unknown;
+      controller.on('open', (event) => {
+        openedMenu = event.menu;
+      });
+
+      parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
+      vi.advanceTimersByTime(100);
+      parent.dispatchEvent(
+        pointer('pointermove', { clientX: 100, clientY: 0 }),
+      );
+      vi.advanceTimersByTime(100); // Opens the submenu, centered at [100, 0]
+      const submenu = openedMenu;
+
+      // Released back at the submenu's own centre: within minSelectionDist,
+      // so nothing is active there.
+      parent.dispatchEvent(pointer('pointerup', { clientX: 100, clientY: 0 }));
+
+      expect(selected).not.toHaveBeenCalled();
+      expect(cancelEvent?.mode).toBe('novice');
+      expect(cancelEvent?.active).toBeNull();
+      expect(cancelEvent?.menu).toBe(submenu);
+
+      controller.dispose();
+    });
+  });
+
   it('removes the menu DOM on dispose while novice mode is open', () => {
     using _canvases = stubbedCanvasContexts();
     using _timers = fakeTimers();

--- a/src/engine/controller.test.ts
+++ b/src/engine/controller.test.ts
@@ -926,14 +926,14 @@ describe('createController', () => {
       });
 
       parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
-      vi.advanceTimersByTime(100); // Opens the root menu
+      vi.advanceTimersByTime(100);
       const rootMenuDom = parent.querySelector('.marking-menu');
 
       // Beyond minMenuSelectionDist (80) on "right", a submenu.
       parent.dispatchEvent(
         pointer('pointermove', { clientX: 100, clientY: 0 }),
       );
-      vi.advanceTimersByTime(100); // The submenu dwell fires
+      vi.advanceTimersByTime(100);
 
       expect(openedMenus).toHaveLength(2);
       expect(openedMenus[1]).not.toBe(openedMenus[0]);

--- a/src/engine/controller.ts
+++ b/src/engine/controller.ts
@@ -18,6 +18,8 @@ export type EngineConfig = MarkingMenuInput & {
   readonly movementsThreshold?: number;
   readonly noviceDwellingTime?: number;
   readonly minSelectionDist?: number;
+  readonly minMenuSelectionDist?: number;
+  readonly submenuOpeningDelay?: number;
 };
 
 /*
@@ -76,6 +78,8 @@ class Controller<Config extends EngineConfig> implements MarkingMenuController<
         movementsThreshold: config.movementsThreshold ?? 5,
         noviceDwellingTime: config.noviceDwellingTime ?? 1000 / 3,
         minSelectionDist: config.minSelectionDist ?? 40,
+        minMenuSelectionDist: config.minMenuSelectionDist ?? 80,
+        submenuOpeningDelay: config.submenuOpeningDelay ?? 100,
       },
       renderer,
     });

--- a/src/engine/machine.test-d.ts
+++ b/src/engine/machine.test-d.ts
@@ -78,6 +78,8 @@ describe('StatesOf<typeof navigationMachine>', () => {
         movementsThreshold: 5,
         noviceDwellingTime: 1,
         minSelectionDist: 40,
+        minMenuSelectionDist: 80,
+        submenuOpeningDelay: 1,
       },
     });
     expectTypeOf(carryModel).toBeFunction();

--- a/src/engine/machine.test.ts
+++ b/src/engine/machine.test.ts
@@ -53,6 +53,8 @@ const options = {
   movementsThreshold: 5,
   noviceDwellingTime: 300,
   minSelectionDist: 40,
+  minMenuSelectionDist: 80,
+  submenuOpeningDelay: 200,
 };
 
 /**
@@ -471,6 +473,146 @@ describe('navigationMachine', () => {
       expect(host.current.name).toBe('idle');
       expect(selected).not.toHaveBeenCalled();
       expect((cancelData?.active as { id: string } | null)?.id).toBe('right');
+    });
+  });
+
+  describe('novice phase: dwelling into a submenu (objectives 9, 11)', () => {
+    it('opens the submenu when the dwell fires beyond minMenuSelectionDist on a non-leaf active item', () => {
+      const host = navigationMachine.start({ model: submenuModel, options });
+      const opened: unknown[] = [];
+      host.on('open', ({ data }) => {
+        opened.push(data);
+      });
+
+      openNovice(host);
+      host.send('move', { position: [100, 0] }); // Beyond minMenuSelectionDist (80), activates "right"
+      const submenu =
+        host.current.name === 'novice' ? host.current.data.active : null;
+      expect(submenu).not.toBeNull();
+
+      opened.length = 0; // Discard the root menu's own `open`
+      host.send('dwell');
+
+      // A genuine phase change: novice re-enters novice, but at the submenu.
+      expect(host.current.name).toBe('novice');
+      const data = host.current.name === 'novice' ? host.current.data : null;
+      expect(data?.menu).toBe(submenu);
+      expect(data?.menuCenter).toEqual([100, 0]);
+      expect(data?.active).toBeNull();
+
+      expect(opened).toHaveLength(1);
+      const event = opened[0] as {
+        mode: string;
+        menu: unknown;
+        menuCenter: number[];
+        position: number[];
+      };
+      expect(event.mode).toBe('novice');
+      expect(event.menu).toBe(submenu);
+      expect(event.menuCenter).toEqual([100, 0]);
+      expect(event.position).toEqual([100, 0]);
+    });
+
+    it('accumulates the prior stroke into the lower stroke and restarts the upper stroke from the new centre', () => {
+      const host = navigationMachine.start({ model: submenuModel, options });
+
+      openNovice(host); // Novice at [0, 0]; lowerStroke [[0,0]], upperStroke [[0,0]]
+      host.send('move', { position: [100, 0] }); // UpperStroke [[0,0],[100,0]]
+      host.send('dwell'); // Opens the submenu at [100, 0]
+
+      const data = host.current.name === 'novice' ? host.current.data : null;
+      expect(data?.upperStroke).toEqual([[100, 0]]);
+      expect(data?.lowerStroke).toEqual([
+        [0, 0],
+        [0, 0],
+        [100, 0],
+      ]);
+    });
+
+    it('does not open when dwelling within minMenuSelectionDist, even on a non-leaf active item', () => {
+      const host = navigationMachine.start({ model: submenuModel, options });
+      openNovice(host);
+      const opened = vi.fn<() => void>();
+      host.on('open', opened);
+
+      // Beyond minSelectionDist (40) so "right" is active, but within
+      // minMenuSelectionDist (80).
+      host.send('move', { position: [50, 0] });
+      const rootMenu =
+        host.current.name === 'novice' ? host.current.data.menu : null;
+
+      host.send('dwell');
+
+      expect(opened).not.toHaveBeenCalled();
+      expect(host.current.name === 'novice' && host.current.data.menu).toBe(
+        rootMenu,
+      );
+    });
+
+    it('does not open on a leaf active item, regardless of distance', () => {
+      const host = startHost(); // The plain, leaf-only fixture model
+      openNovice(host);
+      const opened = vi.fn<() => void>();
+      host.on('open', opened);
+
+      host.send('move', { position: [200, 0] }); // Well beyond minMenuSelectionDist
+      host.send('dwell');
+
+      expect(opened).not.toHaveBeenCalled();
+      expect(host.current.name).toBe('novice');
+    });
+
+    it('does not open when nothing is active', () => {
+      const host = navigationMachine.start({ model: submenuModel, options });
+      openNovice(host);
+      const opened = vi.fn<() => void>();
+      host.on('open', opened);
+
+      host.send('move', { position: [10, 0] }); // Within minSelectionDist: active stays null
+      host.send('dwell');
+
+      expect(opened).not.toHaveBeenCalled();
+    });
+
+    it('a small movement leaves the pending submenu dwell untouched', () => {
+      using _timers = fakeTimers();
+      const host = navigationMachine.start({ model: submenuModel, options });
+      const opened = vi.fn<() => void>();
+      host.on('open', opened);
+
+      host.send('down', { position: [0, 0] });
+      vi.advanceTimersByTime(options.noviceDwellingTime); // Startup dwell -> novice
+      opened.mockClear();
+
+      host.send('move', { position: [100, 0] }); // Significant: activates "right", (re)starts the submenu dwell
+      vi.advanceTimersByTime(options.submenuOpeningDelay - 10);
+      host.send('move', { position: [102, 0] }); // Insignificant (<5px): must not reset it
+      vi.advanceTimersByTime(10);
+
+      expect(opened).toHaveBeenCalledTimes(1);
+    });
+
+    it('significant movement resets the submenu dwell rather than opening it (objective 9)', () => {
+      using _timers = fakeTimers();
+      const host = navigationMachine.start({ model: submenuModel, options });
+      const opened = vi.fn<() => void>();
+      host.on('open', opened);
+
+      host.send('down', { position: [0, 0] });
+      vi.advanceTimersByTime(options.noviceDwellingTime); // Startup dwell -> novice
+      opened.mockClear();
+
+      host.send('move', { position: [100, 0] }); // Starts the submenu dwell
+      vi.advanceTimersByTime(options.submenuOpeningDelay - 10);
+      host.send('move', { position: [200, 0] }); // Significant: restarts it
+      vi.advanceTimersByTime(10);
+
+      // Would have fired here without the reset.
+      expect(opened).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(options.submenuOpeningDelay - 10);
+      // Fires `submenuOpeningDelay` after the *second* move instead.
+      expect(opened).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/engine/machine.test.ts
+++ b/src/engine/machine.test.ts
@@ -516,9 +516,9 @@ describe('navigationMachine', () => {
     it('accumulates the prior stroke into the lower stroke and restarts the upper stroke from the new centre', () => {
       const host = navigationMachine.start({ model: submenuModel, options });
 
-      openNovice(host); // Novice at [0, 0]; lowerStroke [[0,0]], upperStroke [[0,0]]
-      host.send('move', { position: [100, 0] }); // UpperStroke [[0,0],[100,0]]
-      host.send('dwell'); // Opens the submenu at [100, 0]
+      openNovice(host);
+      host.send('move', { position: [100, 0] });
+      host.send('dwell');
 
       const data = host.current.name === 'novice' ? host.current.data : null;
       expect(data?.upperStroke).toEqual([[100, 0]]);
@@ -555,7 +555,7 @@ describe('navigationMachine', () => {
       const opened = vi.fn<() => void>();
       host.on('open', opened);
 
-      host.send('move', { position: [200, 0] }); // Well beyond minMenuSelectionDist
+      host.send('move', { position: [200, 0] });
       host.send('dwell');
 
       expect(opened).not.toHaveBeenCalled();
@@ -626,7 +626,7 @@ describe('navigationMachine', () => {
       host.send('move', { position: [100, 0] }); // One significant move, straight onto "right"
       expect(vi.getTimerCount()).toBe(1); // Restarted, not doubled or dropped
 
-      vi.advanceTimersByTime(options.submenuOpeningDelay); // Opens the submenu at [100, 0]
+      vi.advanceTimersByTime(options.submenuOpeningDelay);
       expect(host.current.name).toBe('novice');
       expect(
         host.current.name === 'novice' && host.current.data.menuCenter,

--- a/src/engine/machine.test.ts
+++ b/src/engine/machine.test.ts
@@ -614,5 +614,28 @@ describe('navigationMachine', () => {
       // Fires `submenuOpeningDelay` after the *second* move instead.
       expect(opened).toHaveBeenCalledTimes(1);
     });
+
+    it('keeps a submenu-dwell timer armed for the freshly opened submenu, even with no wobble between the move that activated it and the dwell that opened it', () => {
+      using _timers = fakeTimers();
+      const host = navigationMachine.start({ model: submenuModel, options });
+
+      host.send('down', { position: [0, 0] });
+      vi.advanceTimersByTime(options.noviceDwellingTime); // Startup dwell -> novice at [0, 0]
+      expect(vi.getTimerCount()).toBe(1); // The root menu's own submenu-dwell timer
+
+      host.send('move', { position: [100, 0] }); // One significant move, straight onto "right"
+      expect(vi.getTimerCount()).toBe(1); // Restarted, not doubled or dropped
+
+      vi.advanceTimersByTime(options.submenuOpeningDelay); // Opens the submenu at [100, 0]
+      expect(host.current.name).toBe('novice');
+      expect(
+        host.current.name === 'novice' && host.current.data.menuCenter,
+      ).toEqual([100, 0]);
+      // The residency must rearm on entering the submenu too, not stay
+      // dropped because this particular transition's `dwellAnchor` happens
+      // to be the very same reference the residency's `restart` predicate
+      // compares against.
+      expect(vi.getTimerCount()).toBe(1);
+    });
   });
 });

--- a/src/engine/machine.ts
+++ b/src/engine/machine.ts
@@ -387,9 +387,17 @@ export const navigationMachine = machine({
     // that submenu: a genuine phase change, even though the destination is
     // named `novice` too. Anything else declines, and — since no other row
     // is declared for (novice, dwell) — the dwell is silently dropped.
-    'novice -dwell> novice'({ fromData, skip }) {
-      const { active, menuCenter, upperStroke, lowerStroke, options } =
-        fromData;
+    'novice -dwell> novice'({
+      fromData: {
+        active,
+        menuCenter,
+        upperStroke,
+        lowerStroke,
+        options,
+        model,
+      },
+      skip,
+    }) {
       const position = upperStroke.at(-1) as Point;
       const { radius } = toPolar(position, menuCenter);
       if (
@@ -401,7 +409,7 @@ export const navigationMachine = machine({
       }
 
       return {
-        model: fromData.model,
+        model,
         options,
         menu: active,
         menuCenter: position,

--- a/src/engine/machine.ts
+++ b/src/engine/machine.ts
@@ -38,6 +38,8 @@ export type NavigationOptions = {
   readonly movementsThreshold: number;
   readonly noviceDwellingTime: number;
   readonly minSelectionDist: number;
+  readonly minMenuSelectionDist: number;
+  readonly submenuOpeningDelay: number;
 };
 
 /**
@@ -71,6 +73,7 @@ export type NavigationState<M extends AnyModelNode> =
       readonly active: ModelItems<M> | null;
       readonly upperStroke: readonly Point[];
       readonly lowerStroke: readonly Point[];
+      readonly dwellAnchor: Point;
     };
 
 type NavigationInputs = {
@@ -103,6 +106,11 @@ type NavigationStates = {
     readonly active: AnyModelNode | null;
     readonly upperStroke: readonly Point[];
     readonly lowerStroke: readonly Point[];
+    // The last position significant movement was measured from: distinct
+    // from `menuCenter`, which stays fixed for the life of this menu. Only a
+    // move that carries this anchor forward can restart the submenu-dwell
+    // residency; see its `restart` predicate below.
+    readonly dwellAnchor: Point;
   };
 };
 
@@ -329,6 +337,7 @@ export const navigationMachine = machine({
       active: null,
       upperStroke: [origin],
       lowerStroke: stroke,
+      dwellAnchor: origin,
     }),
 
     'expert -move> expert': ({ fromData, inputData }) => ({
@@ -337,7 +346,7 @@ export const navigationMachine = machine({
     }),
 
     'novice -move> novice'({ fromData, inputData: { position } }) {
-      const { menuCenter, options, menu } = fromData;
+      const { menuCenter, options, menu, dwellAnchor } = fromData;
       const { azymuth, radius } = toPolar(position, menuCenter);
       const active =
         radius < options.minSelectionDist
@@ -347,6 +356,42 @@ export const navigationMachine = machine({
         ...fromData,
         active,
         upperStroke: [...fromData.upperStroke, position],
+        // A fresh reference only when movement is significant: the
+        // submenu-dwell residency's `restart` predicate below compares this
+        // by reference, so an unchanged anchor must stay the same object.
+        dwellAnchor:
+          dist(dwellAnchor, position) >= options.movementsThreshold
+            ? position
+            : dwellAnchor,
+      };
+    },
+
+    // Pausing beyond `minMenuSelectionDist` on a non-leaf active item opens
+    // that submenu: a genuine phase change, even though the destination is
+    // named `novice` too. Anything else declines, and — since no other row
+    // is declared for (novice, dwell) — the dwell is silently dropped.
+    'novice -dwell> novice'({ fromData, skip }) {
+      const { active, menuCenter, upperStroke, lowerStroke, options } =
+        fromData;
+      const position = upperStroke.at(-1) as Point;
+      const { radius } = toPolar(position, menuCenter);
+      if (
+        active === null ||
+        active.isLeaf ||
+        radius <= options.minMenuSelectionDist
+      ) {
+        return skip();
+      }
+
+      return {
+        model: fromData.model,
+        options,
+        menu: active,
+        menuCenter: position,
+        active: null,
+        upperStroke: [position],
+        lowerStroke: [...lowerStroke, ...upperStroke],
+        dwellAnchor: position,
       };
     },
 
@@ -385,6 +430,24 @@ export const navigationMachine = machine({
       restart: false,
     },
 
+    novice: {
+      run({ toData, send }) {
+        const timer = setTimeout(() => {
+          send('dwell');
+        }, toData.options.submenuOpeningDelay);
+        return () => {
+          clearTimeout(timer);
+        };
+      },
+      // Only a self-transition that carries `dwellAnchor` forward to a new
+      // position — significant movement, or the fresh centre a submenu open
+      // itself produces — restarts the residency; a small move, or a dwell
+      // that failed its own eligibility check and left the state unchanged,
+      // leaves the pending timer alone.
+      restart: ({ fromData, toData }) =>
+        fromData.dwellAnchor !== toData.dwellAnchor,
+    },
+
     'idle -down> startup'({ toData, emit }) {
       emit('start', new MarkingMenuStartEvent({ position: toData.origin }));
     },
@@ -415,6 +478,21 @@ export const navigationMachine = machine({
 
     'expert -move> expert'({ inputData, emit }) {
       emitNullActiveMove(emit, 'expert', inputData.position);
+    },
+
+    // Same shape as `'startup -dwell> novice'`'s own `open`, one recursion
+    // level down: the row above already declined the input unless the
+    // dwell landed beyond `minMenuSelectionDist` on a non-leaf, so an
+    // eligible submenu is all this action ever announces.
+    'novice -dwell> novice'({ toData, emit }) {
+      emit(
+        'open',
+        openEvent({
+          position: toData.menuCenter,
+          menu: toData.menu,
+          menuCenter: toData.menuCenter,
+        }),
+      );
     },
 
     // `move` always fires; `change` only when the nearest item differs from

--- a/src/engine/machine.ts
+++ b/src/engine/machine.ts
@@ -261,8 +261,8 @@ function cancelEvent<N extends AnyModelNode>(data: {
 
 /**
  Shared body of the `startup` and `novice` dwell residencies: arm a `dwell`
- timer for `delayMs` and clear it on exit, whatever ends the residency —
- leaving the state, or disposal.
+ timer for `delayMs` and clear it on exit, whatever ends the residency,
+ whether that is leaving the state or disposal.
  */
 function armDwellTimer(
   delayMs: number,
@@ -385,8 +385,8 @@ export const navigationMachine = machine({
 
     // Pausing beyond `minMenuSelectionDist` on a non-leaf active item opens
     // that submenu: a genuine phase change, even though the destination is
-    // named `novice` too. Anything else declines, and — since no other row
-    // is declared for (novice, dwell) — the dwell is silently dropped.
+    // named `novice` too. Anything else declines, and since no other row is
+    // declared for (novice, dwell), the dwell is silently dropped.
     'novice -dwell> novice'({
       fromData: {
         active,
@@ -418,8 +418,8 @@ export const navigationMachine = machine({
         lowerStroke: [...lowerStroke, ...upperStroke],
         // A fresh reference, deliberately never `position` itself: opening a
         // submenu must always restart the residency for the new menu, and
-        // `position` is `upperStroke.at(-1)`, which — with no wobble between
-        // the move that armed this dwell and the dwell itself — is the very
+        // `position` is `upperStroke.at(-1)`. With no wobble between the
+        // move that armed this dwell and the dwell itself, that is the very
         // same reference `fromData.dwellAnchor` already holds.
         dwellAnchor: [...position],
       };
@@ -458,10 +458,10 @@ export const navigationMachine = machine({
       run: ({ toData, send }) =>
         armDwellTimer(toData.options.submenuOpeningDelay, send),
       // Only a self-transition that carries `dwellAnchor` forward to a new
-      // position — significant movement, or the fresh centre a submenu open
-      // itself produces — restarts the residency; a small move, or a dwell
-      // that failed its own eligibility check and left the state unchanged,
-      // leaves the pending timer alone.
+      // position restarts the residency, whether from significant movement
+      // or the fresh centre a submenu open itself produces. A small move,
+      // or a dwell that failed its own eligibility check and left the state
+      // unchanged, leaves the pending timer alone.
       restart: ({ fromData, toData }) =>
         fromData.dwellAnchor !== toData.dwellAnchor,
     },

--- a/src/engine/machine.ts
+++ b/src/engine/machine.ts
@@ -260,6 +260,23 @@ function cancelEvent<N extends AnyModelNode>(data: {
 }
 
 /**
+ Shared body of the `startup` and `novice` dwell residencies: arm a `dwell`
+ timer for `delayMs` and clear it on exit, whatever ends the residency —
+ leaving the state, or disposal.
+ */
+function armDwellTimer(
+  delayMs: number,
+  send: (input: 'dwell') => void,
+): () => void {
+  const timer = setTimeout(() => {
+    send('dwell');
+  }, delayMs);
+  return () => {
+    clearTimeout(timer);
+  };
+}
+
+/**
  The context every termination action needs: the stroke drawn so far
  (including the release/cancel position), the menu open when it ended (if
  any), and the item that was active (if any). That active item is precisely
@@ -391,7 +408,12 @@ export const navigationMachine = machine({
         active: null,
         upperStroke: [position],
         lowerStroke: [...lowerStroke, ...upperStroke],
-        dwellAnchor: position,
+        // A fresh reference, deliberately never `position` itself: opening a
+        // submenu must always restart the residency for the new menu, and
+        // `position` is `upperStroke.at(-1)`, which — with no wobble between
+        // the move that armed this dwell and the dwell itself — is the very
+        // same reference `fromData.dwellAnchor` already holds.
+        dwellAnchor: [...position],
       };
     },
 
@@ -417,28 +439,16 @@ export const navigationMachine = machine({
     },
 
     startup: {
-      run({ toData, send }) {
-        const timer = setTimeout(() => {
-          send('dwell');
-        }, toData.options.noviceDwellingTime);
-        return () => {
-          clearTimeout(timer);
-        };
-      },
+      run: ({ toData, send }) =>
+        armDwellTimer(toData.options.noviceDwellingTime, send),
       // The dwell is armed once, on arrival: a self-transition (growing the
       // stroke below the movement threshold) must never restart it.
       restart: false,
     },
 
     novice: {
-      run({ toData, send }) {
-        const timer = setTimeout(() => {
-          send('dwell');
-        }, toData.options.submenuOpeningDelay);
-        return () => {
-          clearTimeout(timer);
-        };
-      },
+      run: ({ toData, send }) =>
+        armDwellTimer(toData.options.submenuOpeningDelay, send),
       // Only a self-transition that carries `dwellAnchor` forward to a new
       // position — significant movement, or the fresh centre a submenu open
       // itself produces — restarts the residency; a small move, or a dwell

--- a/src/engine/runtime.test.ts
+++ b/src/engine/runtime.test.ts
@@ -7,6 +7,8 @@ const options = {
   movementsThreshold: 5,
   noviceDwellingTime: 300,
   minSelectionDist: 40,
+  minMenuSelectionDist: 80,
+  submenuOpeningDelay: 200,
 };
 
 const createFakeRenderer = () => ({


### PR DESCRIPTION
Closes #182.

In novice mode, the menu only ever pointed at items; it had no way to descend into one that held its own items. Objective 9 of the RxJS-removal machine (#153) calls for a submenu to open when the pointer pauses beyond `minMenuSelectionDist` on a non-leaf item for `submenuOpeningDelay`, mirroring the delay that already opens the root menu from startup.

The fix mirrors the machine's existing `startup` dwell: `novice` now carries its own dwell residency, armed on entering the state and restarted only when the pointer moves significantly. Firing the dwell while resting on an eligible non-leaf item transitions `novice` into `novice` again, but at the submenu, with a new center and a reset active item, a nested `open` event, and the outgoing menu's stroke folded into the accumulated lower stroke while the visible upper stroke starts fresh. Because the machine already treats `novice`'s menu and active item generically rather than assuming the root, selection and cancellation work at any depth without further changes.

Restarting the residency only on genuine movement, rather than on every pointer sample, needed a small anchor tracked alongside the existing stroke: it moves only when a pointer sample is far enough from it, and the residency compares that anchor by reference to decide whether to reset its timer. One case fell out of that comparison during review: opening a submenu from a single decisive move, with no wobble in between, left the new submenu's anchor pointing at the very same object the old one held, so the fresh submenu never got its own timer armed. It recovered as soon as the pointer moved again, but nothing guaranteed that would happen, so the anchor a submenu opens with is now always a fresh reference.

To check it by hand, run the demo, hold the pointer past the outer ring on an item with children, and wait: its own ring should appear centered where the pointer paused, with the outer stroke drawn from there rather than from the gesture's start.

This lands entirely inside the machine and controller tests; the change carries no public API surface yet; so it ships with no changeset.