### PR TITLE
Overhaul the README and expand API documentation

### DIFF
--- a/.changeset/even-menu-layout.md
+++ b/.changeset/even-menu-layout.md
@@ -2,6 +2,6 @@
 'marking-menu': major
 ---
 
-Lay out each menu level evenly around the full circle to prevent unused
-directions and overlapping items. This moves items in 5-item, 6-item, and
-7-item menus. Set an item's `angle` to preserve its existing position.
+5-, 6-, and 7-item menus now position items evenly around the circle. The
+upgrade raises no error and does not fail builds, but a learned gesture can
+select a different item. Set each item's `angle` to keep its existing direction.

--- a/README.md
+++ b/README.md
@@ -67,11 +67,57 @@ reliable. The previous inline value and priority are restored once every
 controller sharing that parent has been disposed, unless the application
 changed the property in the meantime.
 
-- `items`: `Array` of `{ label, angle?, items? }`. The list of the menu's items. If `items` is provided, the item is a submenu. Each level supports up to 8 items, with at least 45 degrees between neighbors. The first item is on the right; the rest are laid out clockwise.
+- `items`: `Array` of `{ label, angle?, items? }`. The list of the menu's items. If `items` is provided, the item is a submenu. Items remain in listed clockwise order. Each level needs at least 45 degrees between neighboring items.
 
-- `angle`: Optional clockwise angle in degrees from the right. Items without an `angle` are spaced evenly between the stated angles.
+- `angle`: Optional clockwise angle in degrees from the right.
 
 - `parent`: `HTMLElement`. The container of the menu.
+
+#### Item angles
+
+`0` degrees points right, `90` points down, `180` points left, and `270` points up. When two or more items state an angle, their values must follow the item's clockwise list order. The sequence can wrap once through `0`, such as `270`, `0`, `90`.
+
+Items without an `angle` keep their place in the list and divide the gap between the stated angles around them. [Build a menu in the playground](https://quentinroy.github.io/Marking-Menu/playground/) to try a layout.
+
+With no stated angles, items spread evenly around the circle, starting at the right:
+
+```js
+[
+  { label: 'First' },
+  { label: 'Second' },
+  { label: 'Third' },
+  { label: 'Fourth' },
+];
+```
+
+The items land at `0`, `90`, `180`, and `270` degrees.
+
+With one stated angle, the same even layout rotates around that item:
+
+```js
+[
+  { label: 'First' },
+  { label: 'Second' },
+  { angle: 90, label: 'Third' },
+  { label: 'Fourth' },
+];
+```
+
+The items land at `270`, `0`, `90`, and `180` degrees.
+
+With several stated angles, free items divide each gap independently:
+
+```js
+[
+  { angle: 0, label: 'First' },
+  { label: 'Second' },
+  { label: 'Third' },
+  { angle: 180, label: 'Fourth' },
+  { label: 'Fifth' },
+];
+```
+
+The items land at `0`, `60`, `120`, `180`, and `270` degrees.
 
 The controller dispatches six events during a gesture: `start`, `open`, `move`, `change`, `select`, and `cancel`. Listen with `controller.on(type, listener)`, matching `off` to remove a listener. When you're done with the menu, call `controller.dispose()` (or use it with `using`, where your toolchain supports Explicit Resource Management) to stop listening for pointer input and release the DOM resources it created.
 

--- a/README.md
+++ b/README.md
@@ -4,153 +4,176 @@
 [![CI](https://github.com/QuentinRoy/Marking-Menu/actions/workflows/ci.yml/badge.svg)](https://github.com/QuentinRoy/Marking-Menu/actions/workflows/ci.yml)
 [![Deploy](https://github.com/QuentinRoy/Marking-Menu/actions/workflows/deploy.yml/badge.svg)](https://github.com/QuentinRoy/Marking-Menu/actions/workflows/deploy.yml)
 
-This library is an implementation of Gordon Kurtenbach's infamous Marking Menus in JavaScript [[1](https://doi.org/10.1145/120782.120797), [2](http://doi.acm.org/10.1145/169059.169426), [3](http://doi.acm.org/10.1145/191666.191759)].
+A JavaScript marking menu for mouse, touch, and pen input. Press and pause to show the menu, then move toward an item and release to select it. Once you know the directions, draw the gesture without waiting for the menu.
 
-[Have a look at the **demo**](https://quentinroy.github.io/Marking-Menu/).
-
-## License
-
-This _codebase_ is licensed under the MIT license.
-**However**, Marking Menus are concerned by several patents, none of which are owned by the author of this library.
-Make sure you have the rights to include this library in your application before doing so.
-The authors and contributors of this library may not be held responsible for any patent infringement following the use of this codebase.
+[Try the demo](https://quentinroy.github.io/Marking-Menu/) or [build your own menu in the playground](https://quentinroy.github.io/Marking-Menu/playground/).
 
 ## Install
 
-### Browser with CDN
+```sh
+npm install marking-menu
+```
 
-Use a native ES module with an import map to resolve `marking-menu`:
+The package uses ES modules, includes its styles, and ships TypeScript declarations. Create menus in the browser after the parent element exists.
+
+### Browser without a bundler
+
+Add this import map before your module script:
 
 ```html
-<!DOCTYPE html>
-<html>
-  <head>
-    <script type="importmap">
-      {
-        "imports": {
-          "marking-menu": "https://esm.sh/marking-menu@1?raw"
-        }
-      }
-    </script>
-    <script type="module">
-      import { createMarkingMenu } from 'marking-menu';
-
-      // Your stuff.
-    </script>
-  </head>
-  <body></body>
-</html>
+<script type="importmap">
+  {
+    "imports": {
+      "marking-menu": "https://esm.sh/marking-menu@1?raw"
+    }
+  }
+</script>
 ```
 
-### ES modules
+## Usage
 
-```sh
-npm install -S marking-menu
+Give the menu a container with room for gestures:
+
+```html
+<div id="menu-area" style="position: relative; height: 400px"></div>
 ```
 
-Then:
+Run this in your application, or in a `<script type="module">` after the container:
 
 ```js
 import { createMarkingMenu } from 'marking-menu';
+
+const menu = createMarkingMenu({
+  parent: document.getElementById('menu-area'),
+  items: [
+    { label: 'Copy' },
+    {
+      label: 'More',
+      items: [{ label: 'Duplicate' }, { label: 'Delete' }],
+    },
+    { label: 'Paste' },
+    { label: 'Undo' },
+  ],
+});
+
+menu.on('select', (event) => {
+  console.log(event.selection.label);
+});
 ```
+
+The menu listens immediately. Here, Copy is right, More is down, Paste is left, and Undo is up. Pause over More to open its submenu.
+
+Call `menu.dispose()` when the container is removed or you no longer need the menu. It stops listening and removes the elements the menu created.
 
 ## API
 
 ### `createMarkingMenu({ items, parent, ...options })`
 
-`createMarkingMenu` builds the menu and returns an already-active controller. It starts listening for pointer input immediately: there's no separate step to turn it on.
+Returns an active controller. The required properties are:
 
-Activation uses the primary button of a mouse, the primary touch contact, or a
-primary pen contact. While the menu is active, it temporarily sets the
-parent's inline `touch-action` to `none !important` so pointer gestures remain
-reliable. The previous inline value and priority are restored once every
-controller sharing that parent has been disposed, unless the application
-changed the property in the meantime.
+- `parent`: The `HTMLElement` that receives pointer input and contains the menu.
+- `items`: An array of item objects. Each has a required `label` string and optional `id`, `angle`, and nested `items`. Labels display as plain text. IDs are strings and must be unique across the whole menu. A nonempty `items` array makes an item a submenu.
 
-- `items`: `Array` of `{ label, angle?, items? }`. The list of the menu's items. If `items` is provided, the item is a submenu. Items remain in listed clockwise order. Each level needs at least 45 degrees between neighboring items.
+See [item layout](#item-layout) for angles. TypeScript infers event and item types from your configuration; a selected item's `id` is `undefined` if you did not supply one.
 
-- `angle`: Optional clockwise angle in degrees from the right.
+### Options
 
-- `parent`: `HTMLElement`. The container of the menu.
+Pass options alongside `items` and `parent`. Distances use pixels; delays use milliseconds.
 
-#### Item angles
+| Option                 | Default    | Purpose                                                                                  |
+| ---------------------- | ---------- | ---------------------------------------------------------------------------------------- |
+| `noviceDwellingTime`   | `1000 / 3` | Pause before showing the menu.                                                           |
+| `submenuOpeningDelay`  | `100`      | Pause before opening a submenu.                                                          |
+| `movementsThreshold`   | `5`        | Movement needed to start a gesture without opening the menu, or restart a submenu pause. |
+| `minSelectionDist`     | `40`       | Minimum distance from the menu center to select an item.                                 |
+| `minMenuSelectionDist` | `80`       | Minimum distance from the menu center to open a submenu.                                 |
 
-`0` degrees points right, `90` points down, `180` points left, and `270` points up. When two or more items state an angle, their values must follow the item's clockwise list order. The sequence can wrap once through `0`, such as `270`, `0`, `90`.
+Use `log: { error: handler }` to handle internal errors; the default is `console.error`. Invalid menu definitions throw during construction.
 
-Items without an `angle` keep their place in the list and divide the gap between the stated angles around them. [Build a menu in the playground](https://quentinroy.github.io/Marking-Menu/playground/) to try a layout.
+### Events and cleanup
 
-With no stated angles, items spread evenly around the circle, starting at the right:
+Use `menu.on(type, listener)` to register a listener and `menu.off(type, listener)` to remove that same listener.
 
-```js
-[
-  { label: 'First' },
-  { label: 'Second' },
-  { label: 'Third' },
-  { label: 'Fourth' },
-];
+| Event    | When it fires                                 |
+| -------- | --------------------------------------------- |
+| `start`  | A gesture begins.                             |
+| `open`   | A menu or submenu opens.                      |
+| `move`   | The pointer moves during a gesture.           |
+| `change` | The active item changes while a menu is open. |
+| `select` | A gesture ends with a selected item.          |
+| `cancel` | A gesture ends without a selection.           |
+
+`select` carries the selected item as `event.selection`, including its `id` and `label`.
+
+Every event includes `position`, a viewport `[x, y]` pair, and `mode`: `startup` while waiting for movement or a pause, `novice` while using a visible menu, or `expert` while drawing a gesture. See [the event types](src/events.ts) for each payload.
+
+`dispose()` ends the controller's lifetime and can be called more than once. The controller also supports `using` where your toolchain supports it.
+
+## Item layout
+
+Angles are clockwise degrees from the right: `0` is right, `90` is down, `180` is left, and `270` is up. Each menu level uses its own layout; submenu angles are measured from the right, not from the parent's direction.
+
+Items keep their clockwise array order. Stated angles must be finite and distinct after wrapping into `[0, 360)`. They must fit within one clockwise turn in array order: `270, 0, 90` is valid; `0, 270, 180` is not.
+
+Every gap between neighboring items, including the last and first, must be at least 45 degrees. Construction throws if a gap is smaller, so at most eight items fit in a level.
+
+Items without an `angle` are spaced as follows. Results below follow array order and use degrees:
+
+| Stated angles | Placement                                                                                 | Example                                                               |
+| ------------- | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| None          | Equal spacing around the circle, starting at `0`.                                         | Four items: `0, 90, 180, 270`.                                        |
+| One           | Equal spacing, rotated to keep that item at its angle.                                    | Four items, third at `90`: `270, 0, 90, 180`.                         |
+| Several       | Equal spacing within each gap between stated angles, including the gap back to the first. | Five items, first at `0` and fourth at `180`: `0, 60, 120, 180, 270`. |
+
+For the last example, paste this into the [playground](https://quentinroy.github.io/Marking-Menu/playground/):
+
+```json
+{
+  "items": [
+    { "label": "First", "angle": 0 },
+    { "label": "Second" },
+    { "label": "Third" },
+    { "label": "Fourth", "angle": 180 },
+    { "label": "Fifth" }
+  ]
+}
 ```
 
-The items land at `0`, `90`, `180`, and `270` degrees.
+Second and Third split the first 180-degree gap into three 60-degree steps. Fifth splits the remaining 180-degree gap in half, landing at `270`.
 
-With one stated angle, the same even layout rotates around that item:
+## Appearance
 
-```js
-[
-  { label: 'First' },
-  { label: 'Second' },
-  { angle: 90, label: 'Third' },
-  { label: 'Fourth' },
-];
+Set CSS variables on `.marking-menu` to style labels and layout. Scope the selector to your container to style one menu:
+
+```css
+#menu-area .marking-menu {
+  --item-background: #222;
+  --item-color: #fff;
+  --active-item-background: #444;
+  --active-item-color: #fff;
+}
 ```
 
-The items land at `270`, `0`, `90`, and `180` degrees.
+See [the menu styles](src/layout/menu.css) for size, spacing, and line variables.
 
-With several stated angles, free items divide each gap independently:
+Gesture strokes use configuration options: `strokeColor` defaults to `'#000'`, `strokeWidth` to `4`, and `strokeStartPointRadius` to `8`. Widths and radii use pixels. [The drawing options](src/engine/renderer.ts) also cover earlier stroke segments and completed-gesture feedback.
 
-```js
-[
-  { angle: 0, label: 'First' },
-  { label: 'Second' },
-  { label: 'Third' },
-  { angle: 180, label: 'Fourth' },
-  { label: 'Fifth' },
-];
-```
+## Input behavior
 
-The items land at `0`, `60`, `120`, `180`, and `270` degrees.
+Gestures start with the primary mouse button, primary touch contact, or primary pen contact. The controller sets the parent's inline `touch-action` to `none !important` for its lifetime, preventing browser touch gestures in that area.
 
-The controller dispatches six events during a gesture: `start`, `open`, `move`, `change`, `select`, and `cancel`. Listen with `controller.on(type, listener)`, matching `off` to remove a listener. When you're done with the menu, call `controller.dispose()` (or use it with `using`, where your toolchain supports Explicit Resource Management) to stop listening for pointer input and release the DOM resources it created.
+Once all controllers sharing the parent are disposed, the previous inline value and priority are restored, unless your application changed the property in the meantime.
 
-#### Example
+## Upgrading from 0.10.1
 
-```js
-// Create the menu with a sub-menu at the bottom.
-const items = [
-  { label: 'Item Right' },
-  {
-    label: 'Others...',
-    items: [
-      { label: 'Sub Right' },
-      { label: 'Sub Down' },
-      { label: 'Sub Left' },
-      { label: 'Sub Top' },
-    ],
-  },
-  { label: 'Item Left' },
-  { label: 'Item Up' },
-];
-const menu = createMarkingMenu({
-  items,
-  parent: document.getElementById('main'),
-});
+Default item positions change in 5-, 6-, and 7-item menus. The layout change causes no error or build failure, but learned gestures can select different items. Set each item's `angle` to preserve its previous direction.
 
-menu.on('select', (event) => {
-  // Do something.
-  console.log(event.selection.label);
-});
+The release also changes imports, menu configuration, and event handling. Use the named `createMarkingMenu` export with a configuration object and register listeners with `on`. Replace subscription cleanup with `dispose()`.
 
-setTimeout(() => {
-  // Later, disable the menu.
-  menu.dispose();
-}, 60 * 1000);
-```
+## Background and license
+
+This library implements Gordon Kurtenbach's marking menus: [paper 1](https://doi.org/10.1145/120782.120797), [paper 2](http://doi.acm.org/10.1145/169059.169426), and [paper 3](http://doi.acm.org/10.1145/191666.191759).
+
+This codebase is licensed under the MIT license.
+
+Several patents concern marking menus; none belong to this library's author. Make sure you have the rights to use the library in your application. The authors and contributors may not be held responsible for patent infringement resulting from its use.


### PR DESCRIPTION
The README mixed setup, API reference, and layout details, with gaps in timing options, styling, and event behavior. Reorganize the full document around installation and a working example, then cover configuration, events and cleanup, item layout, appearance, input behavior, and upgrading. Move background and licensing to the end.

Expand the API guidance with option defaults and units, event meanings, item IDs and TypeScript inference, and styling examples. Explain angle ordering and spacing with worked examples and link the playground.

Update the existing major changeset and add an upgrade warning: positions change in 5-, 6-, and 7-item menus, so learned gestures can select different items without a layout error or build failure.

Verified all three layout examples against the model. Formatting, type checking, and the 349-test suite passed. Reran the 88 focused model/controller tests for the expanded API documentation; all passed.

Fixes #246
