### PR TITLE
Draw strokes relative to the parent, not the viewport

### DIFF
--- a/.changeset/stroke-parent-coordinates.md
+++ b/.changeset/stroke-parent-coordinates.md
@@ -1,0 +1,9 @@
+---
+'marking-menu': patch
+---
+
+Draw strokes relative to the parent rather than to the viewport. The renderer
+already placed the menu relative to its parent, but passed the stroke, its
+origin marker and the completed-gesture trace straight through in the client
+coordinates they arrive in, so all three were offset by the parent's own
+position. Only a parent at the viewport's top-left was unaffected.

--- a/src/engine/renderer.test.ts
+++ b/src/engine/renderer.test.ts
@@ -3,6 +3,7 @@ import {
   fakeTimers,
   queryCanvasContext,
   stubbedCanvasContexts,
+  type MockContext,
 } from '../__fixtures__/canvas.js';
 import { createModel } from '../model.js';
 import type { Point } from '../utils.js';
@@ -59,6 +60,31 @@ const createStackingRenderer = (parent: HTMLElement) =>
     lowerStrokeWidth,
     gestureFeedbackStrokeWidth: feedbackStrokeWidth,
   });
+
+/**
+ A parent placed away from the viewport's top-left, which is what tells a
+ stroke drawn in client coordinates apart from one drawn in the parent's.
+ */
+const offsetParent = (left: number, top: number): HTMLDivElement => {
+  const parent = document.createElement('div');
+  parent.getBoundingClientRect = () =>
+    ({ left, top, width: 400, height: 300 }) as unknown as DOMRect;
+  return parent;
+};
+
+/**
+ The points a context was asked to draw the stroke's path through, in order.
+ Calls stop at the `stroke()` that ends the line: the origin marker drawn
+ after it moves the pen too, and that is not part of the line.
+ */
+const pathPoints = (context: MockContext): unknown[] => {
+  const calls = context.mock.methodCalls;
+  const lineEnd = calls.findIndex((call) => call.method === 'stroke');
+  return calls
+    .slice(0, lineEnd === -1 ? calls.length : lineEnd)
+    .filter((call) => call.method === 'moveTo' || call.method === 'lineTo')
+    .map((call) => call.args);
+};
 
 describe('createRenderer', () => {
   it('skips the redraw when the upper stroke is reference-equal to the previous frame', () => {
@@ -268,6 +294,58 @@ describe('createRenderer', () => {
     const selected = queryCanvasContext(parent);
     expect(selected.strokeStyle).toBe('#00ff00');
     expect(selected.lineWidth).toBe(5);
+
+    renderer.dispose();
+  });
+
+  it('draws a stroke relative to a parent that is not at the viewport origin', () => {
+    using _canvases = stubbedCanvasContexts();
+    using _timers = fakeTimers();
+
+    const parent = offsetParent(200, 50);
+    const renderer = createRenderer({ parent, strokeStartPointRadius: 4 });
+
+    renderer.render({
+      cursor: 'none',
+      menu: null,
+      upperStroke: [
+        [220, 60],
+        [260, 90],
+      ],
+      lowerStroke: null,
+    });
+    vi.advanceTimersToNextFrame();
+
+    const context = queryCanvasContext(parent);
+    expect(pathPoints(context)).toEqual([
+      [20, 10],
+      [60, 40],
+    ]);
+    // The origin marker is placed in the same space as the line it starts.
+    const arcCall = context.mock.methodCalls.find((c) => c.method === 'arc');
+    expect(arcCall?.args.slice(0, 2)).toEqual([20, 10]);
+
+    renderer.dispose();
+  });
+
+  it('draws a completed-gesture trace relative to that same parent', () => {
+    using _canvases = stubbedCanvasContexts();
+
+    const parent = offsetParent(200, 50);
+    const renderer = createRenderer({ parent });
+
+    renderer.showFeedback({
+      stroke: [
+        [220, 60],
+        [260, 90],
+      ],
+      canceled: false,
+    });
+
+    expect(pathPoints(queryCanvasContext(parent))).toEqual([
+      [20, 10],
+      [60, 40],
+    ]);
 
     renderer.dispose();
   });

--- a/src/engine/renderer.ts
+++ b/src/engine/renderer.ts
@@ -55,9 +55,16 @@ function createStrokeLayer({
 
   const draw = rafThrottle(
     (stroke: readonly Point[], shouldDrawStartPoint: boolean) => {
+      // Strokes arrive in client coordinates, straight from the pointer; a
+      // canvas draws relative to its own top-left, which is the parent's.
+      // Converting here rather than in `sync` keeps that method's reference
+      // check comparing the array the caller passed, and picks up a parent
+      // that has since moved or scrolled.
+      const rect = parent.getBoundingClientRect();
+      const local = stroke.map((point) => toLocalPoint(point, rect));
       canvas?.clear();
-      canvas?.drawStroke(stroke);
-      const [start] = stroke;
+      canvas?.drawStroke(local);
+      const [start] = local;
       if (shouldDrawStartPoint && start !== undefined) {
         canvas?.drawPoint(start);
       }
@@ -247,9 +254,9 @@ export function createRenderer<M extends AnyModelNode = AnyModelNode>({
         if (menuHandle?.model !== view.menu.model) {
           menuHandle?.menu.remove();
           // `LayoutView.menu.center` is in client coordinates; the menu
-          // layout wants it relative to `parent`. This is the one
-          // DOM-dependent conversion the projector deliberately leaves to
-          // the renderer.
+          // layout wants it relative to `parent`. The projector is
+          // DOM-free, so every such conversion is the renderer's to make
+          // (see `createStrokeLayer` and `showFeedback` for the others).
           const cbr = parent.getBoundingClientRect();
           menuHandle = {
             model: view.menu.model,
@@ -278,7 +285,11 @@ export function createRenderer<M extends AnyModelNode = AnyModelNode>({
       restack();
     },
     showFeedback(effect) {
-      gestureFeedback.show(effect.stroke, { canceled: effect.canceled });
+      const rect = parent.getBoundingClientRect();
+      gestureFeedback.show(
+        effect.stroke.map((point) => toLocalPoint(point, rect)),
+        { canceled: effect.canceled },
+      );
     },
     dispose() {
       parent.style.cursor = ownCursor;


### PR DESCRIPTION
The renderer converts the menu's center from the client coordinates the machine works in to coordinates relative to its parent, but passes the stroke, its origin marker and the completed-gesture trace straight through. All three are drawn on canvases positioned at the parent's top-left, so all three came out offset by the parent's own position.

Only a parent sitting at the viewport's top-left was unaffected, which is why this went unnoticed: the demo page's `#main` is exactly that. Put a menu anywhere else on a page and the stroke trails the pointer by the parent's offset.

The conversion now happens where the canvases are drawn. `createStrokeLayer` reads the parent's rectangle per frame, so it also picks up a parent that has moved or scrolled, and its reference check still compares the array the caller passed rather than a mapped copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
