### PR TITLE
Reject menus too crowded for the recognizer

### DIFF
--- a/.changeset/item-angles.md
+++ b/.changeset/item-angles.md
@@ -3,4 +3,6 @@
 ---
 
 Let items set an optional clockwise `angle` in degrees. Items without an
-angle fill the gaps between stated angles.
+angle fill the gaps between stated angles. Menu construction rejects a level
+with less than 45 degrees between neighboring items. The generated corpus
+recognizes 45-degree menus at 90.4% accuracy and 40-degree menus at 61.2%.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ reliable. The previous inline value and priority are restored once every
 controller sharing that parent has been disposed, unless the application
 changed the property in the meantime.
 
-- `items`: `Array` of `{ label, items? }`. The list of the menu's items. If `items` is provided, the item will be considered as a sub-menu (nested `items` has the same form as the top-level list). Currently, `createMarkingMenu` supports up to 8 items per level. The first item is on the right and the followings are layed out clockwise.
+- `items`: `Array` of `{ label, angle?, items? }`. The list of the menu's items. If `items` is provided, the item is a submenu. Each level supports up to 8 items, with at least 45 degrees between neighbors. The first item is on the right; the rest are laid out clockwise.
+
+- `angle`: Optional clockwise angle in degrees from the right. Items without an `angle` are spaced evenly between the stated angles.
 
 - `parent`: `HTMLElement`. The container of the menu.
 

--- a/src/model.test.ts
+++ b/src/model.test.ts
@@ -64,15 +64,45 @@ describe('createModel', () => {
     expect(menu.items.map((item) => item.angle)).toEqual(angles);
   });
 
-  it('keeps angles below 360 degrees for a nine-item level', () => {
-    const menu = createModel({
-      items: Array.from({ length: 9 }, (_, index) => ({
-        label: `Item ${index}`,
-      })),
-    });
-    expect(menu.items.map((item) => item.angle)).toEqual([
-      0, 40, 80, 120, 160, 200, 240, 280, 320,
-    ]);
+  it.each([1, 2, 3, 4, 5, 6, 7, 8])(
+    'builds the supported %i-item layout',
+    (count) => {
+      expect(() =>
+        createModel({
+          items: Array.from({ length: count }, (_, index) => ({
+            label: `Item ${index}`,
+          })),
+        }),
+      ).not.toThrow();
+    },
+  );
+
+  it('rejects an evenly spaced level tighter than the recognizer can resolve', () => {
+    expect(() =>
+      createModel({
+        items: Array.from({ length: 9 }, (_, index) => ({
+          label: `Item ${index}`,
+        })),
+      }),
+    ).toThrow(
+      /level root has 40 degrees between items.*Increase the gap or remove items/v,
+    );
+  });
+
+  it('names a crowded nested level and its spacing', () => {
+    expect(() =>
+      createModel({
+        items: [
+          {
+            label: 'Parent',
+            items: [
+              { angle: 0, label: 'First' },
+              { angle: 40, label: 'Second' },
+            ],
+          },
+        ],
+      }),
+    ).toThrow(/level root > 1 has 40 degrees between items/v);
   });
 
   it('spaces each level from its own item count', () => {

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,3 +1,4 @@
+import { MINIMUM_RESOLVABLE_ANGLE } from './recognizer/recognize-mm-stroke.js';
 import type {
   LiteralId,
   MarkingMenuInput,
@@ -234,6 +235,19 @@ export type MarkingMenuModel<Input extends MarkingMenuInput> = NodeAt<
  * Implementation
  * -------------------------------------------------------------------------- */
 
+const getTightestSpacing = (angles: readonly number[]): number => {
+  if (angles.length < 2) {
+    return Infinity;
+  }
+
+  const sorted = angles.toSorted((a, b) => a - b);
+  return Math.min(
+    ...sorted.map((angle, index) =>
+      mod((sorted[(index + 1) % sorted.length] ?? angle) - angle, 360),
+    ),
+  );
+};
+
 /**
  The behavior shared by the root of the menu and its items.
 
@@ -355,18 +369,9 @@ abstract class MarkingMenuNode {
 
    @returns The smallest gap, in degrees, or `Infinity` if no level has two
    or more items to have a gap between.
-   */
+  */
   getMinAngularGap(): number {
-    let minGap = Infinity;
-    if (this.#items.length >= 2) {
-      const angles = this.#items
-        .map((item) => item.angle)
-        .toSorted((a, b) => a - b);
-      for (const [index, angle] of angles.entries()) {
-        const next = angles[(index + 1) % angles.length] ?? angle;
-        minGap = Math.min(minGap, mod(next - angle, 360));
-      }
-    }
+    let minGap = getTightestSpacing(this.#items.map((item) => item.angle));
 
     for (const item of this.#items) {
       minGap = Math.min(minGap, item.getMinAngularGap());
@@ -544,6 +549,18 @@ const getItemAngles = (
   );
 };
 
+const assertResolvableAngles = (
+  angles: readonly number[],
+  level: string,
+): void => {
+  const spacing = getTightestSpacing(angles);
+  if (spacing < MINIMUM_RESOLVABLE_ANGLE) {
+    throw new RangeError(
+      `Menu level ${level} has ${spacing} degrees between items, but the recognizer needs at least ${MINIMUM_RESOLVABLE_ANGLE}. Increase the gap or remove items.`,
+    );
+  }
+};
+
 /**
  Build the (frozen) item list of one menu level.
 
@@ -564,7 +581,15 @@ const createItems = (
   seenIds: Set<string> = new Set(),
   baseKey?: string,
 ): readonly MarkingMenuItem[] => {
+  const level =
+    baseKey === undefined
+      ? 'root'
+      : `root > ${baseKey
+          .split('-')
+          .map((index) => Number(index) + 1)
+          .join(' > ')}`;
   const angles = getItemAngles(inputs);
+  assertResolvableAngles(angles, level);
   return Object.freeze(
     inputs.map((input, index) => {
       if (input.id !== undefined) {

--- a/src/recognizer/generated-stroke-corpus.test.ts
+++ b/src/recognizer/generated-stroke-corpus.test.ts
@@ -45,6 +45,11 @@ import { measureAccuracy } from './__fixtures__/stroke-corpus.js';
  levels compounds three independent per-level draws, which is why its
  accuracy sits below one level's for both breadths.
 
+ The 8-item menu is the narrowest layout that remains reliable: 45-degree
+ spacing measures 90.4% accuracy. A 9-item menu, with 40-degree spacing,
+ measures 61.2% with the same corpus setup. The recognizer therefore
+ publishes 45 degrees as its smallest resolvable angle.
+
  Menus with 3, 5, 6, and 7 items are also evenly spaced. Their one-level
  accuracy stays at or above 98%, so the corpus holds that floor alongside the
  existing 4- and 8-item calibration checks.

--- a/src/recognizer/recognize-mm-stroke.test.ts
+++ b/src/recognizer/recognize-mm-stroke.test.ts
@@ -10,11 +10,18 @@ import {
   analyzeMarkingMenuStroke,
   divideLongestSegment,
   findItem,
+  MINIMUM_RESOLVABLE_ANGLE,
   pointsToSegments,
   recognizeMarkingMenuStroke,
   walkModel,
 } from './recognize-mm-stroke.js';
 import { strokeLength } from './stroke-length.js';
+
+describe('MINIMUM_RESOLVABLE_ANGLE', () => {
+  it('matches the narrowest calibrated menu spacing', () => {
+    expect(MINIMUM_RESOLVABLE_ANGLE).toBe(45);
+  });
+});
 
 const STROKES_PATH = path.resolve(
   import.meta.dirname,

--- a/src/recognizer/recognize-mm-stroke.ts
+++ b/src/recognizer/recognize-mm-stroke.ts
@@ -11,6 +11,11 @@ import { getStrokeArticulationPoints } from './articulation-points.js';
 import { strokeLength } from './stroke-length.js';
 
 /**
+ The smallest gap, in degrees, that the calibrated recognizer can resolve.
+ */
+export const MINIMUM_RESOLVABLE_ANGLE = 45;
+
+/**
  A segment of a marking-menu stroke, described by its length and angle.
  */
 export type StrokeSegment = {


### PR DESCRIPTION
Menus with gaps below 45 degrees produce gestures the recognizer cannot distinguish. The generated corpus records 90.4% accuracy at 45 degrees and 61.2% at 40 degrees.

The recognizer now publishes the 45-degree limit. Model construction checks each level before rendering and names the crowded level and its spacing when it rejects one. The model imports the limit from the recognizer, which does not import the model.

The README documents the limit. The existing minor changeset for caller-provided angles now records the 45-degree restriction.

Verified with `yarn test`, `yarn typecheck`, `yarn lint`, `yarn format:check`, `yarn build`, `yarn package:lint`, `yarn package:types`, and `yarn package:smoke-test`.

Fixes #245