### PR TITLE
Keep the menu's box model under a host reset

### DIFF
--- a/.changeset/menu-box-sizing.md
+++ b/.changeset/menu-box-sizing.md
@@ -1,0 +1,10 @@
+---
+'marking-menu': patch
+---
+
+Lay the menu out correctly on a page that resets `box-sizing`. The menu's
+stylesheet sizes an item's label by its content and pads around it, and its
+positioning arithmetic adds that padding back. Under a host reset making
+everything `border-box`, as Tailwind's preflight and normalize both do, the
+padding came out of the label instead, leaving its text off centre and its
+box off position. The menu now states the box model it assumes.

--- a/src/layout/menu.css
+++ b/src/layout/menu.css
@@ -1,3 +1,14 @@
+/* A label is sized by its content and padded around it, and the layout adds
+   that padding back to place it (see `--item-box-width` below). A host reset
+   that makes everything `border-box`, as Tailwind's preflight and normalize
+   both do, would take the padding out of the label instead, dropping its
+   text off centre and its box off position. The menu states the box model
+   its own arithmetic assumes rather than inheriting one. */
+.marking-menu,
+.marking-menu * {
+  box-sizing: content-box;
+}
+
 .marking-menu {
   --item-width: 120px;
   --item-height: 20px;


### PR DESCRIPTION
The menu's stylesheet sizes an item's label by its content and pads around it, and its positioning arithmetic adds that padding back through `--item-box-width`. On a page that resets `box-sizing` to `border-box`, which Tailwind's preflight and normalize both do, the padding came out of the label instead: its text sat off center inside a box narrower than the layout had placed it for.

The stylesheet now states the box model its own arithmetic assumes rather than inheriting whatever the host page sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
