### PR TITLE
Expert dwell falls back to novice; exhaustive lifecycle, reentrancy and failure

### DIFF
--- a/src/engine/controller.test-d.ts
+++ b/src/engine/controller.test-d.ts
@@ -42,11 +42,9 @@ describe('createController', () => {
     expectTypeOf(controller.dispose).toEqualTypeOf<() => void>();
   });
 
-  it('exposes exactly the listen-only facade and disposal, nothing else', () => {
-    // Notably no `[Symbol.dispose]`: requiring `using` of consumers is not
-    // something this library does. See `controller.ts`.
+  it('exposes exactly the listen-only facade and both forms of disposal, nothing else', () => {
     expectTypeOf<keyof MarkingMenuController<M>>().toEqualTypeOf<
-      'on' | 'off' | 'dispose'
+      'on' | 'off' | 'dispose' | typeof Symbol.dispose
     >();
   });
 });

--- a/src/engine/controller.test.ts
+++ b/src/engine/controller.test.ts
@@ -210,7 +210,7 @@ describe('createController', () => {
     }).not.toThrow();
   });
 
-  it('is also disposable through [Symbol.dispose](), terminal and idempotent the same way as dispose()', () => {
+  it('is also disposable through [Symbol.dispose](), same as dispose()', () => {
     using _canvases = stubbedCanvasContexts();
     const parent = createParent();
     const controller = createController({ items, parent });
@@ -244,7 +244,7 @@ describe('createController', () => {
     expect(parent.style.getPropertyValue('touch-action')).toBe('');
   });
 
-  it('does not restore touch-action while a second controller on the same parent still holds its own claim', () => {
+  it('keeps touch-action while another controller on the parent still holds a claim', () => {
     using _canvases = stubbedCanvasContexts();
     const parent = createParent();
     const first = createController({ items, parent });
@@ -259,7 +259,7 @@ describe('createController', () => {
     expect(parent.style.getPropertyValue('touch-action')).toBe('');
   });
 
-  it('does not let a throwing consumer listener affect the controller: the gesture proceeds and remaining listeners still run', () => {
+  it('isolates a throwing consumer listener: the gesture proceeds and other listeners still run', () => {
     using _canvases = stubbedCanvasContexts();
     const parent = createParent();
     const controller = createController({ items, parent });
@@ -1126,7 +1126,7 @@ describe('createController', () => {
       { id: 'up', label: 'Up' },
     ] as const;
 
-    it('switches to novice, rooted at the menu the dwell recognizes, once an expert gesture pauses on a submenu', () => {
+    it('switches to novice, rooted at the menu the dwell recognizes', () => {
       using _canvases = stubbedCanvasContexts();
       using _timers = fakeTimers();
       const parent = createParent();
@@ -1168,7 +1168,7 @@ describe('createController', () => {
       controller.dispose();
     });
 
-    it('cancels the expert attempt, without ever selecting, when the dwell recognizes no menu but the root', () => {
+    it('cancels the expert attempt when the dwell recognizes only the root', () => {
       using _canvases = stubbedCanvasContexts();
       using _timers = fakeTimers();
       const parent = createParent();

--- a/src/engine/controller.test.ts
+++ b/src/engine/controller.test.ts
@@ -1109,7 +1109,7 @@ describe('createController', () => {
     });
   });
 
-  describe('mid-expert dwell falling back to novice, or canceling (objective 14)', () => {
+  describe('mid-expert dwell falling back to novice, or canceling', () => {
     const submenuItems = [
       {
         id: 'right',

--- a/src/engine/controller.test.ts
+++ b/src/engine/controller.test.ts
@@ -181,12 +181,17 @@ describe('createController', () => {
 
     const selected = voidMock<[MarkingMenuSelectEvent<AnyModelNode>]>();
     controller.on('select', selected);
+    // Disposal mid-gesture is silent: no final `cancel`, or any other public
+    // event, is ever dispatched for it.
+    const cancelled = voidMock<[MarkingMenuCancelEvent<AnyModelNode>]>();
+    controller.on('cancel', cancelled);
 
     controller.dispose();
 
     expect(parent.querySelectorAll('canvas')).toHaveLength(0);
     expect(parent.style.getPropertyValue('touch-action')).toBe('');
     expect(parent.style.cursor).toBe('');
+    expect(cancelled).not.toHaveBeenCalled();
 
     // Disposal happened mid-gesture, so the capture the gesture took is the
     // controller's to give back: nothing else will ever release it.
@@ -198,10 +203,88 @@ describe('createController', () => {
     // Further pointer input is inert: the DOM listeners are gone.
     parent.dispatchEvent(pointer('pointerup', { clientX: 120, clientY: 0 }));
     expect(selected).not.toHaveBeenCalled();
+    expect(cancelled).not.toHaveBeenCalled();
 
     expect(() => {
       controller.dispose();
     }).not.toThrow();
+  });
+
+  it('is also disposable through [Symbol.dispose](), terminal and idempotent the same way as dispose()', () => {
+    using _canvases = stubbedCanvasContexts();
+    const parent = createParent();
+    const controller = createController({ items, parent });
+
+    parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
+    expect(parent.style.getPropertyValue('touch-action')).toBe('none');
+
+    controller[Symbol.dispose]();
+
+    expect(parent.style.getPropertyValue('touch-action')).toBe('');
+    expect(parent.querySelectorAll('canvas')).toHaveLength(0);
+
+    // Idempotent, and interchangeable with dispose(): whichever runs first
+    // wins, the other is a no-op.
+    expect(() => {
+      controller.dispose();
+      controller[Symbol.dispose]();
+    }).not.toThrow();
+  });
+
+  it('disposes via `using`, releasing everything at the end of the block', () => {
+    using _canvases = stubbedCanvasContexts();
+    const parent = createParent();
+
+    {
+      using _controller = createController({ items, parent });
+      parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
+      expect(parent.style.getPropertyValue('touch-action')).toBe('none');
+    }
+
+    expect(parent.style.getPropertyValue('touch-action')).toBe('');
+  });
+
+  it('does not restore touch-action while a second controller on the same parent still holds its own claim', () => {
+    using _canvases = stubbedCanvasContexts();
+    const parent = createParent();
+    const first = createController({ items, parent });
+    const second = createController({ items, parent });
+
+    expect(parent.style.getPropertyValue('touch-action')).toBe('none');
+
+    first.dispose();
+    expect(parent.style.getPropertyValue('touch-action')).toBe('none');
+
+    second.dispose();
+    expect(parent.style.getPropertyValue('touch-action')).toBe('');
+  });
+
+  it('does not let a throwing consumer listener affect the controller: the gesture proceeds and remaining listeners still run', () => {
+    using _canvases = stubbedCanvasContexts();
+    const parent = createParent();
+    const controller = createController({ items, parent });
+
+    controller.on('start', () => {
+      throw new Error('boom');
+    });
+    const alsoNotified = voidMock<[MarkingMenuStartEvent]>();
+    controller.on('start', alsoNotified);
+
+    expect(() => {
+      parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
+    }).not.toThrow();
+    expect(alsoNotified).toHaveBeenCalledTimes(1);
+
+    let selectedId: string | undefined;
+    controller.on('select', (event) => {
+      selectedId = event.selection.id;
+    });
+    parent.dispatchEvent(pointer('pointermove', { clientX: 100, clientY: 0 }));
+    parent.dispatchEvent(pointer('pointerup', { clientX: 120, clientY: 0 }));
+
+    expect(selectedId).toBe('right');
+
+    controller.dispose();
   });
 
   it('freezes position on start and select, and dispatches select after the DOM is fully rendered', () => {
@@ -1021,6 +1104,101 @@ describe('createController', () => {
       expect(cancelEvent?.mode).toBe('novice');
       expect(cancelEvent?.active).toBeNull();
       expect(cancelEvent?.menu).toBe(submenu);
+
+      controller.dispose();
+    });
+  });
+
+  describe('mid-expert dwell falling back to novice, or canceling (objective 14)', () => {
+    const submenuItems = [
+      {
+        id: 'right',
+        label: 'Right',
+        items: [
+          { id: 'subRight', label: 'Sub Right' },
+          { id: 'subDown', label: 'Sub Down' },
+          { id: 'subLeft', label: 'Sub Left' },
+          { id: 'subUp', label: 'Sub Up' },
+        ],
+      },
+      { id: 'down', label: 'Down' },
+      { id: 'left', label: 'Left' },
+      { id: 'up', label: 'Up' },
+    ] as const;
+
+    it('switches to novice, rooted at the menu the dwell recognizes, once an expert gesture pauses on a submenu', () => {
+      using _canvases = stubbedCanvasContexts();
+      using _timers = fakeTimers();
+      const parent = createParent();
+      const controller = createController({
+        items: submenuItems,
+        parent,
+        noviceDwellingTime: 100,
+      });
+
+      const opened: Array<MarkingMenuOpenEvent<AnyModelNode>> = [];
+      controller.on('open', (event) => {
+        opened.push(event);
+      });
+
+      parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
+      // Crosses movementsThreshold straight onto "right": expert mode.
+      parent.dispatchEvent(
+        pointer('pointermove', { clientX: 100, clientY: 0 }),
+      );
+      vi.advanceTimersByTime(100); // The mid-expert dwell fires.
+
+      expect(opened).toHaveLength(1);
+      expect(opened[0]?.mode).toBe('novice');
+      expect(opened[0]?.menuCenter).toEqual([100, 0]);
+      expect(parent.querySelector('.marking-menu')).not.toBeNull();
+
+      // Selection now works at this depth, exactly as if novice had opened
+      // the submenu by dwelling on it directly.
+      let selectedId: string | undefined;
+      controller.on('select', (event) => {
+        selectedId = event.selection.id;
+      });
+      parent.dispatchEvent(
+        pointer('pointermove', { clientX: 200, clientY: 0 }),
+      );
+      parent.dispatchEvent(pointer('pointerup', { clientX: 200, clientY: 0 }));
+      expect(selectedId).toBe('subRight');
+
+      controller.dispose();
+    });
+
+    it('cancels the expert attempt, without ever selecting, when the dwell recognizes no menu but the root', () => {
+      using _canvases = stubbedCanvasContexts();
+      using _timers = fakeTimers();
+      const parent = createParent();
+      const controller = createController({
+        items, // The plain, leaf-only fixture: every dwell recognizes the root.
+        parent,
+        noviceDwellingTime: 100,
+      });
+
+      const selected = voidMock<[MarkingMenuSelectEvent<AnyModelNode>]>();
+      controller.on('select', selected);
+      const opened = voidMock<[MarkingMenuOpenEvent<AnyModelNode>]>();
+      controller.on('open', opened);
+      let cancelEvent: MarkingMenuCancelEvent<AnyModelNode> | undefined;
+      controller.on('cancel', (event) => {
+        cancelEvent = event;
+      });
+
+      parent.dispatchEvent(pointer('pointerdown', { clientX: 0, clientY: 0 }));
+      parent.dispatchEvent(
+        pointer('pointermove', { clientX: 100, clientY: 0 }),
+      );
+      vi.advanceTimersByTime(100); // The mid-expert dwell fires.
+
+      expect(opened).not.toHaveBeenCalled();
+      expect(selected).not.toHaveBeenCalled();
+      expect(cancelEvent?.mode).toBe('expert');
+      expect(cancelEvent?.active).toBeNull();
+      expect(cancelEvent?.menu).toBeNull();
+      expect(parent.querySelector('.marking-menu')).toBeNull();
 
       controller.dispose();
     });

--- a/src/engine/controller.ts
+++ b/src/engine/controller.ts
@@ -2,6 +2,7 @@ import type {
   MarkingMenuEventEmitter,
   MarkingMenuEventMap,
 } from '../events.js';
+import type { MarkingMenuLogger } from '../marking-menu.js';
 import {
   createModel,
   type MarkingMenuModel,
@@ -9,6 +10,7 @@ import {
 } from '../model.js';
 import type { TypedEventListener } from '../typed-event-emitter.js';
 import type { AnyModelNode, MarkingMenuInput } from '../types.js';
+import { noOp } from '../utils.js';
 import { createPointerSource, type PointerSource } from './pointer-source.js';
 import { createRenderer } from './renderer.js';
 import { createRuntime, type NavigationRuntime } from './runtime.js';
@@ -20,17 +22,27 @@ export type EngineConfig = MarkingMenuInput & {
   readonly minSelectionDist?: number;
   readonly minMenuSelectionDist?: number;
   readonly submenuOpeningDelay?: number;
+  /**
+  Override the default logger used to report internal failures.
+  */
+  readonly log?: Partial<MarkingMenuLogger>;
 };
 
-/*
- No `Disposable`/`[Symbol.dispose]`, deliberately. `using` is syntax, so a
- consumer on a runtime without it cannot even parse the call site, and support
- sits around 70%. `dispose()` is the whole disposal contract; a `using`-capable
- consumer can still wrap this themselves.
+const defaultLogger: MarkingMenuLogger = {
+  error: console?.error?.bind(console) ?? noOp,
+};
+
+/**
+ `dispose()` is the whole disposal contract, both terminal and idempotent;
+ `[Symbol.dispose]()` delegates to it so `using controller = createController(
+ config)` works wherever Explicit Resource Management is supported. Neither
+ patches `Symbol` nor ships a polyfill: a consumer without native support
+ cannot even parse a `using` call site and owns any transpilation it needs.
  */
 export type MarkingMenuController<M extends AnyModelNode> =
   MarkingMenuEventEmitter<M> & {
     dispose(): void;
+    [Symbol.dispose](): void;
   };
 
 /**
@@ -82,6 +94,7 @@ class Controller<Config extends EngineConfig> implements MarkingMenuController<
         submenuOpeningDelay: config.submenuOpeningDelay ?? 100,
       },
       renderer,
+      log: { ...defaultLogger, ...config.log },
     });
     this.#pointerSource = createPointerSource({
       parent: config.parent,
@@ -114,6 +127,10 @@ class Controller<Config extends EngineConfig> implements MarkingMenuController<
     // touch-action claim.
     this.#runtime.dispose();
     this.#pointerSource.dispose();
+  }
+
+  [Symbol.dispose](): void {
+    this.dispose();
   }
 }
 

--- a/src/engine/machine.test.ts
+++ b/src/engine/machine.test.ts
@@ -112,7 +112,7 @@ describe('navigationMachine', () => {
     expect(host.current.name).toBe('startup');
   });
 
-  it('ignores a second down while a gesture is already in progress, in both startup and expert (the pointer source is the primary guard; the machine covers it defensively too)', () => {
+  it('ignores a second down while a gesture is already in progress, in startup, expert and novice alike (the pointer source is the primary guard; the machine covers it defensively too, objective 15)', () => {
     const host = startHost();
 
     host.send('down', { position: [0, 0] });
@@ -124,6 +124,12 @@ describe('navigationMachine', () => {
     const afterExpert = host.current;
     host.send('down', { position: [5, 5] });
     expect(host.current).toEqual(afterExpert);
+
+    host.send('up', { position: [100, 0] });
+    openNovice(host);
+    const afterNovice = host.current;
+    host.send('down', { position: [5, 5] });
+    expect(host.current).toEqual(afterNovice);
   });
 
   it('ignores stray movement or release input while idle', () => {
@@ -271,23 +277,115 @@ describe('navigationMachine', () => {
 
       host.send('move', { position: [100, 0] });
       expect(host.current.name).toBe('expert');
-      expect(vi.getTimerCount()).toBe(0);
+      // The startup dwell is gone, replaced by expert's own mid-gesture
+      // dwell (objective 14): still exactly one timer, never zero or two.
+      expect(vi.getTimerCount()).toBe(1);
     });
+  });
 
-    it('declines a dwell that arrives after startup has been left, as a silent no-op', () => {
-      const host = startHost();
+  describe('expert phase: dwelling into novice or canceling (objective 14)', () => {
+    it('switches to novice rooted at the menu a mid-expert dwell recognizes', () => {
+      const host = navigationMachine.start({ model: submenuModel, options });
+      const opened: unknown[] = [];
+      host.on('open', ({ data }) => {
+        opened.push(data);
+      });
+
       host.send('down', { position: [0, 0] });
-      host.send('move', { position: [100, 0] });
+      host.send('move', { position: [100, 0] }); // Crosses the threshold, onto "right"
       expect(host.current.name).toBe('expert');
-      const afterExpert = host.current;
-
-      const opened = vi.fn<() => void>();
-      host.on('open', opened);
 
       host.send('dwell');
 
-      expect(host.current).toEqual(afterExpert);
+      expect(host.current.name).toBe('novice');
+      const data = host.current.name === 'novice' ? host.current.data : null;
+      const rightMenu = (submenuModel as unknown as { items: unknown[] })
+        .items[0];
+      expect(data?.menu).toBe(rightMenu);
+      expect(data?.menuCenter).toEqual([100, 0]);
+      expect(data?.active).toBeNull();
+
+      expect(opened).toHaveLength(1);
+      const event = opened[0] as {
+        mode: string;
+        menu: unknown;
+        menuCenter: number[];
+      };
+      expect(event.mode).toBe('novice');
+      expect(event.menu).toBe(rightMenu);
+      expect(event.menuCenter).toEqual([100, 0]);
+    });
+
+    it('accumulates the expert stroke into the lower stroke when switching to novice', () => {
+      const host = navigationMachine.start({ model: submenuModel, options });
+
+      host.send('down', { position: [0, 0] });
+      host.send('move', { position: [100, 0] });
+      host.send('dwell');
+
+      const data = host.current.name === 'novice' ? host.current.data : null;
+      expect(data?.upperStroke).toEqual([[100, 0]]);
+      expect(data?.lowerStroke).toEqual([
+        [0, 0],
+        [100, 0],
+      ]);
+    });
+
+    it('cancels the expert attempt, without ever selecting, when the dwell recognizes no menu but the root', () => {
+      const host = startHost(); // The plain, leaf-only fixture model: every dwell recognizes the root.
+      const selected = vi.fn<() => void>();
+      host.on('select', selected);
+      const opened = vi.fn<() => void>();
+      host.on('open', opened);
+      let cancelData:
+        { active: unknown; menu: unknown; mode: string } | undefined;
+      host.on('cancel', ({ data }) => {
+        cancelData = data;
+      });
+
+      host.send('down', { position: [0, 0] });
+      host.send('move', { position: [100, 0] });
+      expect(host.current.name).toBe('expert');
+
+      host.send('dwell');
+
+      expect(host.current.name).toBe('idle');
       expect(opened).not.toHaveBeenCalled();
+      expect(selected).not.toHaveBeenCalled();
+      expect(cancelData?.mode).toBe('expert');
+      expect(cancelData?.active).toBeNull();
+      expect(cancelData?.menu).toBeNull();
+    });
+
+    it('restarts the mid-expert dwell on significant movement rather than firing early', () => {
+      using _timers = fakeTimers();
+      const host = startHost();
+
+      host.send('down', { position: [0, 0] });
+      host.send('move', { position: [100, 0] }); // Enters expert, arms the dwell
+      expect(vi.getTimerCount()).toBe(1);
+
+      vi.advanceTimersByTime(options.noviceDwellingTime - 10);
+      host.send('move', { position: [200, 0] }); // Significant: restarts it
+      vi.advanceTimersByTime(10);
+
+      expect(host.current.name).toBe('expert'); // Would have fired here without the reset.
+
+      vi.advanceTimersByTime(options.noviceDwellingTime - 10);
+      expect(host.current.name).toBe('idle'); // Fires noviceDwellingTime after the second move instead.
+    });
+
+    it('leaves a pending mid-expert dwell untouched by insignificant movement', () => {
+      using _timers = fakeTimers();
+      const host = startHost();
+
+      host.send('down', { position: [0, 0] });
+      host.send('move', { position: [100, 0] });
+      vi.advanceTimersByTime(options.noviceDwellingTime - 10);
+      host.send('move', { position: [102, 0] }); // Insignificant (<5px): must not reset it
+      vi.advanceTimersByTime(10);
+
+      expect(host.current.name).toBe('idle');
     });
   });
 

--- a/src/engine/machine.test.ts
+++ b/src/engine/machine.test.ts
@@ -112,7 +112,7 @@ describe('navigationMachine', () => {
     expect(host.current.name).toBe('startup');
   });
 
-  it('ignores a second down while a gesture is already in progress, in startup, expert and novice alike (the pointer source is the primary guard; the machine covers it defensively too, objective 15)', () => {
+  it('ignores a second down while a gesture is already in progress, in startup, expert and novice alike (the pointer source is the primary guard; the machine covers it defensively too)', () => {
     const host = startHost();
 
     host.send('down', { position: [0, 0] });
@@ -278,12 +278,12 @@ describe('navigationMachine', () => {
       host.send('move', { position: [100, 0] });
       expect(host.current.name).toBe('expert');
       // The startup dwell is gone, replaced by expert's own mid-gesture
-      // dwell (objective 14): still exactly one timer, never zero or two.
+      // dwell: still exactly one timer, never zero or two.
       expect(vi.getTimerCount()).toBe(1);
     });
   });
 
-  describe('expert phase: dwelling into novice or canceling (objective 14)', () => {
+  describe('expert phase: dwelling into novice or canceling', () => {
     it('switches to novice rooted at the menu a mid-expert dwell recognizes', () => {
       const host = navigationMachine.start({ model: submenuModel, options });
       const opened: unknown[] = [];

--- a/src/engine/machine.test.ts
+++ b/src/engine/machine.test.ts
@@ -112,7 +112,8 @@ describe('navigationMachine', () => {
     expect(host.current.name).toBe('startup');
   });
 
-  it('ignores a second down while a gesture is already in progress, in startup, expert and novice alike (the pointer source is the primary guard; the machine covers it defensively too)', () => {
+  // The pointer source is the primary guard; the machine covers it defensively too.
+  it('ignores a second down mid-gesture, in startup, expert, and novice alike', () => {
     const host = startHost();
 
     host.send('down', { position: [0, 0] });
@@ -284,7 +285,7 @@ describe('navigationMachine', () => {
   });
 
   describe('expert phase: dwelling into novice or canceling', () => {
-    it('switches to novice rooted at the menu a mid-expert dwell recognizes', () => {
+    it('switches to novice rooted at the recognized menu', () => {
       const host = navigationMachine.start({ model: submenuModel, options });
       const opened: unknown[] = [];
       host.on('open', ({ data }) => {
@@ -331,7 +332,7 @@ describe('navigationMachine', () => {
       ]);
     });
 
-    it('cancels the expert attempt, without ever selecting, when the dwell recognizes no menu but the root', () => {
+    it('cancels the expert attempt when the dwell recognizes only the root', () => {
       const host = startHost(); // The plain, leaf-only fixture model: every dwell recognizes the root.
       const selected = vi.fn<() => void>();
       host.on('select', selected);
@@ -357,7 +358,7 @@ describe('navigationMachine', () => {
       expect(cancelData?.menu).toBeNull();
     });
 
-    it('restarts the mid-expert dwell on significant movement rather than firing early', () => {
+    it('restarts the mid-expert dwell on significant movement', () => {
       using _timers = fakeTimers();
       const host = startHost();
 

--- a/src/engine/machine.ts
+++ b/src/engine/machine.ts
@@ -377,7 +377,7 @@ export const navigationMachine = machine({
 
     // Mid-expert dwell recognizes the stroke drawn so far as a menu, not a
     // leaf: a non-root match switches to novice rooted there. Anything else
-    // — no match, or the root itself — falls through to the unconditional
+    // (no match, or the root itself) falls through to the unconditional
     // row below, which cancels the expert attempt outright rather than
     // waiting for a release that recognition already knows will fail.
     'expert -dwell> novice'({ fromData: { model, options, stroke }, skip }) {
@@ -503,8 +503,8 @@ export const navigationMachine = machine({
       run: ({ toData, send }) =>
         armDwellTimer(toData.options.noviceDwellingTime, send),
       // Same rationale as novice's own submenu-dwell residency: only a
-      // self-transition that carries `dwellAnchor` forward to a new position
-      // — significant movement — restarts the pending dwell.
+      // self-transition that carries `dwellAnchor` forward to a new position,
+      // i.e. significant movement, restarts the pending dwell.
       restart: ({ fromData, toData }) =>
         fromData.dwellAnchor !== toData.dwellAnchor,
     },

--- a/src/engine/machine.ts
+++ b/src/engine/machine.ts
@@ -97,6 +97,10 @@ type NavigationStates = {
     readonly model: AnyModelNode;
     readonly options: NavigationOptions;
     readonly stroke: readonly Point[];
+    // Same role as novice's own `dwellAnchor`: the last position significant
+    // movement was measured from, compared by reference in the residency's
+    // `restart` predicate below.
+    readonly dwellAnchor: Point;
   };
   novice: {
     readonly model: AnyModelNode;
@@ -332,7 +336,7 @@ export const navigationMachine = machine({
     }) {
       const newStroke = [...stroke, position];
       return dist(origin, position) >= options.movementsThreshold
-        ? { model, options, stroke: newStroke }
+        ? { model, options, stroke: newStroke, dwellAnchor: position }
         : skip();
     },
 
@@ -357,10 +361,51 @@ export const navigationMachine = machine({
       dwellAnchor: origin,
     }),
 
-    'expert -move> expert': ({ fromData, inputData }) => ({
-      ...fromData,
-      stroke: [...fromData.stroke, inputData.position],
-    }),
+    'expert -move> expert'({ fromData, inputData: { position } }) {
+      const { dwellAnchor, options } = fromData;
+      return {
+        ...fromData,
+        stroke: [...fromData.stroke, position],
+        // A fresh reference only on significant movement, same rationale as
+        // novice's own `dwellAnchor` update below.
+        dwellAnchor:
+          dist(dwellAnchor, position) >= options.movementsThreshold
+            ? position
+            : dwellAnchor,
+      };
+    },
+
+    // Mid-expert dwell recognizes the stroke drawn so far as a menu, not a
+    // leaf: a non-root match switches to novice rooted there. Anything else
+    // — no match, or the root itself — falls through to the unconditional
+    // row below, which cancels the expert attempt outright rather than
+    // waiting for a release that recognition already knows will fail.
+    'expert -dwell> novice'({ fromData: { model, options, stroke }, skip }) {
+      const menu = recognizeMarkingMenuStroke(stroke, model, {
+        maxDepth: -1,
+        requireMenu: true,
+      });
+      if (menu === null || menu.isRoot) {
+        return skip();
+      }
+
+      const position = stroke.at(-1) as Point;
+      return {
+        model,
+        options,
+        menu,
+        menuCenter: position,
+        active: null,
+        upperStroke: [position],
+        lowerStroke: stroke,
+        dwellAnchor: [...position],
+      };
+    },
+
+    // The row above declined: no menu was recognized, or it was the root.
+    'expert -dwell> idle'({ fromData: { model, options } }) {
+      return { model, options };
+    },
 
     'novice -move> novice'({ fromData, inputData: { position } }) {
       const { menuCenter, options, menu, dwellAnchor } = fromData;
@@ -454,6 +499,16 @@ export const navigationMachine = machine({
       restart: false,
     },
 
+    expert: {
+      run: ({ toData, send }) =>
+        armDwellTimer(toData.options.noviceDwellingTime, send),
+      // Same rationale as novice's own submenu-dwell residency: only a
+      // self-transition that carries `dwellAnchor` forward to a new position
+      // — significant movement — restarts the pending dwell.
+      restart: ({ fromData, toData }) =>
+        fromData.dwellAnchor !== toData.dwellAnchor,
+    },
+
     novice: {
       run: ({ toData, send }) =>
         armDwellTimer(toData.options.submenuOpeningDelay, send),
@@ -496,6 +551,32 @@ export const navigationMachine = machine({
 
     'expert -move> expert'({ inputData, emit }) {
       emitNullActiveMove(emit, 'expert', inputData.position);
+    },
+
+    // Same shape as `'startup -dwell> novice'`'s own `open`: the row above
+    // already confirmed the recognized menu is eligible, so this action only
+    // ever announces one.
+    'expert -dwell> novice'({ fromData, toData, emit }) {
+      emit(
+        'open',
+        openEvent({
+          position: fromData.stroke.at(-1) as Point,
+          menu: toData.menu,
+          menuCenter: toData.menuCenter,
+        }),
+      );
+    },
+
+    // No selection was ever attempted: the dwell fired before a release,
+    // and recognition already found nothing worth switching to.
+    'expert -dwell> idle'({ fromData, emit }) {
+      const { stroke } = fromData;
+      const position = stroke.at(-1) as Point;
+      emit('feedback', { stroke, canceled: true });
+      emit(
+        'cancel',
+        cancelEvent({ mode: 'expert', position, active: null, menu: null }),
+      );
     },
 
     // Same shape as `'startup -dwell> novice'`'s own `open`, one recursion

--- a/src/engine/runtime.test.ts
+++ b/src/engine/runtime.test.ts
@@ -307,7 +307,7 @@ describe('createRuntime', () => {
 
       runtime.on('start', () => {
         // Re-entrant, queued behind the current batch (same mechanism the
-        // existing reentrancy test above exercises) — but this time,
+        // existing reentrancy test above exercises), but this time,
         // disposal happens before it can ever be observed.
         runtime.send({ type: 'pointer.up', position: [100, 0] });
         runtime.dispose();

--- a/src/engine/runtime.test.ts
+++ b/src/engine/runtime.test.ts
@@ -212,7 +212,7 @@ describe('createRuntime', () => {
   });
 
   describe('internal failure', () => {
-    it('tears down, logs, then rethrows, when reacting to the machine own layout output fails', () => {
+    it('tears down, logs, then rethrows when the layout output fails', () => {
       const renderer = createFakeRenderer();
       const failure = new Error('boom');
       renderer.render.mockImplementationOnce(() => {
@@ -236,7 +236,7 @@ describe('createRuntime', () => {
       }).toThrow('disposed');
     });
 
-    it('tears down, logs, then rethrows, when reacting to the machine own feedback output fails', () => {
+    it('tears down, logs, then rethrows when the feedback output fails', () => {
       const renderer = createFakeRenderer();
       const failure = new Error('boom');
       renderer.showFeedback.mockImplementationOnce(() => {
@@ -254,7 +254,7 @@ describe('createRuntime', () => {
       expect(log.error).toHaveBeenCalledExactlyOnceWith(failure);
     });
 
-    it('logs and suppresses a teardown failure while unwinding a primary failure, and rethrows only the original', () => {
+    it('suppresses a teardown failure while unwinding a primary one, rethrows the original', () => {
       const renderer = createFakeRenderer();
       const primaryFailure = new Error('primary');
       const teardownFailure = new Error('teardown');
@@ -296,7 +296,7 @@ describe('createRuntime', () => {
   });
 
   describe('reentrancy and disposal mid-batch', () => {
-    it('drops whatever remains of a batch once disposal happens mid-batch', () => {
+    it('drops the rest of a batch once disposal happens mid-batch', () => {
       const runtime = createRuntime({
         model,
         options,

--- a/src/engine/runtime.test.ts
+++ b/src/engine/runtime.test.ts
@@ -210,4 +210,116 @@ describe('createRuntime', () => {
       expect.objectContaining({ canceled: true }),
     );
   });
+
+  describe('internal failure', () => {
+    it('tears down, logs, then rethrows, when reacting to the machine own layout output fails', () => {
+      const renderer = createFakeRenderer();
+      const failure = new Error('boom');
+      renderer.render.mockImplementationOnce(() => {
+        throw failure;
+      });
+      const log = { error: vi.fn<(error: Error) => void>() };
+      const runtime = createRuntime({ model, options, renderer, log });
+
+      expect(() => {
+        runtime.send({ type: 'pointer.down', position: [0, 0] });
+      }).toThrow(failure);
+
+      // Torn down through the same path as `dispose()`.
+      expect(renderer.dispose).toHaveBeenCalledTimes(1);
+      // Logged before the throw reaches the caller above.
+      expect(log.error).toHaveBeenCalledExactlyOnceWith(failure);
+      // Unrecoverable: further input throws the disposed-controller error,
+      // not a repeat of the original failure.
+      expect(() => {
+        runtime.send({ type: 'pointer.move', position: [1, 0] });
+      }).toThrow('disposed');
+    });
+
+    it('tears down, logs, then rethrows, when reacting to the machine own feedback output fails', () => {
+      const renderer = createFakeRenderer();
+      const failure = new Error('boom');
+      renderer.showFeedback.mockImplementationOnce(() => {
+        throw failure;
+      });
+      const log = { error: vi.fn<(error: Error) => void>() };
+      const runtime = createRuntime({ model, options, renderer, log });
+
+      runtime.send({ type: 'pointer.down', position: [0, 0] });
+      expect(() => {
+        runtime.send({ type: 'pointer.up', position: [0, 0] });
+      }).toThrow(failure);
+
+      expect(renderer.dispose).toHaveBeenCalledTimes(1);
+      expect(log.error).toHaveBeenCalledExactlyOnceWith(failure);
+    });
+
+    it('logs and suppresses a teardown failure while unwinding a primary failure, and rethrows only the original', () => {
+      const renderer = createFakeRenderer();
+      const primaryFailure = new Error('primary');
+      const teardownFailure = new Error('teardown');
+      renderer.render.mockImplementationOnce(() => {
+        throw primaryFailure;
+      });
+      renderer.dispose.mockImplementationOnce(() => {
+        throw teardownFailure;
+      });
+      const log = { error: vi.fn<(error: Error) => void>() };
+      const runtime = createRuntime({ model, options, renderer, log });
+
+      expect(() => {
+        runtime.send({ type: 'pointer.down', position: [0, 0] });
+      }).toThrow(primaryFailure);
+
+      expect(log.error).toHaveBeenNthCalledWith(1, teardownFailure);
+      expect(log.error).toHaveBeenNthCalledWith(2, primaryFailure);
+      expect(log.error).toHaveBeenCalledTimes(2);
+    });
+
+    it('normalizes a non-Error throw before logging and rethrowing it', () => {
+      const renderer = createFakeRenderer();
+      renderer.render.mockImplementationOnce(() => {
+        // eslint-disable-next-line @typescript-eslint/only-throw-error -- simulating a non-Error throw on purpose
+        throw 'boom';
+      });
+      const log = { error: vi.fn<(error: Error) => void>() };
+      const runtime = createRuntime({ model, options, renderer, log });
+
+      expect(() => {
+        runtime.send({ type: 'pointer.down', position: [0, 0] });
+      }).toThrow(Error);
+      expect(log.error).toHaveBeenCalledTimes(1);
+      const loggedError = log.error.mock.calls[0]?.[0];
+      expect(loggedError).toBeInstanceOf(Error);
+      expect(loggedError?.message).toContain('boom');
+    });
+  });
+
+  describe('reentrancy and disposal mid-batch', () => {
+    it('drops whatever remains of a batch once disposal happens mid-batch', () => {
+      const runtime = createRuntime({
+        model,
+        options,
+        renderer: createFakeRenderer(),
+      });
+      const emitted = recordEmitted(runtime);
+      let didSelectFire = false;
+
+      runtime.on('start', () => {
+        // Re-entrant, queued behind the current batch (same mechanism the
+        // existing reentrancy test above exercises) — but this time,
+        // disposal happens before it can ever be observed.
+        runtime.send({ type: 'pointer.up', position: [100, 0] });
+        runtime.dispose();
+      });
+      runtime.on('select', () => {
+        didSelectFire = true;
+      });
+
+      runtime.send({ type: 'pointer.down', position: [0, 0] });
+
+      expect(didSelectFire).toBe(false);
+      expect(emitted).toEqual(['start']);
+    });
+  });
 });

--- a/src/engine/runtime.ts
+++ b/src/engine/runtime.ts
@@ -76,8 +76,8 @@ export function createRuntime<M extends AnyModelNode>({
   const host = navigationMachine.start({ model, options });
 
   /**
-   An internal failure — an invariant violation surfacing while reacting to
-   the machine's own `layout`/`feedback` outputs, never a consumer's fault —
+   An internal failure (an invariant violation surfacing while reacting to
+   the machine's own `layout`/`feedback` outputs, never a consumer's fault)
    tears the controller down through the same path as `dispose()`, logs it,
    then rethrows so it still escapes the pointer listener or dwell timer
    that triggered it. A teardown failure while unwinding is itself logged

--- a/src/engine/runtime.ts
+++ b/src/engine/runtime.ts
@@ -1,5 +1,7 @@
 import type { MarkingMenuEventEmitter } from '../events.js';
+import type { MarkingMenuLogger } from '../marking-menu.js';
 import type { AnyModelNode } from '../types.js';
+import { noOp } from '../utils.js';
 import type { LayoutView } from './layout-view.js';
 import {
   navigationMachine,
@@ -7,6 +9,13 @@ import {
   type NavigationOptions,
 } from './machine.js';
 import type { LayoutRenderer } from './renderer.js';
+
+const defaultLogger: MarkingMenuLogger = {
+  error: console?.error?.bind(console) ?? noOp,
+};
+
+const toError = (value: unknown): Error =>
+  value instanceof Error ? value : new Error(String(value));
 
 /**
 All an input source needs of the runtime: no events, no model.
@@ -47,10 +56,12 @@ export function createRuntime<M extends AnyModelNode>({
   model,
   options,
   renderer,
+  log = defaultLogger,
 }: {
   model: M;
   options: NavigationOptions;
   renderer: LayoutRenderer<M>;
+  log?: MarkingMenuLogger;
 }): NavigationRuntime<M> {
   const target = new EventTarget();
   // One registration per (type, listener) pair, in registration order, so
@@ -64,11 +75,39 @@ export function createRuntime<M extends AnyModelNode>({
 
   const host = navigationMachine.start({ model, options });
 
+  /**
+   An internal failure — an invariant violation surfacing while reacting to
+   the machine's own `layout`/`feedback` outputs, never a consumer's fault —
+   tears the controller down through the same path as `dispose()`, logs it,
+   then rethrows so it still escapes the pointer listener or dwell timer
+   that triggered it. A teardown failure while unwinding is itself logged
+   and suppressed: the original error is the one that keeps propagating.
+   */
+  const handleInternalFailure = (error: unknown): never => {
+    const normalized = toError(error);
+    try {
+      dispose();
+    } catch (teardownError) {
+      log.error(toError(teardownError));
+    }
+
+    log.error(normalized);
+    throw normalized;
+  };
+
   const offLayout = host.on('layout', ({ data }) => {
-    renderer.render(data as unknown as LayoutView<M>);
+    try {
+      renderer.render(data as unknown as LayoutView<M>);
+    } catch (error) {
+      handleInternalFailure(error);
+    }
   });
   const offFeedback = host.on('feedback', ({ data }) => {
-    renderer.showFeedback(data);
+    try {
+      renderer.showFeedback(data);
+    } catch (error) {
+      handleInternalFailure(error);
+    }
   });
   const offPublic = publicOutputs.map((name) =>
     host.on(name, ({ data }) => {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "lib": ["ES2024", "ESNext.Disposable", "DOM", "DOM.Iterable"],
     "types": ["vite/client"]
   },
   "include": ["src"],


### PR DESCRIPTION
## Summary

Two clusters, per #183:

- **Expert falls back to novice.** A mid-expert dwell now recognizes the stroke drawn so far as a menu (`requireMenu: true`, full depth). A non-root match switches to novice rooted there (a nested `open`, the same shape as `startup -dwell> novice`); no match, or the root itself, cancels the expert attempt outright, mirroring the legacy RxJS engine's `expertToNoviceSwitchHOO`. The dwell itself reuses `noviceDwellingTime` and restarts on significant movement, via a `dwellAnchor` field on `expert` state modeled after novice's own.
- **Lifecycle, reentrancy and failure.** `dispose()` gains a matching `[Symbol.dispose]()` (no `Symbol` patching, no polyfill). An internal failure while reacting to the machine's own `layout`/`feedback` outputs now tears the controller down through the *same* code path as `dispose()`, logs it via a configurable `log` option, then rethrows, so it still escapes the pointer listener or dwell timer that triggered it. A teardown failure while unwinding a primary one is logged and suppressed rather than masking the original.

Most of the reentrancy/queueing/disposal-silence machinery turned out to already be correctly in place from the tracer-bullet slice (totorobot's own process-global send queue, and `dispose()` unsubscribing before sending `dispose` to the host). This PR adds the missing exhaustive test coverage for it (reentrant dispatch draining after the batch, disposal mid-batch dropping the remainder, a throwing consumer listener not affecting the controller, second-gesture-start being a no-op at the machine level regardless of layer) alongside the genuinely new expert-fallback and failure-handling behavior.

No changeset: `src/engine/*` isn't reachable from the public `createMarkingMenu` API until the cutover in #184.

## Acceptance criteria (from #183)

- [x] Mid-expert dwell recognizing a non-root menu switches to novice rooted there.
- [x] Mid-expert dwell recognizing no menu, or the root, cancels the expert attempt.
- [x] `dispose()` and `[Symbol.dispose]()` are both available, both terminal, both idempotent; no `Symbol` patching and no bundled polyfill.
- [x] Disposal during an active gesture is silent: no final `cancel` or any other public event.
- [x] Disposal removes listeners, releases pointer capture, cancels timers and queued inputs, cancels pending rendering work, tears down menu and canvas DOM and every feedback trace, and releases exactly one shared `touch-action` claim.
- [x] Disposing one controller while another still holds a claim on the same parent does not restore `touch-action`.
- [x] A listener synthesizing a pointer event is queued and drained after the current batch, in order.
- [x] Disposal mid-batch drops the remainder of the batch.
- [x] An internal failure tears down, then logs, then rethrows, through the same code path as `dispose()`.
- [x] A teardown failure while unwinding a primary failure is logged and suppressed; the original error is rethrown.
- [x] A throwing consumer listener is not observed, not caught and not acted on; remaining listeners still run and the gesture proceeds.
- [x] Internal input entry points throw after disposal, to surface implementation bugs.
- [x] A second gesture-start while one is active is a no-op, covered at the machine level regardless of which layer enforces it.
- [x] No changeset.

## Test plan

- [x] `vitest run` (332 tests passing)
- [x] `tsc -b` (no type errors)
- [x] `eslint .` (clean)
- [x] `prettier --check .` (clean)
- [x] `vitest run --coverage` (thresholds met: statements 97.6%, branches 91.9%, functions 99.6%, lines 97.6%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkSCopw4h5MZ5xGq5aPohM

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkSCopw4h5MZ5xGq5aPohM)_
