### PR TITLE
layout: stop building menu item markup with innerHTML

### DIFF
--- a/.changeset/no-more-innerhtml.md
+++ b/.changeset/no-more-innerhtml.md
@@ -1,0 +1,6 @@
+---
+'marking-menu': patch
+---
+
+Stop using `innerHTML` to render menu item labels. A label containing markup
+now shows as plain text instead of being parsed as HTML.

--- a/src/layout/menu.ts
+++ b/src/layout/menu.ts
@@ -106,8 +106,14 @@ const template = (
     // this and I could not be bothered fixing it.
     elt.style.setProperty('--cosine', `${Math.cos(-radAngle)}`);
     elt.style.setProperty('--sine', `${Math.sin(-radAngle)}`);
-    elt.innerHTML += '<div class="marking-menu-line"></div>';
-    elt.innerHTML += `<div class="marking-menu-label">${item.label}</div>`;
+    const lineElt = doc.createElement('div');
+    lineElt.className = 'marking-menu-line';
+    elt.append(lineElt);
+
+    const labelElt = doc.createElement('div');
+    labelElt.className = 'marking-menu-label';
+    labelElt.textContent = item.label;
+    elt.append(labelElt);
     main.append(elt);
   }
 


### PR DESCRIPTION
## Summary
- Item labels come from the public API as plain strings and were being concatenated into `innerHTML`, so a label containing markup could run as script instead of showing as text
- Build the line and label elements with `createElement` and set the label with `textContent` instead, removing all `innerHTML` use from the codebase

## Test plan
- [x] `npm test` (29 tests pass, includes type checking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)