### PR TITLE
Draw the novice feedback as a straight line, above the menu

### DIFF
--- a/src/__fixtures__/canvas.ts
+++ b/src/__fixtures__/canvas.ts
@@ -79,9 +79,19 @@ export const fakeTimers = (): Disposable => {
 };
 
 /**
+Read the mock 2D context of a canvas.
+*/
+export const canvasContext = (canvas: HTMLCanvasElement): MockContext =>
+  (canvas.getContext as unknown as () => MockContext)();
+
+/**
 Read the mock 2D context of the first canvas under `parent`.
 */
-export const queryCanvasContext = (parent: HTMLElement): MockContext =>
-  (
-    parent.querySelector('canvas')?.getContext as unknown as () => MockContext
-  )();
+export const queryCanvasContext = (parent: HTMLElement): MockContext => {
+  const canvas = parent.querySelector('canvas');
+  if (canvas === null) {
+    throw new Error('No canvas was rendered under the parent.');
+  }
+
+  return canvasContext(canvas);
+};

--- a/src/engine/layout-view.ts
+++ b/src/engine/layout-view.ts
@@ -16,6 +16,23 @@ export type LayoutView<M extends AnyModelNode> = {
   readonly lowerStroke: readonly Point[] | null;
 };
 
+/**
+ The segment novice mode draws on top of the open menu: from the menu's
+ center to the pointer, never the path the pointer took to get there.
+ Startup and expert keep their whole traced stroke instead, which is the
+ mark being drawn. The machine stores only `lastPosition` and builds the
+ segment here, so the two can never disagree.
+ */
+export function noviceUpperStroke({
+  menuCenter,
+  lastPosition,
+}: {
+  readonly menuCenter: Point;
+  readonly lastPosition: Point;
+}): readonly [Point, Point] {
+  return [menuCenter, lastPosition];
+}
+
 export function projectLayout<M extends AnyModelNode>(
   state: NavigationState<M>,
 ): LayoutView<M> {
@@ -52,7 +69,7 @@ export function projectLayout<M extends AnyModelNode>(
           activeKey:
             (state.active as { readonly key: string } | null)?.key ?? null,
         },
-        upperStroke: state.upperStroke,
+        upperStroke: noviceUpperStroke(state),
         lowerStroke: state.lowerStroke,
       };
     }

--- a/src/engine/machine.test.ts
+++ b/src/engine/machine.test.ts
@@ -355,7 +355,7 @@ describe('navigationMachine', () => {
       host.send('dwell');
 
       const data = host.current.name === 'novice' ? host.current.data : null;
-      expect(data?.upperStroke).toEqual([[100, 0]]);
+      expect(data?.lastPosition).toEqual([100, 0]);
       expect(data?.lowerStroke).toEqual([
         [0, 0],
         [100, 0],
@@ -642,7 +642,7 @@ describe('navigationMachine', () => {
       expect(event.position).toEqual([100, 0]);
     });
 
-    it('accumulates the prior stroke into the lower stroke and restarts the upper stroke from the new centre', () => {
+    it('accumulates the prior stroke into the lower stroke and restarts from the new center', () => {
       const host = navigationMachine.start({ model: submenuModel, options });
 
       openNovice(host);
@@ -650,7 +650,7 @@ describe('navigationMachine', () => {
       host.send('dwell');
 
       const data = host.current.name === 'novice' ? host.current.data : null;
-      expect(data?.upperStroke).toEqual([[100, 0]]);
+      expect(data?.lastPosition).toEqual([100, 0]);
       expect(data?.lowerStroke).toEqual([
         [0, 0],
         [0, 0],
@@ -814,7 +814,12 @@ describe('navigationMachine', () => {
         [0, 0],
         [100, 0],
       ]);
-      expect(layouts.at(-1)?.upperStroke).toEqual([[100, 0]]);
+      // The fresh submenu has had no move yet, so its segment is still a
+      // single point drawn twice.
+      expect(layouts.at(-1)?.upperStroke).toEqual([
+        [100, 0],
+        [100, 0],
+      ]);
     });
 
     it('announces a completed novice gesture as one straight segment per menu level', () => {

--- a/src/engine/machine.test.ts
+++ b/src/engine/machine.test.ts
@@ -2,7 +2,11 @@ import { fakeTimers } from '../__fixtures__/canvas.js';
 import { createModel } from '../model.js';
 import { recognizeMarkingMenuStroke } from '../recognizer/recognize-mm-stroke.js';
 import type * as RecognizeModule from '../recognizer/recognize-mm-stroke.js';
-import { navigationMachine } from './machine.js';
+import {
+  navigationMachine,
+  type NavigationFeedbackAnnouncement,
+  type NavigationLayoutAnnouncement,
+} from './machine.js';
 
 // Wraps the real recognizer rather than replacing it: every existing test
 // keeps exercising genuine recognition geometry, and only the tests that
@@ -89,6 +93,32 @@ const recordEmitted = (host: ReturnType<typeof startHost>): string[] => {
   }
 
   return emitted;
+};
+
+/**
+Record every layout announcement a host makes, in order.
+*/
+const recordLayouts = (
+  host: ReturnType<typeof startHost>,
+): NavigationLayoutAnnouncement[] => {
+  const layouts: NavigationLayoutAnnouncement[] = [];
+  host.on('layout', ({ data }) => {
+    layouts.push(data);
+  });
+  return layouts;
+};
+
+/**
+Record every feedback announcement a host makes, in order.
+*/
+const recordFeedback = (
+  host: ReturnType<typeof startHost>,
+): NavigationFeedbackAnnouncement[] => {
+  const feedback: NavigationFeedbackAnnouncement[] = [];
+  host.on('feedback', ({ data }) => {
+    feedback.push(data);
+  });
+  return feedback;
 };
 
 describe('navigationMachine', () => {
@@ -735,6 +765,80 @@ describe('navigationMachine', () => {
       // to be the very same reference the residency's `restart` predicate
       // compares against.
       expect(vi.getTimerCount()).toBe(1);
+    });
+  });
+
+  describe('the strokes it announces to the layout', () => {
+    it('reduces the novice upper stroke to the menu center and the last position, whatever path the pointer took between them', () => {
+      const host = startHost();
+      const layouts = recordLayouts(host);
+
+      openNovice(host);
+      host.send('move', { position: [30, 20] });
+      host.send('move', { position: [100, 0] });
+
+      expect(layouts.at(-1)?.upperStroke).toEqual([
+        [0, 0],
+        [100, 0],
+      ]);
+    });
+
+    it('keeps accumulating the startup and expert stroke point by point', () => {
+      const host = startHost();
+      const layouts = recordLayouts(host);
+
+      host.send('down', { position: [0, 0] });
+      host.send('move', { position: [1, 0] }); // Below the threshold: still startup.
+      host.send('move', { position: [100, 0] }); // Crosses it: expert.
+      host.send('move', { position: [100, 40] });
+
+      expect(layouts.at(-1)?.upperStroke).toEqual([
+        [0, 0],
+        [1, 0],
+        [100, 0],
+        [100, 40],
+      ]);
+    });
+
+    it("folds the parent menu's straight segment, not the pointer's path, into the lower stroke when a submenu opens", () => {
+      const host = navigationMachine.start({ model: submenuModel, options });
+      const layouts = recordLayouts(host);
+
+      openNovice(host);
+      host.send('move', { position: [30, 20] });
+      host.send('move', { position: [100, 0] });
+      host.send('dwell');
+
+      expect(layouts.at(-1)?.lowerStroke).toEqual([
+        [0, 0],
+        [0, 0],
+        [100, 0],
+      ]);
+      expect(layouts.at(-1)?.upperStroke).toEqual([[100, 0]]);
+    });
+
+    it('announces a completed novice gesture as one straight segment per menu level', () => {
+      const host = navigationMachine.start({ model: submenuModel, options });
+      const feedback = recordFeedback(host);
+
+      openNovice(host);
+      host.send('move', { position: [30, 20] });
+      host.send('move', { position: [100, 0] });
+      host.send('dwell'); // Opens the "right" submenu, centered on [100, 0].
+      host.send('move', { position: [70, -60] });
+      host.send('move', { position: [100, -100] });
+      host.send('up', { position: [100, -100] });
+
+      // Each menu center repeats where one level's segment ends and the
+      // next begins, and the release position repeats the last move.
+      expect(feedback.at(-1)?.stroke).toEqual([
+        [0, 0],
+        [0, 0],
+        [100, 0],
+        [100, 0],
+        [100, -100],
+        [100, -100],
+      ]);
     });
   });
 });

--- a/src/engine/machine.ts
+++ b/src/engine/machine.ts
@@ -451,7 +451,11 @@ export const navigationMachine = machine({
       return {
         ...fromData,
         active,
-        upperStroke: [...fromData.upperStroke, position],
+        // Replaced, never appended to: novice feedback is the straight
+        // segment from the menu's center to the pointer, not the path taken
+        // to get there. Startup and expert accumulate instead, since their
+        // stroke is the mark being drawn.
+        upperStroke: [menuCenter, position],
         // A fresh reference only when movement is significant: the
         // submenu-dwell residency's `restart` predicate below compares this
         // by reference, so an unchanged anchor must stay the same object.

--- a/src/engine/machine.ts
+++ b/src/engine/machine.ts
@@ -17,7 +17,7 @@ import type {
   ModelMenus,
 } from '../types.js';
 import { dist, toPolar, type Point } from '../utils.js';
-import { projectLayout } from './layout-view.js';
+import { noviceUpperStroke, projectLayout } from './layout-view.js';
 
 /*
  The navigation machine, declared as a totorobot definition rather than a
@@ -89,7 +89,11 @@ type NavigationPhaseFields<Menu, Active> = {
     readonly menu: Menu;
     readonly menuCenter: Point;
     readonly active: Active | null;
-    readonly upperStroke: readonly Point[];
+    // Where the pointer is now. The upper stroke novice mode draws is the
+    // straight segment from `menuCenter` to here, so the machine keeps the
+    // endpoint rather than the segment: `noviceUpperStroke` builds it for
+    // the three places that need it.
+    readonly lastPosition: Point;
     readonly lowerStroke: readonly Point[];
     // The last position significant movement was measured from: distinct
     // from `menuCenter`, which stays fixed for the life of this menu. Only a
@@ -299,9 +303,9 @@ function terminationContext(
   readonly active: AnyModelNode | null;
 } {
   if ('lowerStroke' in fromData) {
-    const { lowerStroke, upperStroke, menu, active } = fromData;
+    const { lowerStroke, menu, active } = fromData;
     return {
-      stroke: [...lowerStroke, ...upperStroke, position],
+      stroke: [...lowerStroke, ...noviceUpperStroke(fromData), position],
       menu,
       active,
     };
@@ -390,7 +394,7 @@ export const navigationMachine = machine({
       menu: model,
       menuCenter: origin,
       active: null,
-      upperStroke: [origin],
+      lastPosition: origin,
       lowerStroke: stroke,
       dwellAnchor: origin,
     }),
@@ -430,7 +434,7 @@ export const navigationMachine = machine({
         menu,
         menuCenter: position,
         active: null,
-        upperStroke: [position],
+        lastPosition: position,
         lowerStroke: stroke,
         dwellAnchor: [...position],
       };
@@ -451,11 +455,7 @@ export const navigationMachine = machine({
       return {
         ...fromData,
         active,
-        // Replaced, never appended to: novice feedback is the straight
-        // segment from the menu's center to the pointer, not the path taken
-        // to get there. Startup and expert accumulate instead, since their
-        // stroke is the mark being drawn.
-        upperStroke: [menuCenter, position],
+        lastPosition: position,
         // A fresh reference only when movement is significant: the
         // submenu-dwell residency's `restart` predicate below compares this
         // by reference, so an unchanged anchor must stay the same object.
@@ -470,19 +470,10 @@ export const navigationMachine = machine({
     // that submenu: a genuine phase change, even though the destination is
     // named `novice` too. Anything else declines, and since no other row is
     // declared for (novice, dwell), the dwell is silently dropped.
-    'novice -dwell> novice'({
-      fromData: {
-        active,
-        menuCenter,
-        upperStroke,
-        lowerStroke,
-        options,
-        model,
-      },
-      skip,
-    }) {
-      const position = upperStroke.at(-1) as Point;
-      const { radius } = toPolar(position, menuCenter);
+    'novice -dwell> novice'({ fromData, skip }) {
+      const { active, menuCenter, lastPosition, lowerStroke, options, model } =
+        fromData;
+      const { radius } = toPolar(lastPosition, menuCenter);
       if (
         active === null ||
         active.isLeaf ||
@@ -495,16 +486,18 @@ export const navigationMachine = machine({
         model,
         options,
         menu: active,
-        menuCenter: position,
+        menuCenter: lastPosition,
         active: null,
-        upperStroke: [position],
-        lowerStroke: [...lowerStroke, ...upperStroke],
-        // A fresh reference, deliberately never `position` itself: opening a
-        // submenu must always restart the residency for the new menu, and
-        // `position` is `upperStroke.at(-1)`. With no wobble between the
-        // move that armed this dwell and the dwell itself, that is the very
-        // same reference `fromData.dwellAnchor` already holds.
-        dwellAnchor: [...position],
+        lastPosition,
+        // The parent menu's own segment becomes part of the trail left
+        // behind the new one.
+        lowerStroke: [...lowerStroke, ...noviceUpperStroke(fromData)],
+        // A fresh reference, deliberately never `lastPosition` itself:
+        // opening a submenu must always restart the residency for the new
+        // menu, and with no wobble between the move that armed this dwell
+        // and the dwell itself, `lastPosition` is the very same reference
+        // `fromData.dwellAnchor` already holds.
+        dwellAnchor: [...lastPosition],
       };
     },
 

--- a/src/engine/renderer.test.ts
+++ b/src/engine/renderer.test.ts
@@ -2,6 +2,7 @@ import {
   fakeTimers,
   queryCanvasContext,
   stubbedCanvasContexts,
+  type MockContext,
 } from '../__fixtures__/canvas.js';
 import { createModel } from '../model.js';
 import type { Point } from '../utils.js';
@@ -13,6 +14,33 @@ const model = createModel({
     { id: 'b', label: 'B' },
   ],
 });
+
+// A distinct model reference, which is all it takes for the renderer to
+// recreate the menu element rather than patch it.
+const otherModel = createModel({
+  items: [
+    { id: 'a', label: 'A' },
+    { id: 'b', label: 'B' },
+  ],
+});
+
+// The two stroke layers are told apart by their line width, the one drawing
+// property `drawPoint` leaves alone.
+const upperStrokeWidth = 7;
+const lowerStrokeWidth = 3;
+
+/**
+Name every child of `parent` by the layer it belongs to, in paint order.
+*/
+const layerOrder = (parent: HTMLElement): string[] =>
+  [...parent.children].map((child) => {
+    if (!(child instanceof HTMLCanvasElement)) {
+      return 'menu';
+    }
+
+    const context = (child.getContext as unknown as () => MockContext)();
+    return context.lineWidth === upperStrokeWidth ? 'upper' : 'lower';
+  });
 
 describe('createRenderer', () => {
   it('skips the redraw when the upper stroke is reference-equal to the previous frame', () => {
@@ -222,6 +250,81 @@ describe('createRenderer', () => {
     const selected = queryCanvasContext(parent);
     expect(selected.strokeStyle).toBe('#00ff00');
     expect(selected.lineWidth).toBe(5);
+
+    renderer.dispose();
+  });
+
+  it('paints the lower stroke behind the open menu and the upper stroke in front of it', () => {
+    using _canvases = stubbedCanvasContexts();
+    using _timers = fakeTimers();
+
+    const parent = document.createElement('div');
+    const renderer = createRenderer<typeof model>({
+      parent,
+      strokeWidth: upperStrokeWidth,
+      lowerStrokeWidth,
+    });
+
+    renderer.render({
+      cursor: 'none',
+      menu: { model, center: [0, 0], activeKey: null },
+      upperStroke: [
+        [0, 0],
+        [10, 0],
+      ],
+      lowerStroke: [
+        [0, 0],
+        [5, 5],
+      ],
+    });
+    vi.advanceTimersToNextFrame();
+
+    expect(layerOrder(parent)).toEqual(['lower', 'menu', 'upper']);
+
+    renderer.dispose();
+  });
+
+  it('restores the order when a submenu replaces the menu element', () => {
+    using _canvases = stubbedCanvasContexts();
+    using _timers = fakeTimers();
+
+    const parent = document.createElement('div');
+    const renderer = createRenderer<typeof model>({
+      parent,
+      strokeWidth: upperStrokeWidth,
+      lowerStrokeWidth,
+    });
+    const upperStroke: Point[] = [
+      [0, 0],
+      [10, 0],
+    ];
+
+    renderer.render({
+      cursor: 'none',
+      menu: { model, center: [0, 0], activeKey: null },
+      upperStroke,
+      lowerStroke: [
+        [0, 0],
+        [5, 5],
+      ],
+    });
+    vi.advanceTimersToNextFrame();
+
+    renderer.render({
+      cursor: 'none',
+      menu: { model: otherModel, center: [10, 0], activeKey: null },
+      // Reference-equal, so the layer skips its redraw: the upper stroke
+      // must still be moved back in front of the recreated menu.
+      upperStroke,
+      lowerStroke: [
+        [0, 0],
+        [5, 5],
+        [10, 0],
+      ],
+    });
+    vi.advanceTimersToNextFrame();
+
+    expect(layerOrder(parent)).toEqual(['lower', 'menu', 'upper']);
 
     renderer.dispose();
   });

--- a/src/engine/renderer.test.ts
+++ b/src/engine/renderer.test.ts
@@ -1,8 +1,8 @@
 import {
+  canvasContext,
   fakeTimers,
   queryCanvasContext,
   stubbedCanvasContexts,
-  type MockContext,
 } from '../__fixtures__/canvas.js';
 import { createModel } from '../model.js';
 import type { Point } from '../utils.js';
@@ -25,21 +25,25 @@ const otherModel = createModel({
 });
 
 // The two stroke layers are told apart by their line width, the one drawing
-// property `drawPoint` leaves alone.
+// property `drawPoint` leaves alone, so the stacking tests below have to
+// configure the two widths differently.
 const upperStrokeWidth = 7;
 const lowerStrokeWidth = 3;
+
+type Layer = 'lower' | 'menu' | 'upper';
 
 /**
 Name every child of `parent` by the layer it belongs to, in paint order.
 */
-const layerOrder = (parent: HTMLElement): string[] =>
+const layerOrder = (parent: HTMLElement): Layer[] =>
   [...parent.children].map((child) => {
     if (!(child instanceof HTMLCanvasElement)) {
       return 'menu';
     }
 
-    const context = (child.getContext as unknown as () => MockContext)();
-    return context.lineWidth === upperStrokeWidth ? 'upper' : 'lower';
+    return canvasContext(child).lineWidth === upperStrokeWidth
+      ? 'upper'
+      : 'lower';
   });
 
 describe('createRenderer', () => {

--- a/src/engine/renderer.test.ts
+++ b/src/engine/renderer.test.ts
@@ -24,26 +24,40 @@ const otherModel = createModel({
   ],
 });
 
-// The two stroke layers are told apart by their line width, the one drawing
+// The canvas layers are told apart by their line width, the one drawing
 // property `drawPoint` leaves alone, so the stacking tests below have to
-// configure the two widths differently.
+// configure all three widths differently.
 const upperStrokeWidth = 7;
 const lowerStrokeWidth = 3;
+const feedbackStrokeWidth = 5;
 
-type Layer = 'lower' | 'menu' | 'upper';
+type Layer = 'lower' | 'menu' | 'upper' | 'feedback';
+
+const layerByStrokeWidth = new Map<number | undefined, Layer>([
+  [upperStrokeWidth, 'upper'],
+  [lowerStrokeWidth, 'lower'],
+  [feedbackStrokeWidth, 'feedback'],
+]);
 
 /**
 Name every child of `parent` by the layer it belongs to, in paint order.
 */
-const layerOrder = (parent: HTMLElement): Layer[] =>
-  [...parent.children].map((child) => {
-    if (!(child instanceof HTMLCanvasElement)) {
-      return 'menu';
-    }
+const layerOrder = (parent: HTMLElement): Array<Layer | undefined> =>
+  [...parent.children].map((child) =>
+    child instanceof HTMLCanvasElement
+      ? layerByStrokeWidth.get(canvasContext(child).lineWidth)
+      : 'menu',
+  );
 
-    return canvasContext(child).lineWidth === upperStrokeWidth
-      ? 'upper'
-      : 'lower';
+/**
+A renderer whose three canvas layers are individually identifiable.
+*/
+const createStackingRenderer = (parent: HTMLElement) =>
+  createRenderer<typeof model>({
+    parent,
+    strokeWidth: upperStrokeWidth,
+    lowerStrokeWidth,
+    gestureFeedbackStrokeWidth: feedbackStrokeWidth,
   });
 
 describe('createRenderer', () => {
@@ -263,11 +277,7 @@ describe('createRenderer', () => {
     using _timers = fakeTimers();
 
     const parent = document.createElement('div');
-    const renderer = createRenderer<typeof model>({
-      parent,
-      strokeWidth: upperStrokeWidth,
-      lowerStrokeWidth,
-    });
+    const renderer = createStackingRenderer(parent);
 
     renderer.render({
       cursor: 'none',
@@ -293,11 +303,7 @@ describe('createRenderer', () => {
     using _timers = fakeTimers();
 
     const parent = document.createElement('div');
-    const renderer = createRenderer<typeof model>({
-      parent,
-      strokeWidth: upperStrokeWidth,
-      lowerStrokeWidth,
-    });
+    const renderer = createStackingRenderer(parent);
     const upperStroke: Point[] = [
       [0, 0],
       [10, 0],
@@ -329,6 +335,43 @@ describe('createRenderer', () => {
     vi.advanceTimersToNextFrame();
 
     expect(layerOrder(parent)).toEqual(['lower', 'menu', 'upper']);
+
+    renderer.dispose();
+  });
+
+  it('keeps a completed-gesture trace in front of a menu that opens before it expires', () => {
+    using _canvases = stubbedCanvasContexts();
+    using _timers = fakeTimers();
+
+    const parent = document.createElement('div');
+    const renderer = createStackingRenderer(parent);
+
+    renderer.showFeedback({
+      stroke: [
+        [0, 0],
+        [10, 0],
+      ],
+      canceled: false,
+    });
+    // Well inside the default feedback duration, so the trace is still up
+    // when the next gesture opens its menu.
+    vi.advanceTimersByTime(334);
+
+    renderer.render({
+      cursor: 'none',
+      menu: { model, center: [0, 0], activeKey: null },
+      upperStroke: [
+        [0, 0],
+        [10, 0],
+      ],
+      lowerStroke: [
+        [0, 0],
+        [5, 5],
+      ],
+    });
+    vi.advanceTimersToNextFrame();
+
+    expect(layerOrder(parent)).toEqual(['lower', 'menu', 'feedback', 'upper']);
 
     renderer.dispose();
   });

--- a/src/engine/renderer.ts
+++ b/src/engine/renderer.ts
@@ -197,14 +197,14 @@ export function createRenderer<M extends AnyModelNode = AnyModelNode>({
    upper stroke and its origin marker go in front of it, so the marker
    stays visible and the line is not cut where it crosses an item.
 
-   The completed-gesture feedback belongs in front of the menu too, which
-   it gets for free: `showFeedback` only ever runs once the menu is gone,
-   and appends its own canvas.
+   A completed-gesture trace belongs in front of the menu as well. It
+   outlives the gesture that produced it, so a menu opened before it fades
+   is appended after it and would cover it.
 
    Nothing in the stylesheet sets any of this, and each canvas and the menu
-   land wherever the view first asked for them, so sibling order is all
-   that holds it. Every render re-asserts that order, moving an element
-   only when it is out of place.
+   land wherever they were first needed, so sibling order is all that holds
+   it. Every render re-asserts that order, moving an element only when it
+   is out of place.
    */
   function restack(): void {
     const menuElement = menuHandle?.menu.element;
@@ -220,6 +220,14 @@ export function createRenderer<M extends AnyModelNode = AnyModelNode>({
     const upper = upperStroke.element();
     if (upper !== null && !isPaintedBefore(menuElement, upper)) {
       menuElement.after(upper);
+    }
+
+    // After the upper stroke, so a live gesture still draws over a fading
+    // trace of the previous one.
+    for (const trace of gestureFeedback.elements()) {
+      if (!isPaintedBefore(menuElement, trace)) {
+        menuElement.after(trace);
+      }
     }
   }
 

--- a/src/engine/renderer.ts
+++ b/src/engine/renderer.ts
@@ -47,6 +47,7 @@ function createStrokeLayer({
     stroke: readonly Point[] | null,
     options?: { drawStartPoint?: boolean },
   ) => void;
+  element: () => HTMLCanvasElement | null;
   dispose: () => void;
 } {
   let canvas: StrokeCanvas | null = null;
@@ -75,12 +76,24 @@ function createStrokeLayer({
         draw(stroke, shouldDrawStartPoint);
       }
     },
+    element: () => canvas?.element ?? null,
     dispose() {
       draw.cancel();
       canvas?.remove();
       canvas = null;
     },
   };
+}
+
+/**
+ Whether `node` is painted before `other`. The two are always siblings under
+ the renderer's parent, never nested, so `compareDocumentPosition` returns
+ exactly one of the two ordering flags and nothing has to be masked off.
+ */
+function isPaintedBefore(node: Node, other: Node): boolean {
+  return (
+    node.compareDocumentPosition(other) === Node.DOCUMENT_POSITION_FOLLOWING
+  );
 }
 
 export type RendererOptions = {
@@ -178,6 +191,34 @@ export function createRenderer<M extends AnyModelNode = AnyModelNode>({
     },
   });
 
+  /**
+   The paint order the novice feedback depends on: the lower stroke, which
+   records movement made before the menu opened, goes behind the menu; the
+   upper stroke and its origin marker go in front of it, so the marker
+   stays visible and the line is not cut where it crosses an item.
+
+   Nothing in the stylesheet sets this, and each canvas and the menu land
+   wherever the view first asked for them, so sibling order is all that
+   holds it. Every render re-asserts that order, moving an element only
+   when it is out of place.
+   */
+  function restack(): void {
+    const menuElement = menuHandle?.menu.element;
+    if (menuElement === undefined) {
+      return;
+    }
+
+    const lower = lowerStroke.element();
+    if (lower !== null && !isPaintedBefore(lower, menuElement)) {
+      menuElement.before(lower);
+    }
+
+    const upper = upperStroke.element();
+    if (upper !== null && !isPaintedBefore(menuElement, upper)) {
+      menuElement.after(upper);
+    }
+  }
+
   return {
     render(view) {
       parent.style.cursor = view.cursor === 'default' ? ownCursor : view.cursor;
@@ -222,6 +263,7 @@ export function createRenderer<M extends AnyModelNode = AnyModelNode>({
 
       upperStroke.sync(view.upperStroke, { drawStartPoint: isNoviceMode });
       lowerStroke.sync(view.lowerStroke);
+      restack();
     },
     showFeedback(effect) {
       gestureFeedback.show(effect.stroke, { canceled: effect.canceled });

--- a/src/engine/renderer.ts
+++ b/src/engine/renderer.ts
@@ -197,10 +197,14 @@ export function createRenderer<M extends AnyModelNode = AnyModelNode>({
    upper stroke and its origin marker go in front of it, so the marker
    stays visible and the line is not cut where it crosses an item.
 
-   Nothing in the stylesheet sets this, and each canvas and the menu land
-   wherever the view first asked for them, so sibling order is all that
-   holds it. Every render re-asserts that order, moving an element only
-   when it is out of place.
+   The completed-gesture feedback belongs in front of the menu too, which
+   it gets for free: `showFeedback` only ever runs once the menu is gone,
+   and appends its own canvas.
+
+   Nothing in the stylesheet sets any of this, and each canvas and the menu
+   land wherever the view first asked for them, so sibling order is all
+   that holds it. Every render re-asserts that order, moving an element
+   only when it is out of place.
    */
   function restack(): void {
     const menuElement = menuHandle?.menu.element;

--- a/src/layout/gesture-feedback.ts
+++ b/src/layout/gesture-feedback.ts
@@ -20,6 +20,11 @@ export type GestureFeedback = {
   */
   show: (stroke: readonly Point[], options?: { canceled?: boolean }) => void;
   /**
+  The canvases of the traces still showing, so callers can place them among
+  their siblings.
+  */
+  elements: () => readonly HTMLCanvasElement[];
+  /**
   Immediately remove any shown feedback.
   */
   remove: () => void;
@@ -88,5 +93,8 @@ export function createGestureFeedback({
     strokeTimeoutEntries = [];
   };
 
-  return { show, remove };
+  const elements = () =>
+    strokeTimeoutEntries.map(({ canvas }) => canvas.element);
+
+  return { show, elements, remove };
 }

--- a/src/layout/menu.css
+++ b/src/layout/menu.css
@@ -26,9 +26,9 @@
      z-ordered children in the document's z-stack. */
   transform: translate(0px, 0px);
   /* No z-index here on purpose: the menu sits between the two stroke
-     canvases, above the lower stroke and below the upper one. The renderer
-     keeps it there by ordering the siblings itself, so a z-index here
-     would break that. */
+     canvases, above the lower stroke and below both the upper one and the
+     completed-gesture feedback. The renderer keeps it there by ordering
+     the siblings itself, so a z-index here would break that. */
 }
 
 .marking-menu-item {

--- a/src/layout/menu.css
+++ b/src/layout/menu.css
@@ -25,6 +25,10 @@
   /* Using transform to make .marking-menu a stacking context and confine
      z-ordered children in the document's z-stack. */
   transform: translate(0px, 0px);
+  /* No z-index here on purpose: the menu sits between the two stroke
+     canvases, above the lower stroke and below the upper one. The renderer
+     keeps it there by ordering the siblings itself, so a z-index here
+     would break that. */
 }
 
 .marking-menu-item {

--- a/src/layout/menu.ts
+++ b/src/layout/menu.ts
@@ -50,6 +50,10 @@ export type MenuLayoutModel = {
  */
 export type Menu = {
   /**
+  The menu's root element, so callers can place it among its siblings.
+  */
+  element: HTMLElement;
+  /**
   Mark the item with the given id as active (or none if nullish).
   */
   setActive: (itemId: string | number | null) => void;
@@ -168,5 +172,5 @@ export function createMenu({
   };
 
   // Create the interface.
-  return { setActive, remove };
+  return { element: main, setActive, remove };
 }

--- a/src/layout/stroke.ts
+++ b/src/layout/stroke.ts
@@ -39,6 +39,10 @@ export type StrokeCanvasOptions = {
  */
 export type StrokeCanvas = {
   /**
+  The canvas element, so callers can place it among its siblings.
+  */
+  element: HTMLCanvasElement;
+  /**
   Clear the canvas.
   */
   clear: () => void;
@@ -158,5 +162,5 @@ export function createStrokeCanvas({
     canvas.remove();
   };
 
-  return { clear, drawStroke, drawPoint, remove };
+  return { element: canvas, clear, drawStroke, drawPoint, remove };
 }


### PR DESCRIPTION
Dwelling to open the novice menu and then dragging produced two wrong things at once. The line from the menu center followed every wobble of the pointer's path instead of pointing straight at it, so a slow or curved drag left a scribble across the menu. And the stroke was painted underneath the menu, hiding the round marker that shows where the current menu is anchored and cutting the line wherever it crossed an item.

Both are regressions in unreleased code, from separate causes, so they are fixed separately.

The novice `move` transition appended each new position to the upper stroke. Novice state now stores `lastPosition` and nothing else, and `noviceUpperStroke` builds the two-point segment from the menu center for the three places that read it: the layout projection, the submenu open that folds it into the lower stroke, and the completed-gesture stroke. The segment is a pair by type, so nothing has to assume it. Startup and expert are untouched and keep accumulating, because there the stroke is the mark being drawn. One consequence worth knowing: a menu nobody has moved on yet reports its segment as its center twice, where the old array held one point. The line drawn is the same and the completed-gesture stroke is byte-identical.

The renderer creates its canvases once and keeps them, and neither they nor the menu set a paint order, so the layers ended up wherever append order left them. `render` now re-asserts the order it needs, lower stroke behind the menu and upper stroke in front of it, moving an element only when it is out of place. Giving the three layers `z-index` values was the alternative, and was rejected because it turns an internal invariant into styling a consumer can override. The rule is written down in the renderer and in `menu.css` so the next rewrite inherits it.

To check by hand, run `yarn demo:dev`, hold the pointer still to open the menu, then drag slowly along a curve. The line stays straight and the origin dot stays visible.

The tests sit at the two seams that already existed. The machine ones drive it with pointer inputs and assert on the `layout` and `feedback` announcements rather than its internal state, so the stroke representation stays free to change. The renderer ones render a view into a fresh parent and assert the sibling order under it, including after a submenu replaces the menu element, which is the path the stacking fix could regress.

No changeset: the public event set and payloads are untouched, and both defects live in code that has not shipped.

Fixes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)