### PR TITLE
Style corner items by quadrant instead of exact angle

### DIFF
--- a/.changeset/quadrant-corner-styling.md
+++ b/.changeset/quadrant-corner-styling.md
@@ -1,9 +1,0 @@
----
-'marking-menu': patch
----
-
-Style corner items by the quadrant they sit in rather than by an exact angle.
-Any item strictly inside a quadrant now gets that quadrant's corner class, so
-free-form angles are covered instead of only the four that used to match
-exactly. Angles on an axis (0, 90, 180, 270) still get no corner class, and
-45/135/225/315 keep the same class as before.

--- a/.changeset/quadrant-corner-styling.md
+++ b/.changeset/quadrant-corner-styling.md
@@ -1,0 +1,9 @@
+---
+'marking-menu': patch
+---
+
+Style corner items by the quadrant they sit in rather than by an exact angle.
+Any item strictly inside a quadrant now gets that quadrant's corner class, so
+free-form angles are covered instead of only the four that used to match
+exactly. Angles on an axis (0, 90, 180, 270) still get no corner class, and
+45/135/225/315 keep the same class as before.

--- a/src/layout/__snapshots__/menu.test.ts.snap
+++ b/src/layout/__snapshots__/menu.test.ts.snap
@@ -21,7 +21,7 @@ exports[`createMenu > can be removed 1`] = `
       </div>
     </div>
     <div
-      class="marking-menu-item"
+      class="marking-menu-item bottom-right-item"
       data-item-id="item-1-key"
       style="--angle: 10deg; --cosine: 0.984807753012208; --sine: -0.17364817766693033;"
     >
@@ -35,7 +35,7 @@ exports[`createMenu > can be removed 1`] = `
       </div>
     </div>
     <div
-      class="marking-menu-item active"
+      class="marking-menu-item bottom-right-item active"
       data-item-id="item-2-key"
       style="--angle: 20deg; --cosine: 0.9396926207859084; --sine: -0.3420201433256687;"
     >
@@ -49,7 +49,7 @@ exports[`createMenu > can be removed 1`] = `
       </div>
     </div>
     <div
-      class="marking-menu-item"
+      class="marking-menu-item bottom-right-item"
       data-item-id="item-3-key"
       style="--angle: 30deg; --cosine: 0.8660254037844387; --sine: -0.49999999999999994;"
     >
@@ -89,7 +89,7 @@ exports[`createMenu > renders 1`] = `
       </div>
     </div>
     <div
-      class="marking-menu-item"
+      class="marking-menu-item bottom-right-item"
       data-item-id="item-1-key"
       style="--angle: 10deg; --cosine: 0.984807753012208; --sine: -0.17364817766693033;"
     >
@@ -103,7 +103,7 @@ exports[`createMenu > renders 1`] = `
       </div>
     </div>
     <div
-      class="marking-menu-item"
+      class="marking-menu-item bottom-right-item"
       data-item-id="item-2-key"
       style="--angle: 20deg; --cosine: 0.9396926207859084; --sine: -0.3420201433256687;"
     >
@@ -117,7 +117,7 @@ exports[`createMenu > renders 1`] = `
       </div>
     </div>
     <div
-      class="marking-menu-item"
+      class="marking-menu-item bottom-right-item"
       data-item-id="item-3-key"
       style="--angle: 30deg; --cosine: 0.8660254037844387; --sine: -0.49999999999999994;"
     >
@@ -131,7 +131,7 @@ exports[`createMenu > renders 1`] = `
       </div>
     </div>
     <div
-      class="marking-menu-item"
+      class="marking-menu-item bottom-right-item"
       data-item-id="item-4-key"
       style="--angle: 40deg; --cosine: 0.766044443118978; --sine: -0.6427876096865393;"
     >
@@ -145,7 +145,7 @@ exports[`createMenu > renders 1`] = `
       </div>
     </div>
     <div
-      class="marking-menu-item active"
+      class="marking-menu-item bottom-right-item active"
       data-item-id="item-5-key"
       style="--angle: 50deg; --cosine: 0.6427876096865394; --sine: -0.766044443118978;"
     >
@@ -183,7 +183,7 @@ exports[`createMenu > renders without active element 1`] = `
       </div>
     </div>
     <div
-      class="marking-menu-item"
+      class="marking-menu-item bottom-right-item"
       data-item-id="item-1-key"
       style="--angle: 10deg; --cosine: 0.984807753012208; --sine: -0.17364817766693033;"
     >
@@ -197,7 +197,7 @@ exports[`createMenu > renders without active element 1`] = `
       </div>
     </div>
     <div
-      class="marking-menu-item"
+      class="marking-menu-item bottom-right-item"
       data-item-id="item-2-key"
       style="--angle: 20deg; --cosine: 0.9396926207859084; --sine: -0.3420201433256687;"
     >
@@ -211,7 +211,7 @@ exports[`createMenu > renders without active element 1`] = `
       </div>
     </div>
     <div
-      class="marking-menu-item"
+      class="marking-menu-item bottom-right-item"
       data-item-id="item-3-key"
       style="--angle: 30deg; --cosine: 0.8660254037844387; --sine: -0.49999999999999994;"
     >
@@ -249,7 +249,7 @@ exports[`createMenu > update the active element 1`] = `
       </div>
     </div>
     <div
-      class="marking-menu-item"
+      class="marking-menu-item bottom-right-item"
       data-item-id="item-1-key"
       style="--angle: 10deg; --cosine: 0.984807753012208; --sine: -0.17364817766693033;"
     >
@@ -263,7 +263,7 @@ exports[`createMenu > update the active element 1`] = `
       </div>
     </div>
     <div
-      class="marking-menu-item active"
+      class="marking-menu-item bottom-right-item active"
       data-item-id="item-2-key"
       style="--angle: 20deg; --cosine: 0.9396926207859084; --sine: -0.3420201433256687;"
     >
@@ -277,7 +277,7 @@ exports[`createMenu > update the active element 1`] = `
       </div>
     </div>
     <div
-      class="marking-menu-item"
+      class="marking-menu-item bottom-right-item"
       data-item-id="item-3-key"
       style="--angle: 30deg; --cosine: 0.8660254037844387; --sine: -0.49999999999999994;"
     >
@@ -315,7 +315,7 @@ exports[`createMenu > update the active element 2`] = `
       </div>
     </div>
     <div
-      class="marking-menu-item active"
+      class="marking-menu-item bottom-right-item active"
       data-item-id="item-1-key"
       style="--angle: 10deg; --cosine: 0.984807753012208; --sine: -0.17364817766693033;"
     >
@@ -329,7 +329,7 @@ exports[`createMenu > update the active element 2`] = `
       </div>
     </div>
     <div
-      class="marking-menu-item"
+      class="marking-menu-item bottom-right-item"
       data-item-id="item-2-key"
       style="--angle: 20deg; --cosine: 0.9396926207859084; --sine: -0.3420201433256687;"
     >
@@ -343,7 +343,7 @@ exports[`createMenu > update the active element 2`] = `
       </div>
     </div>
     <div
-      class="marking-menu-item"
+      class="marking-menu-item bottom-right-item"
       data-item-id="item-3-key"
       style="--angle: 30deg; --cosine: 0.8660254037844387; --sine: -0.49999999999999994;"
     >

--- a/src/layout/menu.test.ts
+++ b/src/layout/menu.test.ts
@@ -63,6 +63,49 @@ describe('createMenu', () => {
     expect((items[4] as Element).className).toBe('marking-menu-item');
   });
 
+  it('styles arbitrary angles by the quadrant they fall in', () => {
+    const div = document.createElement('div');
+    createMenu({
+      parent: div,
+      model: {
+        items: [10, 100, 190, 280, 0, 90, 180, 270, -10, 370].map(
+          (angle, i) => ({
+            label: `item-${i}-name`,
+            angle,
+            key: `item-${i}-key`,
+          }),
+        ),
+      },
+      center: [30, 50],
+      doc: document,
+    });
+    const items = div.querySelectorAll('.marking-menu-item');
+    expect((items[0] as Element).classList.contains('bottom-right-item')).toBe(
+      true,
+    );
+    expect((items[1] as Element).classList.contains('bottom-left-item')).toBe(
+      true,
+    );
+    expect((items[2] as Element).classList.contains('top-left-item')).toBe(
+      true,
+    );
+    expect((items[3] as Element).classList.contains('top-right-item')).toBe(
+      true,
+    );
+    expect((items[4] as Element).className).toBe('marking-menu-item');
+    expect((items[5] as Element).className).toBe('marking-menu-item');
+    expect((items[6] as Element).className).toBe('marking-menu-item');
+    expect((items[7] as Element).className).toBe('marking-menu-item');
+    // -10 is equivalent to 350, inside the top-right quadrant.
+    expect((items[8] as Element).classList.contains('top-right-item')).toBe(
+      true,
+    );
+    // 370 is equivalent to 10, inside the bottom-right quadrant.
+    expect((items[9] as Element).classList.contains('bottom-right-item')).toBe(
+      true,
+    );
+  });
+
   it('update the active element', () => {
     const div = document.createElement('div');
     const m = createMenu({

--- a/src/layout/menu.ts
+++ b/src/layout/menu.ts
@@ -63,13 +63,25 @@ export type Menu = {
   remove: () => void;
 };
 
-// Identify corner items as these may be styled differently.
-const CORNER_ITEM_CLASSES: Record<number, string> = {
-  45: 'bottom-right-item',
-  135: 'bottom-left-item',
-  225: 'top-left-item',
-  315: 'top-right-item',
-};
+// Items may be styled differently near a corner, so the connecting line meets
+// the label squarely. Which corner applies depends on the quadrant the item's
+// angle falls in, not on any exact angle: an axis-aligned angle (0, 90, 180,
+// 270) sits between two quadrants and gets no corner class.
+const CORNER_ITEM_CLASSES = [
+  'bottom-right-item',
+  'bottom-left-item',
+  'top-left-item',
+  'top-right-item',
+];
+
+function getCornerClass(angle: number): string | undefined {
+  const normalizedAngle = ((angle % 360) + 360) % 360;
+  if (normalizedAngle % 90 === 0) {
+    return undefined;
+  }
+
+  return CORNER_ITEM_CLASSES[Math.floor(normalizedAngle / 90)];
+}
 
 const template = (
   { items, center }: { items: readonly MenuLayoutItem[]; center: Point },
@@ -84,7 +96,7 @@ const template = (
     elt.className = 'marking-menu-item';
     elt.dataset.itemId = item.key;
     elt.style.setProperty('--angle', `${item.angle}deg`);
-    const cornerClass = CORNER_ITEM_CLASSES[item.angle];
+    const cornerClass = getCornerClass(item.angle);
     if (cornerClass !== undefined) {
       elt.classList.add(cornerClass);
     }


### PR DESCRIPTION
Corner styling in the menu layout is keyed on exactly four angles: 45, 135, 225, and 315 degrees, each getting a class that squares off the corner where the connecting line meets the label. Item angles are currently always multiples of 45 or 90 degrees, so this covers every case today, but an upcoming change lets items sit at any angle, and once they do, only those four exact values would still match; every other diagonal item would render as if it pointed straight along an axis instead of getting the corner treatment (#241, groundwork for #43).

`getCornerClass()` in `menu.ts` replaces the fixed lookup table with a rule based on which quadrant an angle falls in. Any angle strictly between two axes gets that quadrant's class; an angle lying exactly on an axis (0, 90, 180, or 270 degrees) still gets none, matching the current behavior for horizontal and vertical items. The four angles that used to match exactly keep the same class as before, so this changes nothing for any menu built today.

To check it manually, render a menu with an item at, say, 20 degrees and confirm its element picks up the `bottom-right-item` class, while one at exactly 90 degrees has no corner class.

Existing snapshots only change where items at angles like 10 to 50 degrees now correctly receive `bottom-right-item`; everything else is untouched. A new test covers one angle per quadrant plus all four axis boundaries plus negative and over-360 angles to confirm they wrap around correctly.

No changeset: since no released version's menus can produce an angle other than a multiple of 45 degrees, this has no observable effect until the free-form angle feature ships.
