### PR TITLE
Spread menu items evenly at every count

### DIFF
--- a/.changeset/even-menu-layout.md
+++ b/.changeset/even-menu-layout.md
@@ -2,5 +2,7 @@
 'marking-menu': major
 ---
 
-Lay out each menu level evenly around the full circle. Items in menus with 5,
-6, or 7 entries move to new angles, so users must relearn those gestures.
+Lay out each menu level evenly around the full circle to prevent unused
+directions and overlapping items. This moves items in 5-item, 6-item, and
+7-item menus. To preserve existing gestures, wait for #244 and set each
+item's `angle` explicitly.

--- a/.changeset/even-menu-layout.md
+++ b/.changeset/even-menu-layout.md
@@ -1,0 +1,6 @@
+---
+'marking-menu': major
+---
+
+Lay out each menu level evenly around the full circle. Items in menus with 5,
+6, or 7 entries move to new angles, so users must relearn those gestures.

--- a/.changeset/even-menu-layout.md
+++ b/.changeset/even-menu-layout.md
@@ -4,5 +4,5 @@
 
 Lay out each menu level evenly around the full circle to prevent unused
 directions and overlapping items. This moves items in 5-item, 6-item, and
-7-item menus. To preserve existing gestures, wait for #244 and set each
+7-item menus. To preserve existing layout, wait for #244 and set each
 item's `angle` explicitly.

--- a/src/model.test.ts
+++ b/src/model.test.ts
@@ -24,7 +24,81 @@ describe('createModel', () => {
     expect(menu.items.map((item) => item.angle)).toEqual([0, 90, 180, 270]);
   });
 
-  it('lays out more than four items every 45 degrees', () => {
+  it('spreads three items evenly around the circle', () => {
+    const menu = createModel({
+      items: [{ label: 'One' }, { label: 'Two' }, { label: 'Three' }],
+    });
+    expect(menu.items.map((item) => item.angle)).toEqual([0, 120, 240]);
+  });
+
+  it('spreads five items evenly around the circle', () => {
+    const menu = createModel({
+      items: [
+        { label: 'One' },
+        { label: 'Two' },
+        { label: 'Three' },
+        { label: 'Four' },
+        { label: 'Five' },
+      ],
+    });
+    expect(menu.items.map((item) => item.angle)).toEqual([
+      0, 72, 144, 216, 288,
+    ]);
+  });
+
+  it.each([
+    { count: 6, angles: [0, 60, 120, 180, 240, 300] },
+    {
+      count: 7,
+      angles: [
+        0, 51.42857142857143, 102.85714285714286, 154.28571428571428,
+        205.71428571428572, 257.14285714285717, 308.57142857142856,
+      ],
+    },
+  ])('spreads $count items evenly around the circle', ({ count, angles }) => {
+    const menu = createModel({
+      items: Array.from({ length: count }, (_, index) => ({
+        label: `Item ${index}`,
+      })),
+    });
+    expect(menu.items.map((item) => item.angle)).toEqual(angles);
+  });
+
+  it('keeps angles below 360 degrees for a nine-item level', () => {
+    const menu = createModel({
+      items: Array.from({ length: 9 }, (_, index) => ({
+        label: `Item ${index}`,
+      })),
+    });
+    expect(menu.items.map((item) => item.angle)).toEqual([
+      0, 40, 80, 120, 160, 200, 240, 280, 320,
+    ]);
+  });
+
+  it('spaces each level from its own item count', () => {
+    const menu = createModel({
+      items: [
+        {
+          label: 'Parent',
+          items: [
+            { label: 'One' },
+            { label: 'Two' },
+            { label: 'Three' },
+            { label: 'Four' },
+            { label: 'Five' },
+          ],
+        },
+        { label: 'Second' },
+        { label: 'Third' },
+      ],
+    });
+    expect(menu.items.map((item) => item.angle)).toEqual([0, 120, 240]);
+    expect(menu.items[0].items.map((item) => item.angle)).toEqual([
+      0, 72, 144, 216, 288,
+    ]);
+  });
+
+  it('lays out eight items every 45 degrees', () => {
     const menu = createModel({
       items: [
         { label: 'Sub 1' },
@@ -33,10 +107,12 @@ describe('createModel', () => {
         { label: 'Sub 4' },
         { label: 'Sub 5' },
         { label: 'Sub 6' },
+        { label: 'Sub 7' },
+        { label: 'Sub 8' },
       ],
     });
     expect(menu.items.map((item) => item.angle)).toEqual([
-      0, 45, 90, 135, 180, 225,
+      0, 45, 90, 135, 180, 225, 270, 315,
     ]);
   });
 
@@ -223,8 +299,8 @@ describe('createModel', () => {
         },
       ],
     });
-    expect(getMinAngularGap(menu)).toBe(45);
-    expect(getMinAngularGap(menu.items[1])).toBe(45);
+    expect(getMinAngularGap(menu)).toBe(72);
+    expect(getMinAngularGap(menu.items[1])).toBe(72);
   });
 
   it('reports no gap for a level with fewer than two items', () => {
@@ -247,7 +323,7 @@ describe('createModel', () => {
   it('does not let the items be mutated', () => {
     const menu = createModel({ items: [{ id: 'right', label: 'Right' }] });
     expect(() => {
-      // @ts-expect-error -- exactly what is being checked at runtime.
+      // @ts-expect-error, exactly what is being checked at runtime.
       menu.items[0].label = 'Mutated';
     }).toThrow(TypeError);
     expect(menu.items[0].label).toBe('Right');
@@ -295,7 +371,7 @@ describe('createModel', () => {
     expect(dynamic).toEqual(literal);
     expect(dynamic.getChild('right')?.angle).toBe(0);
     expect(dynamic.getChild('unknown')).toBeNull();
-    expect(dynamic.getNearestChild(90)?.label).toBe('Bottom');
+    expect(dynamic.getNearestChild(90)?.label).toBe('Right');
     expect(dynamic.getMaxDepth()).toBe(2);
   });
 });

--- a/src/model.ts
+++ b/src/model.ts
@@ -234,9 +234,6 @@ export type MarkingMenuModel<Input extends MarkingMenuInput> = NodeAt<
  * Implementation
  * -------------------------------------------------------------------------- */
 
-const getAngleRange = (items: readonly unknown[]): number =>
-  items.length > 4 ? 45 : 90;
-
 /**
  The behavior shared by the root of the menu and its items.
 
@@ -462,7 +459,7 @@ const createItems = (
   seenIds: Set<string> = new Set(),
   baseKey?: string,
 ): readonly MarkingMenuItem[] => {
-  const angleRange = getAngleRange(inputs);
+  const angleStep = 360 / inputs.length;
   return Object.freeze(
     inputs.map((input, index) => {
       if (input.id !== undefined) {
@@ -480,7 +477,7 @@ const createItems = (
       return new MarkingMenuItem({
         id: input.id,
         label: input.label,
-        angle: index * angleRange,
+        angle: index * angleStep,
         key,
         parent,
         items: (self) =>

--- a/src/recognizer/__fixtures__/stroke-corpus.ts
+++ b/src/recognizer/__fixtures__/stroke-corpus.ts
@@ -10,14 +10,10 @@ import { createRandom } from './random.js';
  `../generated-stroke-corpus.test.ts`), kept in its own file so the test
  file stays focused on the calibration and the assertions.
 
- A list of counts is an angle configuration as much as a single count is:
- `createModel` spaces each level by that level's own count (see
- `getAngleRange` in `../../model.ts`), so `[4, 8]` walks a 90-degree-spaced
- top level into a 45-degree-spaced submenu, a spacing no single uniform
- breadth produces. The menus are built with `createModel` itself, rather
- than from any hardcoded angle table, so a change to how `createModel` lays
- a level out changes what this corpus measures on its next run, with
- nothing here to update by hand.
+ A list of counts maps to a distinct collection of angles: `createModel`
+ spaces each level from its own item count. `[4, 8]` starts 90 degrees apart
+ and enters a 45-degree submenu. The corpus builds menus through
+ `createModel`, so it measures the layout currently used by the library.
  */
 
 type EvenItem = { label: string; items?: EvenItem[] };

--- a/src/recognizer/generated-stroke-corpus.test.ts
+++ b/src/recognizer/generated-stroke-corpus.test.ts
@@ -45,14 +45,9 @@ import { measureAccuracy } from './__fixtures__/stroke-corpus.js';
  levels compounds three independent per-level draws, which is why its
  accuracy sits below one level's for both breadths.
 
- Item counts of 5, 6 and 7 use the library's current, crowded layout rather
- than an evenly spaced one (see issue #43), and a menu whose levels hold
- different counts is an angle configuration of its own: `createModel` spaces
- each level by that level's own count, so `[4, 8]` walks a 90-degree-spaced
- top level into a 45-degree-spaced submenu, a spacing no single uniform
- breadth produces. Both are swept and reported below for later work to
- compare against, but neither is held to a floor of their own: stating an
- item's own angle doesn't exist yet either, and that is what issue #43 adds.
+ Menus with 3, 5, 6, and 7 items are also evenly spaced. Their one-level
+ accuracy stays at or above 98%, so the corpus holds that floor alongside the
+ existing 4- and 8-item calibration checks.
  */
 
 describe('generated stroke corpus', () => {
@@ -73,13 +68,9 @@ describe('generated stroke corpus', () => {
     );
   });
 
-  describe('sweeping item counts the library does not yet lay out evenly', () => {
-    // These counts share their layout's 45-degree step with the 8-item menu
-    // above (see `getAngleRange` in `../model.ts`), so a sane implementation
-    // scores in the same ballpark; nothing here pins that down as a
-    // requirement, only reports it.
+  describe('menus newly laid out evenly', () => {
     it.each([3, 5, 6, 7])(
-      'reports an accuracy for a %i-item, 1 level menu',
+      'recognizes a %i-item, 1 level menu at or above 98%',
       (breadth) => {
         const accuracy = measureAccuracy({
           breadths: [breadth],
@@ -87,8 +78,7 @@ describe('generated stroke corpus', () => {
           seed: breadth * 1000,
         });
 
-        expect(accuracy).toBeGreaterThan(0);
-        expect(accuracy).toBeLessThanOrEqual(1);
+        expect(accuracy).toBeGreaterThanOrEqual(0.98);
       },
     );
   });


### PR DESCRIPTION
## Summary

- Space each level's items evenly.
- Keep 4-item and 8-item angles unchanged. Move 5-item, 6-item, and 7-item angles.
- Hold generated-corpus accuracy for 3-item, 5-item, 6-item, and 7-item menus at 98% or above.

## Tests

- `yarn test`
- `yarn typecheck`
- `yarn lint`
- `yarn format:check`
- `yarn build`
- `yarn package:lint`
- `yarn package:types`
- `yarn package:smoke-test`

Fixes #243