### PR TITLE
Let items state their own angle

### DIFF
--- a/.changeset/even-menu-layout.md
+++ b/.changeset/even-menu-layout.md
@@ -4,5 +4,4 @@
 
 Lay out each menu level evenly around the full circle to prevent unused
 directions and overlapping items. This moves items in 5-item, 6-item, and
-7-item menus. To preserve existing layout, wait for #244 and set each
-item's `angle` explicitly.
+7-item menus. Set an item's `angle` to preserve its existing position.

--- a/.changeset/item-angles.md
+++ b/.changeset/item-angles.md
@@ -1,0 +1,6 @@
+---
+'marking-menu': minor
+---
+
+Let items set an optional clockwise `angle` in degrees. Items without an
+angle fill the gaps between stated angles.

--- a/demo/menu-config.test.ts
+++ b/demo/menu-config.test.ts
@@ -4,7 +4,7 @@ import { readMenuConfig, writeMenuConfig } from './menu-config.js';
 
 const menu: MarkingMenuInput = {
   items: [
-    { id: 'a', label: 'A', items: [{ label: 'A1' }] },
+    { angle: 45, id: 'a', label: 'A', items: [{ angle: 90, label: 'A1' }] },
     { label: 'Wait, (really) @ home?' },
   ],
 };
@@ -35,5 +35,13 @@ describe('readMenuConfig / writeMenuConfig', () => {
 
   it('reads no menu from JSON of the wrong shape', () => {
     expect(readMenuConfig('?config=%7B%22items%22%3A%5B4%5D%7D')).toBeNull();
+  });
+
+  it('rejects a non-finite item angle', () => {
+    expect(
+      readMenuConfig(
+        '?config=%7B%22items%22%3A%5B%7B%22label%22%3A%22A%22%2C%22angle%22%3A1e999%7D%5D%7D',
+      ),
+    ).toBeNull();
   });
 });

--- a/demo/menu-config.ts
+++ b/demo/menu-config.ts
@@ -57,9 +57,11 @@ function asItem(value: unknown): MarkingMenuItemInput | null {
     return null;
   }
 
-  const { id, label, items } = value;
+  const { angle, id, label, items } = value;
   if (
     typeof label !== 'string' ||
+    (angle !== undefined &&
+      (typeof angle !== 'number' || !Number.isFinite(angle))) ||
     (id !== undefined && typeof id !== 'string')
   ) {
     return null;
@@ -71,6 +73,7 @@ function asItem(value: unknown): MarkingMenuItemInput | null {
   }
 
   return {
+    ...(angle !== undefined && { angle }),
     ...(id !== undefined && { id }),
     label,
     ...(items !== undefined && { items: nested }),

--- a/demo/playground/menu-schema.test-d.ts
+++ b/demo/playground/menu-schema.test-d.ts
@@ -12,10 +12,9 @@ import { menuSchema } from './menu-schema.js';
  completion for a menu the library no longer accepts, nor stay silent about a
  field it has grown. It is checked by `tsc`, not run.
 
- The angle of issue #43 is the case this exists for: adding one to
- `MarkingMenuItemInput` fails the key assertion below until this schema has
- one too, and with it the shape check a shared link goes through (see
- `demo/menu-config.ts`).
+ Adding a field to `MarkingMenuItemInput` fails the key assertion below until
+ the schema describes it too. The shape check then carries it through shared
+ links in `demo/menu-config.ts`.
  */
 
 /**

--- a/demo/playground/menu-schema.test.ts
+++ b/demo/playground/menu-schema.test.ts
@@ -16,9 +16,19 @@ describe('validateMenuSource', () => {
     expect(validateMenuSource(source).ok).toBe(true);
   });
 
-  it('rejects a property the library has no use for', () => {
+  it('accepts an item with an angle', () => {
     const result = validateMenuSource(
       '{ "items": [{ "label": "Right", "angle": 45 }] }',
+    );
+    expect(result).toEqual({
+      ok: true,
+      menu: { items: [{ angle: 45, label: 'Right' }] },
+    });
+  });
+
+  it('rejects an unknown item property', () => {
+    const result = validateMenuSource(
+      '{ "items": [{ "label": "Right", "unknown": true }] }',
     );
     expect(result.ok).toBe(false);
   });

--- a/demo/playground/menu-schema.ts
+++ b/demo/playground/menu-schema.ts
@@ -10,10 +10,8 @@ import type { MarkingMenuInput } from '../../src/types.js';
  It is not published with the package, hence no `$id`: there is no URL it
  could be fetched from.
 
- It has no `angle`, because the library has none: `src/model.ts` lays every
- item out at `index * (items.length > 4 ? 45 : 90)`. Per-item angles are
- issue #43; `menu-schema.test-d.ts` fails the moment the input type grows a
- field this schema does not have.
+ The schema mirrors every field in `MarkingMenuInput`.
+ `menu-schema.test-d.ts` fails when the input type and schema differ.
  */
 export const menuSchema = {
   $schema: 'https://json-schema.org/draft/2020-12/schema',
@@ -37,7 +35,7 @@ export const menuSchema = {
       type: 'array',
       title: 'Menu level',
       description:
-        'One level of the menu. Items are laid out clockwise starting to the right, evenly spread: 90 degrees apart up to four items, 45 degrees apart beyond that. The order here is the order around the circle.',
+        'One level of the menu. Items appear clockwise in the order listed here.',
       items: { $ref: '#/$defs/item' },
     },
     item: {
@@ -59,6 +57,12 @@ export const menuSchema = {
           title: 'Label',
           description:
             'The text drawn on the item, and what a selection reports back. Required.',
+        },
+        angle: {
+          type: 'number',
+          title: 'Angle',
+          description:
+            'A clockwise angle in degrees from the right. Optional. Items without one fill the gaps between stated angles.',
         },
         items: {
           $ref: '#/$defs/items',

--- a/demo/playground/menu-source.ts
+++ b/demo/playground/menu-source.ts
@@ -32,6 +32,9 @@ function formatItem(item: MarkingMenuItemInput, indent: string): string {
   const fields = [
     ...(item.id === undefined ? [] : [`"id": ${JSON.stringify(item.id)}`]),
     `"label": ${JSON.stringify(item.label)}`,
+    ...(item.angle === undefined
+      ? []
+      : [`"angle": ${JSON.stringify(item.angle)}`]),
   ];
   if (item.items === undefined) {
     return `{ ${fields.join(', ')} }`;

--- a/src/model.test.ts
+++ b/src/model.test.ts
@@ -417,6 +417,18 @@ describe('createModel', () => {
     ).toThrow(/different angles/v);
   });
 
+  it('rejects a repeated non-first angle', () => {
+    expect(() =>
+      createModel({
+        items: [
+          { angle: 10, label: 'First' },
+          { angle: 50, label: 'Second' },
+          { angle: 50, label: 'Third' },
+        ],
+      }),
+    ).toThrow(/different angles/v);
+  });
+
   it('rejects stated angles that need more than one turn', () => {
     expect(() =>
       createModel({

--- a/src/model.test.ts
+++ b/src/model.test.ts
@@ -116,6 +116,74 @@ describe('createModel', () => {
     ]);
   });
 
+  it('keeps stated angles at every level', () => {
+    const menu = createModel({
+      items: [
+        {
+          angle: 45,
+          label: 'Parent',
+          items: [
+            { angle: 20, label: 'First' },
+            { label: 'Free' },
+            { angle: 140, label: 'Last' },
+          ],
+        },
+        { label: 'Other' },
+      ],
+    });
+
+    expect(menu.items.map((item) => item.angle)).toEqual([45, 225]);
+    expect(menu.items[0].items.map((item) => item.angle)).toEqual([
+      20, 80, 140,
+    ]);
+  });
+
+  it('spreads free items across each stated-angle gap', () => {
+    const menu = createModel({
+      items: [
+        { angle: 0, label: 'First' },
+        { label: 'Second' },
+        { label: 'Third' },
+        { angle: 180, label: 'Fourth' },
+        { label: 'Fifth' },
+      ],
+    });
+
+    expect(menu.items.map((item) => item.angle)).toEqual([
+      0, 60, 120, 180, 270,
+    ]);
+  });
+
+  it('rotates an even circle around one stated angle', () => {
+    const menu = createModel({
+      items: [
+        { label: 'First' },
+        { label: 'Second' },
+        { angle: 90, label: 'Third' },
+        { label: 'Fourth' },
+      ],
+    });
+
+    expect(menu.items.map((item) => item.angle)).toEqual([270, 0, 90, 180]);
+  });
+
+  it('wraps stated angles while keeping listing order clockwise', () => {
+    const menu = createModel({
+      items: [
+        { angle: 270, label: 'First' },
+        { label: 'Second' },
+        { angle: 0, label: 'Third' },
+        { angle: 90, label: 'Fourth' },
+      ],
+    });
+
+    expect(menu.items.map((item) => item.angle)).toEqual([270, 315, 0, 90]);
+    for (const item of menu.items) {
+      expect(item.angle).toBeGreaterThanOrEqual(0);
+      expect(item.angle).toBeLessThan(360);
+    }
+  });
+
   it('keeps the ids and the labels of the items, at every level', () => {
     const menu = createModel({
       items: [
@@ -327,6 +395,38 @@ describe('createModel', () => {
       menu.items[0].label = 'Mutated';
     }).toThrow(TypeError);
     expect(menu.items[0].label).toBe('Right');
+  });
+
+  it.each([NaN, Infinity, -Infinity])(
+    'rejects the non-finite angle %p',
+    (angle) => {
+      expect(() =>
+        createModel({ items: [{ angle, label: 'Invalid' }] }),
+      ).toThrow(/angles must be finite/v);
+    },
+  );
+
+  it('rejects two items at the same angle', () => {
+    expect(() =>
+      createModel({
+        items: [
+          { angle: 0, label: 'First' },
+          { angle: 360, label: 'Second' },
+        ],
+      }),
+    ).toThrow(/different angles/v);
+  });
+
+  it('rejects stated angles that need more than one turn', () => {
+    expect(() =>
+      createModel({
+        items: [
+          { angle: 0, label: 'First' },
+          { angle: 270, label: 'Second' },
+          { angle: 180, label: 'Third' },
+        ],
+      }),
+    ).toThrow(/more than one full turn/v);
   });
 
   it('rejects two items sharing the same id', () => {

--- a/src/model.ts
+++ b/src/model.ts
@@ -482,6 +482,10 @@ const getItemAngles = (
   let previousAngle = firstItem.angle;
   for (const item of otherItems) {
     const { angle: itemAngle } = item;
+    if (itemAngle === normalizeAngle(previousAngle)) {
+      throw new Error('Menu items at a level must have different angles.');
+    }
+
     let angle = itemAngle;
     while (angle <= previousAngle) {
       angle += 360;
@@ -489,9 +493,7 @@ const getItemAngles = (
 
     if (angle >= firstItem.angle + 360) {
       throw new Error(
-        angle === firstItem.angle + 360
-          ? 'Menu items at a level must have different angles.'
-          : 'Menu item angles at a level cannot span more than one full turn.',
+        'Menu item angles at a level cannot span more than one full turn.',
       );
     }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -439,6 +439,83 @@ class MarkingMenuRoot extends MarkingMenuNode {
   }
 }
 
+const normalizeAngle = (angle: number): number => mod(angle, 360);
+
+const getItemAngles = (
+  inputs: readonly MarkingMenuItemInput[],
+): readonly number[] => {
+  const stated = inputs.flatMap((input, index) => {
+    if (input.angle === undefined) {
+      return [];
+    }
+
+    if (!Number.isFinite(input.angle)) {
+      throw new TypeError('Menu item angles must be finite numbers.');
+    }
+
+    return [{ angle: normalizeAngle(input.angle), index }];
+  });
+
+  if (stated.length === 0) {
+    const angleStep = 360 / inputs.length;
+    return inputs.map((_, index) => index * angleStep);
+  }
+
+  if (stated.length === 1) {
+    const [item] = stated;
+    if (item === undefined) {
+      throw new Error('Expected one stated angle.');
+    }
+
+    const angleStep = 360 / inputs.length;
+    return inputs.map((_, index) =>
+      normalizeAngle(item.angle + (index - item.index) * angleStep),
+    );
+  }
+
+  const [firstItem, ...otherItems] = stated;
+  if (firstItem === undefined) {
+    throw new Error('Expected at least one stated angle.');
+  }
+
+  const unwrapped = [firstItem];
+  let previousAngle = firstItem.angle;
+  for (const item of otherItems) {
+    const { angle: itemAngle } = item;
+    let angle = itemAngle;
+    while (angle <= previousAngle) {
+      angle += 360;
+    }
+
+    if (angle >= firstItem.angle + 360) {
+      throw new Error(
+        angle === firstItem.angle + 360
+          ? 'Menu items at a level must have different angles.'
+          : 'Menu item angles at a level cannot span more than one full turn.',
+      );
+    }
+
+    unwrapped.push({ ...item, angle });
+    previousAngle = angle;
+  }
+
+  const angles: number[] = [];
+  for (const [index, item] of unwrapped.entries()) {
+    const next = unwrapped[index + 1] ?? {
+      angle: firstItem.angle + 360,
+      index: firstItem.index + inputs.length,
+    };
+    const angleStep = (next.angle - item.angle) / (next.index - item.index);
+    for (let offset = 0; offset < next.index - item.index; offset++) {
+      angles[(item.index + offset) % inputs.length] = normalizeAngle(
+        item.angle + offset * angleStep,
+      );
+    }
+  }
+
+  return angles;
+};
+
 /**
  Build the (frozen) item list of one menu level.
 
@@ -459,7 +536,7 @@ const createItems = (
   seenIds: Set<string> = new Set(),
   baseKey?: string,
 ): readonly MarkingMenuItem[] => {
-  const angleStep = 360 / inputs.length;
+  const angles = getItemAngles(inputs);
   return Object.freeze(
     inputs.map((input, index) => {
       if (input.id !== undefined) {
@@ -477,7 +554,7 @@ const createItems = (
       return new MarkingMenuItem({
         id: input.id,
         label: input.label,
-        angle: index * angleStep,
+        angle: angles[index] ?? 0,
         key,
         parent,
         items: (self) =>
@@ -494,7 +571,7 @@ const createItems = (
 
  @param input - The description of the menu.
  @returns The root of the model.
- @throws If two items share the same id.
+ @throws If two items share an id, or a level has invalid angles.
  */
 export function createModel<const Input extends MarkingMenuInput>(
   input: Input & ValidateInput<Input>,

--- a/src/model.ts
+++ b/src/model.ts
@@ -441,10 +441,13 @@ class MarkingMenuRoot extends MarkingMenuNode {
 
 const normalizeAngle = (angle: number): number => mod(angle, 360);
 
-const getItemAngles = (
+type StatedItemAngle = { angle: number; index: number };
+type StatedItemAngles = [StatedItemAngle, ...StatedItemAngle[]];
+
+const collectStatedAngles = (
   inputs: readonly MarkingMenuItemInput[],
-): readonly number[] => {
-  const stated = inputs.flatMap((input, index) => {
+): StatedItemAngle[] =>
+  inputs.flatMap((input, index) => {
     if (input.angle === undefined) {
       return [];
     }
@@ -456,29 +459,26 @@ const getItemAngles = (
     return [{ angle: normalizeAngle(input.angle), index }];
   });
 
-  if (stated.length === 0) {
-    const angleStep = 360 / inputs.length;
-    return inputs.map((_, index) => index * angleStep);
-  }
+const spreadEvenly = (itemCount: number): number[] => {
+  const angleStep = 360 / itemCount;
+  return Array.from({ length: itemCount }, (_, index) => index * angleStep);
+};
 
-  if (stated.length === 1) {
-    const [item] = stated;
-    if (item === undefined) {
-      throw new Error('Expected one stated angle.');
-    }
+const rotateAroundOne = (
+  itemCount: number,
+  item: StatedItemAngle,
+): number[] => {
+  const angleStep = 360 / itemCount;
+  return Array.from({ length: itemCount }, (_, index) =>
+    normalizeAngle(item.angle + (index - item.index) * angleStep),
+  );
+};
 
-    const angleStep = 360 / inputs.length;
-    return inputs.map((_, index) =>
-      normalizeAngle(item.angle + (index - item.index) * angleStep),
-    );
-  }
-
-  const [firstItem, ...otherItems] = stated;
-  if (firstItem === undefined) {
-    throw new Error('Expected at least one stated angle.');
-  }
-
-  const unwrapped = [firstItem];
+const unwrapStatedAngles = (
+  firstItem: StatedItemAngle,
+  otherItems: readonly StatedItemAngle[],
+): StatedItemAngles => {
+  const unwrapped: StatedItemAngles = [firstItem];
   let previousAngle = firstItem.angle;
   for (const item of otherItems) {
     const { angle: itemAngle } = item;
@@ -501,21 +501,47 @@ const getItemAngles = (
     previousAngle = angle;
   }
 
+  return unwrapped;
+};
+
+const interpolateGaps = (
+  itemCount: number,
+  statedItems: Readonly<StatedItemAngles>,
+): number[] => {
+  const [firstItem] = statedItems;
   const angles: number[] = [];
-  for (const [index, item] of unwrapped.entries()) {
-    const next = unwrapped[index + 1] ?? {
+  for (const [index, item] of statedItems.entries()) {
+    const next = statedItems[index + 1] ?? {
       angle: firstItem.angle + 360,
-      index: firstItem.index + inputs.length,
+      index: firstItem.index + itemCount,
     };
     const angleStep = (next.angle - item.angle) / (next.index - item.index);
     for (let offset = 0; offset < next.index - item.index; offset++) {
-      angles[(item.index + offset) % inputs.length] = normalizeAngle(
+      angles[(item.index + offset) % itemCount] = normalizeAngle(
         item.angle + offset * angleStep,
       );
     }
   }
 
   return angles;
+};
+
+const getItemAngles = (
+  inputs: readonly MarkingMenuItemInput[],
+): readonly number[] => {
+  const [firstItem, ...otherItems] = collectStatedAngles(inputs);
+  if (firstItem === undefined) {
+    return spreadEvenly(inputs.length);
+  }
+
+  if (otherItems.length === 0) {
+    return rotateAroundOne(inputs.length, firstItem);
+  }
+
+  return interpolateGaps(
+    inputs.length,
+    unwrapStatedAngles(firstItem, otherItems),
+  );
 };
 
 /**

--- a/src/recognizer/__fixtures__/stroke-corpus.ts
+++ b/src/recognizer/__fixtures__/stroke-corpus.ts
@@ -16,23 +16,32 @@ import { createRandom } from './random.js';
  `createModel`, so it measures the layout currently used by the library.
  */
 
-type EvenItem = { label: string; items?: EvenItem[] };
+type CorpusItem = { angle?: number; label: string; items?: CorpusItem[] };
 
 /**
  The items of a menu whose levels have the given item counts, from the top
  level down: `[4, 8]` builds a 4-item top level whose items each open an
  8-item submenu.
  */
-const buildLevels = (breadths: readonly number[]): EvenItem[] => {
+const buildLevels = (
+  breadths: readonly number[],
+  statedAngles: ReadonlyArray<ReadonlyArray<number | undefined>>,
+): CorpusItem[] => {
   const [breadth, ...rest] = breadths;
   if (breadth === undefined) {
     return [];
   }
 
-  return Array.from({ length: breadth }, (_, index) => ({
-    label: `item-${index}`,
-    ...(rest.length > 0 && { items: buildLevels(rest) }),
-  }));
+  return Array.from({ length: breadth }, (_, index) => {
+    const angle = statedAngles[0]?.[index];
+    return {
+      ...(angle !== undefined && { angle }),
+      label: `item-${index}`,
+      ...(rest.length > 0 && {
+        items: buildLevels(rest, statedAngles.slice(1)),
+      }),
+    };
+  });
 };
 
 /**
@@ -40,8 +49,10 @@ const buildLevels = (breadths: readonly number[]): EvenItem[] => {
  many items, laid out however `createModel` lays out a plain item list of
  that size.
  */
-export const buildMenu = (breadths: readonly number[]) =>
-  createModel({ items: buildLevels(breadths) });
+export const buildMenu = (
+  breadths: readonly number[],
+  statedAngles: ReadonlyArray<ReadonlyArray<number | undefined>> = [],
+) => createModel({ items: buildLevels(breadths, statedAngles) });
 
 /**
  The generic shape {@link randomPath} walks: any node exposing its
@@ -85,6 +96,8 @@ const randomPath = (
  @param options - Configuration options.
  @param options.breadths - One entry per level, from the top down: how many
  items that level holds.
+ @param options.statedAngles - Optional per-level item angles. Each nested
+ list follows that level's item order.
  @param options.trials - How many random paths to try.
  @param options.wobble - The wobble to generate strokes with. Defaults to the
  calibrated one.
@@ -93,16 +106,18 @@ const randomPath = (
  */
 export function measureAccuracy({
   breadths,
+  statedAngles,
   trials,
   wobble,
   seed = 0,
 }: {
   breadths: readonly number[];
+  statedAngles?: ReadonlyArray<ReadonlyArray<number | undefined>>;
   trials: number;
   wobble?: Wobble;
   seed?: number;
 }): number {
-  const model = buildMenu(breadths);
+  const model = buildMenu(breadths, statedAngles);
   const random = createRandom(seed);
   let recognized = 0;
   for (let trial = 0; trial < trials; trial++) {

--- a/src/recognizer/generated-stroke-corpus.test.ts
+++ b/src/recognizer/generated-stroke-corpus.test.ts
@@ -100,4 +100,18 @@ describe('generated stroke corpus', () => {
       expect(accuracy).toBeLessThanOrEqual(1);
     });
   });
+
+  it('recognizes a menu with stated and free angles at or above 80%', () => {
+    const accuracy = measureAccuracy({
+      breadths: [4, 5],
+      statedAngles: [
+        [0, undefined, 180, undefined],
+        [0, undefined, 90, undefined, 270],
+      ],
+      trials: 500,
+      seed: 244,
+    });
+
+    expect(accuracy).toBeGreaterThanOrEqual(0.8);
+  });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,10 @@ export type MarkingMenuItemInput = {
   */
   readonly label: string;
   /**
+  The item's optional clockwise angle in degrees, measured from the right.
+  */
+  readonly angle?: number | undefined;
+  /**
   The item's sub-items, if any.
   */
   readonly items?: readonly MarkingMenuItemInput[] | undefined;


### PR DESCRIPTION
## Summary

Add optional item angles and place free items within the remaining gaps. Reject invalid angles and update the playground schema.

## Tests

`yarn test`, `yarn typecheck`, `yarn lint`, `yarn format:check`, `yarn build`, `yarn package:lint`, `yarn package:types`, and `yarn package:smoke-test`.

Fixes #244