### PR TITLE
Fix stroke and label geometry, and let the recognizer explain itself

### DIFF
--- a/.changeset/menu-box-sizing.md
+++ b/.changeset/menu-box-sizing.md
@@ -1,0 +1,10 @@
+---
+'marking-menu': patch
+---
+
+Lay the menu out correctly on a page that resets `box-sizing`. The menu's
+stylesheet sizes an item's label by its content and pads around it, and its
+positioning arithmetic adds that padding back. Under a host reset making
+everything `border-box`, as Tailwind's preflight and normalize both do, the
+padding came out of the label instead, leaving its text off centre and its
+box off position. The menu now states the box model it assumes.

--- a/.changeset/stroke-parent-coordinates.md
+++ b/.changeset/stroke-parent-coordinates.md
@@ -1,0 +1,9 @@
+---
+'marking-menu': patch
+---
+
+Draw strokes relative to the parent rather than to the viewport. The renderer
+already placed the menu relative to its parent, but passed the stroke, its
+origin marker and the completed-gesture trace straight through in the client
+coordinates they arrive in, so all three were offset by the parent's own
+position. Only a parent at the viewport's top-left was unaffected.

--- a/src/engine/renderer.test.ts
+++ b/src/engine/renderer.test.ts
@@ -3,6 +3,7 @@ import {
   fakeTimers,
   queryCanvasContext,
   stubbedCanvasContexts,
+  type MockContext,
 } from '../__fixtures__/canvas.js';
 import { createModel } from '../model.js';
 import type { Point } from '../utils.js';
@@ -59,6 +60,31 @@ const createStackingRenderer = (parent: HTMLElement) =>
     lowerStrokeWidth,
     gestureFeedbackStrokeWidth: feedbackStrokeWidth,
   });
+
+/**
+ A parent placed away from the viewport's top-left, which is what tells a
+ stroke drawn in client coordinates apart from one drawn in the parent's.
+ */
+const offsetParent = (left: number, top: number): HTMLDivElement => {
+  const parent = document.createElement('div');
+  parent.getBoundingClientRect = () =>
+    ({ left, top, width: 400, height: 300 }) as unknown as DOMRect;
+  return parent;
+};
+
+/**
+ The points a context was asked to draw the stroke's path through, in order.
+ Calls stop at the `stroke()` that ends the line: the origin marker drawn
+ after it moves the pen too, and that is not part of the line.
+ */
+const pathPoints = (context: MockContext): unknown[] => {
+  const calls = context.mock.methodCalls;
+  const lineEnd = calls.findIndex((call) => call.method === 'stroke');
+  return calls
+    .slice(0, lineEnd === -1 ? calls.length : lineEnd)
+    .filter((call) => call.method === 'moveTo' || call.method === 'lineTo')
+    .map((call) => call.args);
+};
 
 describe('createRenderer', () => {
   it('skips the redraw when the upper stroke is reference-equal to the previous frame', () => {
@@ -268,6 +294,58 @@ describe('createRenderer', () => {
     const selected = queryCanvasContext(parent);
     expect(selected.strokeStyle).toBe('#00ff00');
     expect(selected.lineWidth).toBe(5);
+
+    renderer.dispose();
+  });
+
+  it('draws a stroke relative to a parent that is not at the viewport origin', () => {
+    using _canvases = stubbedCanvasContexts();
+    using _timers = fakeTimers();
+
+    const parent = offsetParent(200, 50);
+    const renderer = createRenderer({ parent, strokeStartPointRadius: 4 });
+
+    renderer.render({
+      cursor: 'none',
+      menu: null,
+      upperStroke: [
+        [220, 60],
+        [260, 90],
+      ],
+      lowerStroke: null,
+    });
+    vi.advanceTimersToNextFrame();
+
+    const context = queryCanvasContext(parent);
+    expect(pathPoints(context)).toEqual([
+      [20, 10],
+      [60, 40],
+    ]);
+    // The origin marker is placed in the same space as the line it starts.
+    const arcCall = context.mock.methodCalls.find((c) => c.method === 'arc');
+    expect(arcCall?.args.slice(0, 2)).toEqual([20, 10]);
+
+    renderer.dispose();
+  });
+
+  it('draws a completed-gesture trace relative to that same parent', () => {
+    using _canvases = stubbedCanvasContexts();
+
+    const parent = offsetParent(200, 50);
+    const renderer = createRenderer({ parent });
+
+    renderer.showFeedback({
+      stroke: [
+        [220, 60],
+        [260, 90],
+      ],
+      canceled: false,
+    });
+
+    expect(pathPoints(queryCanvasContext(parent))).toEqual([
+      [20, 10],
+      [60, 40],
+    ]);
 
     renderer.dispose();
   });

--- a/src/engine/renderer.ts
+++ b/src/engine/renderer.ts
@@ -55,9 +55,16 @@ function createStrokeLayer({
 
   const draw = rafThrottle(
     (stroke: readonly Point[], shouldDrawStartPoint: boolean) => {
+      // Strokes arrive in client coordinates, straight from the pointer; a
+      // canvas draws relative to its own top-left, which is the parent's.
+      // Converting here rather than in `sync` keeps that method's reference
+      // check comparing the array the caller passed, and picks up a parent
+      // that has since moved or scrolled.
+      const rect = parent.getBoundingClientRect();
+      const local = stroke.map((point) => toLocalPoint(point, rect));
       canvas?.clear();
-      canvas?.drawStroke(stroke);
-      const [start] = stroke;
+      canvas?.drawStroke(local);
+      const [start] = local;
       if (shouldDrawStartPoint && start !== undefined) {
         canvas?.drawPoint(start);
       }
@@ -247,9 +254,9 @@ export function createRenderer<M extends AnyModelNode = AnyModelNode>({
         if (menuHandle?.model !== view.menu.model) {
           menuHandle?.menu.remove();
           // `LayoutView.menu.center` is in client coordinates; the menu
-          // layout wants it relative to `parent`. This is the one
-          // DOM-dependent conversion the projector deliberately leaves to
-          // the renderer.
+          // layout wants it relative to `parent`. The projector is
+          // DOM-free, so every such conversion is the renderer's to make
+          // (see `createStrokeLayer` and `showFeedback` for the others).
           const cbr = parent.getBoundingClientRect();
           menuHandle = {
             model: view.menu.model,
@@ -278,7 +285,11 @@ export function createRenderer<M extends AnyModelNode = AnyModelNode>({
       restack();
     },
     showFeedback(effect) {
-      gestureFeedback.show(effect.stroke, { canceled: effect.canceled });
+      const rect = parent.getBoundingClientRect();
+      gestureFeedback.show(
+        effect.stroke.map((point) => toLocalPoint(point, rect)),
+        { canceled: effect.canceled },
+      );
     },
     dispose() {
       parent.style.cursor = ownCursor;

--- a/src/layout/menu.css
+++ b/src/layout/menu.css
@@ -1,3 +1,14 @@
+/* A label is sized by its content and padded around it, and the layout adds
+   that padding back to place it (see `--item-box-width` below). A host reset
+   that makes everything `border-box`, as Tailwind's preflight and normalize
+   both do, would take the padding out of the label instead, dropping its
+   text off centre and its box off position. The menu states the box model
+   its own arithmetic assumes rather than inheriting one. */
+.marking-menu,
+.marking-menu * {
+  box-sizing: content-box;
+}
+
 .marking-menu {
   --item-width: 120px;
   --item-height: 20px;

--- a/src/recognizer/recognize-mm-stroke.test.ts
+++ b/src/recognizer/recognize-mm-stroke.test.ts
@@ -7,12 +7,14 @@ import { type Mock } from 'vitest';
 import type { ModelItem } from '../types.js';
 import type { Point } from '../utils.js';
 import {
+  analyzeMarkingMenuStroke,
   divideLongestSegment,
   findItem,
   pointsToSegments,
   recognizeMarkingMenuStroke,
   walkModel,
 } from './recognize-mm-stroke.js';
+import { strokeLength } from './stroke-length.js';
 
 const STROKES_PATH = path.resolve(
   import.meta.dirname,
@@ -384,5 +386,77 @@ describe('recognizeMarkingMenuStroke', () => {
         requireLeaf: true,
       });
     }).toThrow('The result cannot be both a leaf and a menu');
+  });
+});
+
+describe('analyzeMarkingMenuStroke', () => {
+  it('finds the same path recognizeMarkingMenuStroke would', async () => {
+    const stroke = await readStroke([225, 0, 135].join('-'));
+    const model = createMockModel(3);
+
+    // Mock items are recreated on every `getNearestChild` call (see
+    // `createMockModel`), so the two calls below never share item instances.
+    // `requestedAngle` is what each level was actually reached with, and is
+    // what the other "recognizes real 3 levels strokes" tests already key
+    // off of to compare paths for that same reason.
+    const analysis = analyzeMarkingMenuStroke(stroke, model);
+    const recognized = recognizeMarkingMenuStroke(stroke, model, {
+      requireMenu: false,
+      requireLeaf: false,
+    });
+
+    expect(analysis.path?.at(-1)?.requestedAngle).toBe(
+      recognized?.requestedAngle,
+    );
+    expect(analysis.path?.at(-1)?.parent?.requestedAngle).toBe(
+      recognized?.parent?.requestedAngle,
+    );
+    expect(analysis.path?.at(-1)?.parent?.parent?.requestedAngle).toBe(
+      recognized?.parent?.parent?.requestedAngle,
+    );
+  });
+
+  it('derives the angle threshold from the model breadth', async () => {
+    const stroke = await readStroke(90);
+    const model = createMockModel(1, 8);
+
+    const { angleThreshold } = analyzeMarkingMenuStroke(stroke, model);
+
+    expect(angleThreshold).toBeCloseTo(360 / 8 / 2 / 0.75);
+  });
+
+  it('derives the expected segment length from the stroke length and depth', async () => {
+    const stroke = await readStroke(90);
+    const model = createMockModel(1);
+
+    const { expectedSegmentLength } = analyzeMarkingMenuStroke(stroke, model);
+
+    expect(expectedSegmentLength).toBeCloseTo(strokeLength(stroke) / 1);
+  });
+
+  it('reports articulation points bounding the whole stroke', async () => {
+    const stroke = await readStroke([225, 0, 135].join('-'));
+    const model = createMockModel(3);
+
+    const { articulationPoints } = analyzeMarkingMenuStroke(stroke, model);
+
+    expect(articulationPoints[0]).toEqual(stroke[0]);
+    expect(articulationPoints.at(-1)).toEqual(stroke.at(-1));
+  });
+
+  it('reports segments as a subsequence of the corners joined pairwise', async () => {
+    const stroke = await readStroke([225, 0, 135].join('-'));
+    const model = createMockModel(3);
+
+    const { articulationPoints, segments } = analyzeMarkingMenuStroke(
+      stroke,
+      model,
+    );
+    const everyPossibleSegment = pointsToSegments([...articulationPoints]);
+
+    expect(segments.length).toBeGreaterThan(0);
+    for (const segment of segments) {
+      expect(everyPossibleSegment).toContainEqual(segment.points);
+    }
   });
 });

--- a/src/recognizer/recognize-mm-stroke.ts
+++ b/src/recognizer/recognize-mm-stroke.ts
@@ -19,6 +19,13 @@ type StrokeSegment = {
 };
 
 /**
+ A {@link StrokeSegment} still carrying the two points it was measured
+ between, kept only where a caller needs to draw the segment rather than just
+ walk the model with it.
+ */
+type LocatedStrokeSegment = StrokeSegment & { points: Segment };
+
+/**
  Join the consecutive points of `points` into segments.
 
  @param points - A list of points.
@@ -195,6 +202,68 @@ const getMinAngularGap = (model: AnyModelNode): number =>
   (model as unknown as { getMinAngularGap(): number }).getMinAngularGap();
 
 /**
+ Resolve a (possibly negative) `maxDepth` option against a model.
+
+ @param model - The model the depth is resolved against.
+ @param maxDepthOption - The requested depth. A negative value counts back
+ from the model's own maximum depth.
+ @returns The resolved, non-negative depth.
+ */
+const resolveMaxDepth = (
+  model: AnyModelNode,
+  maxDepthOption: number,
+): number =>
+  maxDepthOption < 0 ? model.getMaxDepth() + maxDepthOption : maxDepthOption;
+
+/**
+ Cut a stroke into the segments a marking-menu walk is attempted against:
+ find its articulation points, then join them pairwise, dropping segments too
+ short to be a deliberate move. Shared by {@link recognizeMarkingMenuStroke}
+ and {@link analyzeMarkingMenuStroke} so the two can never disagree on the
+ threshold or segments a stroke produced.
+
+ @param stroke - A list of points.
+ @param model - The model the stroke is recognized against, for the smallest
+ gap between two of its neighboring items.
+ @param maxDepth - The already-resolved maximum menu depth to walk.
+ @returns The threshold and segmentation the stroke was cut into.
+ */
+const cutStroke = (
+  stroke: readonly Point[],
+  model: AnyModelNode,
+  maxDepth: number,
+): {
+  angleThreshold: number;
+  expectedSegmentLength: number;
+  articulationPoints: Point[];
+  segments: LocatedStrokeSegment[];
+} => {
+  const length = strokeLength(stroke);
+  const expectedSegmentLength = length / maxDepth;
+  const sensitivity = 0.75;
+  const angleThreshold = getMinAngularGap(model) / 2 / sensitivity;
+  const articulationPoints = getStrokeArticulationPoints(stroke, {
+    expectedSegmentLength,
+    angleThreshold,
+  });
+  const minSegmentSize = expectedSegmentLength / 3;
+  // Get the segments of the marking menus.
+  const segments = pointsToSegments(articulationPoints)
+    // Change the representation of the segment to include its length.
+    .map((seg) => ({ points: seg, length: dist(...seg) }))
+    // Remove the segments that are too small.
+    .filter((seg) => seg.length > minSegmentSize)
+    // Add each segment's angle, keeping its points for callers that draw it.
+    .map((seg) => ({ ...seg, angle: segmentAngle(...seg.points) }));
+  return {
+    angleThreshold,
+    expectedSegmentLength,
+    articulationPoints,
+    segments,
+  };
+};
+
+/**
  Recognize the item selected by a marking menu stroke.
 
  @param stroke - A list of points.
@@ -242,30 +311,8 @@ export function recognizeMarkingMenuStroke<N extends AnyModelNode>(
     throw new Error('The result cannot be both a leaf and a menu');
   }
 
-  const maxDepth =
-    maxDepthOption < 0 ? model.getMaxDepth() + maxDepthOption : maxDepthOption;
-  const minAngularGap = getMinAngularGap(model);
-  const length = strokeLength(stroke);
-  const expectedSegmentLength = length / maxDepth;
-  const sensitivity = 0.75;
-  const angleThreshold = minAngularGap / 2 / sensitivity;
-  const articulationPoints = getStrokeArticulationPoints(stroke, {
-    expectedSegmentLength,
-    angleThreshold,
-  });
-  const minSegmentSize = expectedSegmentLength / 3;
-  // Get the segments of the marking menus.
-  const segments = pointsToSegments(articulationPoints)
-    // Change the representation of the segment to include its length.
-    .map((seg) => ({ points: seg, length: dist(...seg) }))
-    // Remove the segments that are too small.
-    .filter((seg) => seg.length > minSegmentSize)
-    // Change again the representation of the segment to include its length but not its
-    // its points anymore.
-    .map((seg) => ({
-      angle: segmentAngle(...seg.points),
-      length: seg.length,
-    }));
+  const maxDepth = resolveMaxDepth(model, maxDepthOption);
+  const { segments } = cutStroke(stroke, model, maxDepth);
   const path = findItem({ model, segments, maxDepth });
   // Paths are never empty, so the item is only nullish when the path is.
   const item = path?.at(-1) ?? null;
@@ -288,4 +335,77 @@ export function recognizeMarkingMenuStroke<N extends AnyModelNode>(
   }
 
   return item;
+}
+
+/**
+ What a stroke recognition attempt did, on top of the item it landed on: the
+ threshold applied, the corners found, and the pieces the stroke was cut into.
+ Meant for a caller that displays this rather than just acting on the result
+ (see {@link analyzeMarkingMenuStroke}).
+ */
+export type MarkingMenuStrokeAnalysis<N extends AnyModelNode> = {
+  /**
+  The angle, in degrees, past which a bend in the stroke counts as a corner.
+  */
+  readonly angleThreshold: number;
+  /**
+  The segment length the stroke was expected to divide into, given its total
+  length and the depth walked.
+  */
+  readonly expectedSegmentLength: number;
+  /**
+  The points along the stroke recognized as corners, start and end included.
+  */
+  readonly articulationPoints: readonly Point[];
+  /**
+  The pieces the stroke was cut into between corners, each with the two
+  points it spans, its length, and its angle. Short pieces between corners
+  are already dropped, but a menu deeper than this list is long is walked by
+  further dividing the longest piece, which invents a piece with no point of
+  its own to draw; `path` still reflects that division, this list does not.
+  */
+  readonly segments: readonly LocatedStrokeSegment[];
+  /**
+  The path the stroke was walked down, or `null` if it does not lead
+  anywhere in the model.
+  */
+  readonly path: NonEmptyArray<ModelNodes<N>> | null;
+};
+
+/**
+ Recognize a marking menu stroke like {@link recognizeMarkingMenuStroke},
+ while also reporting the threshold, corners and pieces the recognition
+ relied on, for a caller that wants to show that reasoning rather than just
+ use its outcome.
+
+ @param stroke - A list of points.
+ @param model - The model to recognize the stroke against.
+ @param options - Additional options.
+ @param options.maxDepth - The maximum menu depth to walk. If negative,
+ start from the maximum depth of the model.
+ @returns The full analysis of the recognition attempt.
+ */
+export function analyzeMarkingMenuStroke<N extends AnyModelNode>(
+  stroke: readonly Point[],
+  model: N,
+  options?: { maxDepth?: number },
+): MarkingMenuStrokeAnalysis<N> {
+  const maxDepth = resolveMaxDepth(
+    model,
+    options?.maxDepth ?? model.getMaxDepth(),
+  );
+  const {
+    angleThreshold,
+    expectedSegmentLength,
+    articulationPoints,
+    segments,
+  } = cutStroke(stroke, model, maxDepth);
+  const path = findItem({ model, segments, maxDepth });
+  return {
+    angleThreshold,
+    expectedSegmentLength,
+    articulationPoints,
+    segments,
+    path,
+  };
 }


### PR DESCRIPTION
Three library changes, all found while building the playground page in #249 and all independent of it.

The renderer converts the menu's center from the client coordinates the machine works in to coordinates relative to its parent, but passed the stroke, its origin marker and the completed-gesture trace straight through. All three were drawn offset by the parent's own position, so only a parent sitting at the viewport's top-left came out right. The demo page's parent happens to be exactly that, which is why this went unnoticed. The conversion now happens where the canvases are drawn, per frame, so it also picks up a parent that has moved or scrolled.

The menu's stylesheet sizes an item's label by its content and pads around it, and its positioning arithmetic adds that padding back through `--item-box-width`. On a page that resets `box-sizing` to `border-box`, which Tailwind's preflight and normalize both do, the padding came out of the label instead: its text sat off center inside a box narrower than the layout had placed it for. The stylesheet now states the box model its own arithmetic assumes.

Last, `recognizeMarkingMenuStroke` answers which item a stroke lands on and nothing else, so a caller that wants to show the recognizer's reasoning cannot see the corners it found, the pieces it cut the stroke into, or the threshold it used. `analyzeMarkingMenuStroke` returns those alongside the path walked. The segmentation both functions rely on moves into a shared `cutStroke` so the two can never disagree, and each segment carries the two points it spans so the pieces can be drawn where they were found. Neither function is a public export; the recognizer stays internal.

To see the first two, put a menu in a parent that is not at the top-left of the page, on a page with a CSS reset, and draw a mark. Before this change the stroke trails the pointer by the parent's offset and the item labels sit low in their boxes.

The two fixes carry changesets and are patch releases. The recognizer addition does not, since it changes nothing that is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
