### PR TITLE
Consolidate the machine's termination-event emission

### DIFF
--- a/src/engine/machine.ts
+++ b/src/engine/machine.ts
@@ -310,6 +310,40 @@ function terminationContext(
   return { stroke: [...fromData.stroke, position], menu: null, active: null };
 }
 
+/**
+ Shared tail of the `up` and `cancel` termination actions: announce
+ `feedback`, then `select` or `cancel` depending on whether a selection was
+ found. Cancel's own call always passes a null `selection`, since it never
+ attempts one.
+ */
+function emitTermination(
+  emit: ((name: 'feedback', data: NavigationFeedbackAnnouncement) => void) &
+    ((name: 'cancel', data: MarkingMenuCancelEvent<AnyModelNode>) => void) &
+    ((name: 'select', data: MarkingMenuSelectEvent<AnyModelNode>) => void),
+  {
+    from,
+    position,
+    stroke,
+    menu,
+    active,
+    selection,
+  }: {
+    readonly from: MarkingMenuMode;
+    readonly position: Point;
+    readonly stroke: readonly Point[];
+    readonly menu: AnyModelNode | null;
+    readonly active: AnyModelNode | null;
+    readonly selection: AnyModelNode | null;
+  },
+): void {
+  emit('feedback', { stroke, canceled: selection === null });
+  if (selection === null) {
+    emit('cancel', cancelEvent({ mode: from, position, active, menu }));
+  } else {
+    emit('select', selectEvent({ mode: from, position, selection, menu }));
+  }
+}
+
 export const navigationMachine = machine({
   inputs: type<MachineInputs>(),
   states: type<MachineStates>(),
@@ -571,11 +605,14 @@ export const navigationMachine = machine({
     'expert -dwell> idle'({ fromData, emit }) {
       const { stroke } = fromData;
       const position = stroke.at(-1) as Point;
-      emit('feedback', { stroke, canceled: true });
-      emit(
-        'cancel',
-        cancelEvent({ mode: 'expert', position, active: null, menu: null }),
-      );
+      emitTermination(emit, {
+        from: 'expert',
+        position,
+        stroke,
+        menu: null,
+        active: null,
+        selection: null,
+      });
     },
 
     // Same shape as `'startup -dwell> novice'`'s own `open`, one recursion
@@ -650,13 +687,14 @@ export const navigationMachine = machine({
         selection = recognizeMarkingMenuStroke(stroke, fromData.model);
       }
 
-      emit('feedback', { stroke, canceled: selection === null });
-
-      if (selection === null) {
-        emit('cancel', cancelEvent({ mode: from, position, active, menu }));
-      } else {
-        emit('select', selectEvent({ mode: from, position, selection, menu }));
-      }
+      emitTermination(emit, {
+        from,
+        position,
+        stroke,
+        menu,
+        active,
+        selection,
+      });
     },
 
     // A pointer cancelled outright never selects, regardless of what was
@@ -672,8 +710,14 @@ export const navigationMachine = machine({
       const { position } = inputData;
       const { stroke, menu, active } = terminationContext(fromData, position);
 
-      emit('feedback', { stroke, canceled: true });
-      emit('cancel', cancelEvent({ mode: from, position, active, menu }));
+      emitTermination(emit, {
+        from,
+        position,
+        stroke,
+        menu,
+        active,
+        selection: null,
+      });
     },
   },
 });

--- a/src/engine/machine.ts
+++ b/src/engine/machine.ts
@@ -311,9 +311,10 @@ function terminationContext(
 }
 
 /**
- Shared tail of the `up` and `cancel` termination actions: announce
- `feedback`, then `select` or `cancel` depending on whether a selection was
- found. Cancel's own call always passes a null `selection`, since it never
+ Shared tail of every action that ends a gesture — `up`, `cancel`, and the
+ expert dwell that finds nothing to switch to: announce `feedback`, then
+ `select` or `cancel` depending on whether a selection was found. The
+ latter two callers always pass a null `selection`, since neither ever
  attempts one.
  */
 function emitTermination(


### PR DESCRIPTION
#186 asked for a post-parity pass over the navigation machine now that all four phases exist and are pinned by tests: look for duplicated terminal transitions and repeated timer handling, and only split the four phase handlers into their own modules if any one had grown past roughly 150 to 200 lines including its own helpers.

`src/engine/machine.ts` is a single totorobot definition where every phase's transitions and actions live in declarative tables, not as four hand-written functions, and none of them comes close to that line threshold, so no extraction was warranted. What was left to consolidate: three places that end a gesture, the `up` transition, the `cancel` transition, and the expert dwell that finds nothing to switch to, each built a `feedback` event followed by a `cancel` or `select` event with the same shape. They now share one `emitTermination` helper. Dwell-timer arming, termination-context extraction, and null-active move emission were already factored out before this review, so there was nothing left to consolidate there.

To check the behavior is unchanged, read `emitTermination` in `src/engine/machine.ts` alongside its three call sites (`expert -dwell> idle`, `* -up> idle`, `* -cancel> idle`) and compare the events each one emits against the versions on `main`.

`yarn test` covers this machine end to end and passes untouched: no test file changed, and no changeset, since none of this changes public behavior.

The file grew from 679 to 724 lines: the helper's own declaration and its object-literal call sites cost more lines than the terse inline calls they replace. Line count wasn't the goal; one shared definition of the termination-event shape is.

Closes #186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)