### PR TITLE
demo: move script to head and reorder head elements

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -3,6 +3,16 @@
   <head>
     <meta charset="UTF-8" />
     <meta content="width=device-width" name="viewport" />
+    <title>Marking Menu Demonstration</title>
+    <script type="importmap">
+      {
+        "imports": {
+          "marking-menu": "./index.js"
+        }
+      }
+    </script>
+    <link href="./style.css" rel="stylesheet" />
+    <script type="module" src="./script.js"></script>
     <meta
       content="Interactive demonstration of the Marking Menu interaction technique."
       name="description"
@@ -13,16 +23,6 @@
       content="https://quentinroy.github.io/Marking-Menu/"
       property="og:url"
     />
-    <title>Marking Menu Demonstration</title>
-    <link href="./style.css" rel="stylesheet" />
-    <script type="importmap">
-      {
-        "imports": {
-          "marking-menu": "./index.js"
-        }
-      }
-    </script>
-    <script type="module" src="./script.js"></script>
   </head>
 
   <body>

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,15 +3,6 @@
   <head>
     <meta charset="UTF-8" />
     <meta content="width=device-width" name="viewport" />
-    <title>Marking Menu Demonstration</title>
-    <script type="importmap">
-      {
-        "imports": {
-          "marking-menu": "./index.js"
-        }
-      }
-    </script>
-    <link href="./style.css" rel="stylesheet" />
     <meta
       content="Interactive demonstration of the Marking Menu interaction technique."
       name="description"
@@ -22,6 +13,16 @@
       content="https://quentinroy.github.io/Marking-Menu/"
       property="og:url"
     />
+    <title>Marking Menu Demonstration</title>
+    <link href="./style.css" rel="stylesheet" />
+    <script type="importmap">
+      {
+        "imports": {
+          "marking-menu": "./index.js"
+        }
+      }
+    </script>
+    <script type="module" src="./script.js"></script>
   </head>
 
   <body>
@@ -64,7 +65,5 @@
         ></path>
       </svg>
     </a>
-
-    <script type="module" src="./script.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Move the demo script tag from the bottom of the body to the head with `type="module"` for proper module loading. Reorder head elements to place meta tags before title, styles, and scripts.