### PR TITLE
engine: merge the two selection thresholds into one

### DIFF
--- a/.changeset/matching-dwell-delays.md
+++ b/.changeset/matching-dwell-delays.md
@@ -1,0 +1,7 @@
+---
+'marking-menu': major
+---
+
+Raise the default `submenuOpeningDelay` from 100 to `1000 / 3`, matching
+`noviceDwellingTime`, so showing the menu and opening a submenu take the
+same pause.

--- a/.changeset/single-selection-threshold.md
+++ b/.changeset/single-selection-threshold.md
@@ -1,0 +1,12 @@
+---
+'marking-menu': major
+---
+
+Replace `minSelectionDist` and `minMenuSelectionDist` with a single
+`deadZoneRadius` option, defaulting to 40. An item becomes active once the
+pointer leaves that radius, and pausing on it there opens its submenu. The
+band between the two old distances, where an item was active but a pause did
+nothing, is gone. Both old names are ignored.
+
+Raise `submenuOpeningDelay` to `1000 / 3`, matching `noviceDwellingTime`, so
+both pauses last the same time.

--- a/.changeset/single-selection-threshold.md
+++ b/.changeset/single-selection-threshold.md
@@ -6,7 +6,5 @@ Replace `minSelectionDist` and `minMenuSelectionDist` with a single
 `deadZoneRadius` option, defaulting to 40. An item becomes active once the
 pointer leaves that radius, and pausing on it there opens its submenu. The
 band between the two old distances, where an item was active but a pause did
-nothing, is gone. Both old names are ignored.
-
-Raise `submenuOpeningDelay` to `1000 / 3`, matching `noviceDwellingTime`, so
-both pauses last the same time.
+nothing, is gone. TypeScript rejects the old names; JavaScript callers
+passing them get no warning and no effect.

--- a/README.md
+++ b/README.md
@@ -80,13 +80,12 @@ See [item layout](#item-layout) for angles. TypeScript infers event and item typ
 
 Pass options alongside `items` and `parent`. Distances use pixels; delays use milliseconds.
 
-| Option                 | Default    | Purpose                                                                                  |
-| ---------------------- | ---------- | ---------------------------------------------------------------------------------------- |
-| `noviceDwellingTime`   | `1000 / 3` | Pause before showing the menu.                                                           |
-| `submenuOpeningDelay`  | `100`      | Pause before opening a submenu.                                                          |
-| `movementsThreshold`   | `5`        | Movement needed to start a gesture without opening the menu, or restart a submenu pause. |
-| `minSelectionDist`     | `40`       | Minimum distance from the menu center to select an item.                                 |
-| `minMenuSelectionDist` | `80`       | Minimum distance from the menu center to open a submenu.                                 |
+| Option                | Default    | Purpose                                                                                  |
+| --------------------- | ---------- | ---------------------------------------------------------------------------------------- |
+| `noviceDwellingTime`  | `1000 / 3` | Pause before showing the menu.                                                           |
+| `submenuOpeningDelay` | `1000 / 3` | Pause before opening a submenu.                                                          |
+| `movementsThreshold`  | `5`        | Movement needed to start a gesture without opening the menu, or restart a submenu pause. |
+| `deadZoneRadius`      | `40`       | Distance from the menu center past which an item becomes active.                         |
 
 Use `log: { error: handler }` to handle internal errors; the default is `console.error`. Invalid menu definitions throw during construction.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Pass options alongside `items` and `parent`. Distances use pixels; delays use mi
 | `noviceDwellingTime`  | `1000 / 3` | Pause before showing the menu.                                                           |
 | `submenuOpeningDelay` | `1000 / 3` | Pause before opening a submenu.                                                          |
 | `movementsThreshold`  | `5`        | Movement needed to start a gesture without opening the menu, or restart a submenu pause. |
-| `deadZoneRadius`      | `40`       | Distance from the menu center past which an item becomes active.                         |
+| `deadZoneRadius`      | `40`       | Distance from the menu center past which an item becomes active and can open a submenu.  |
 
 Use `log: { error: handler }` to handle internal errors; the default is `console.error`. Invalid menu definitions throw during construction.
 

--- a/e2e/tests/dispatch-ordering.spec.ts
+++ b/e2e/tests/dispatch-ordering.spec.ts
@@ -36,7 +36,7 @@ function observed<T extends Observation['type']>(
   return observation as Extract<Observation, { type: T }>;
 }
 
-// Beyond the default `minSelectionDist` (40px): far enough to select item
+// Beyond the default `deadZoneRadius` (40px): far enough to select item
 // "a" unambiguously, the same margin `mouse.spec.ts` uses for its own
 // selections.
 const SELECT_RADIUS = 100;

--- a/e2e/tests/mouse.spec.ts
+++ b/e2e/tests/mouse.spec.ts
@@ -17,7 +17,8 @@ import { waitForLogEntry } from '../helpers/log.js';
 // movementsThreshold 5, noviceDwellingTime and submenuOpeningDelay ~333ms.
 // Radii below are chosen with enough margin from those thresholds to be
 // unambiguous rather than to probe the thresholds themselves (that's the
-// unit suites' job).
+// unit suites' job). Tests that must resolve before a pause elapses race
+// the delay itself, the way the startup cases below do.
 const SELECT_RADIUS = 100;
 const TINY_RADIUS = 3; // Below the 5px movements threshold.
 
@@ -255,6 +256,9 @@ test('novice non-leaf cancellation: releasing over a submenu item before the dwe
   });
   expect(last?.selectionId).toBeUndefined();
   expect(log.some((entry) => entry.type === 'select')).toBe(false);
+  // Only the root menu opened: had the release lost its race with the
+  // submenu delay, `Others...` would have opened too.
+  expect(log.filter((entry) => entry.type === 'open')).toHaveLength(1);
 });
 
 test('pointer capture: releasing outside the gesture surface still completes recognition', async ({

--- a/e2e/tests/mouse.spec.ts
+++ b/e2e/tests/mouse.spec.ts
@@ -13,13 +13,12 @@ import {
 } from '../helpers/gestures.js';
 import { waitForLogEntry } from '../helpers/log.js';
 
-// The fixture uses the library's defaults: minSelectionDist 40,
-// minMenuSelectionDist 80, movementsThreshold 5, noviceDwellingTime ~333ms.
+// The fixture uses the library's defaults: deadZoneRadius 40,
+// movementsThreshold 5, noviceDwellingTime and submenuOpeningDelay ~333ms.
 // Radii below are chosen with enough margin from those thresholds to be
 // unambiguous rather than to probe the thresholds themselves (that's the
 // unit suites' job).
 const SELECT_RADIUS = 100;
-const NON_LEAF_HOVER_RADIUS = 60; // Between 40 (selection) and 80 (submenu).
 const TINY_RADIUS = 3; // Below the 5px movements threshold.
 
 test('novice mode: dwelling opens the menu, lays out every item, and a release selects', async ({
@@ -232,18 +231,18 @@ test('novice center cancellation: releasing at the center cancels without select
   expect(log.some((entry) => entry.type === 'select')).toBe(false);
 });
 
-test('novice non-leaf cancellation: releasing over a submenu item (not far enough to open it) cancels', async ({
+test('novice non-leaf cancellation: releasing over a submenu item before the dwell opens it cancels', async ({
   page,
 }) => {
   const center = await surfaceCenter(page);
   await pressAt(page, center);
   await waitForMenuOpen(page);
 
-  // Between the 40px selection radius and the 80px submenu-opening radius:
-  // far enough to be "active" over `Others...`, not far enough to open it.
+  // `Others...` becomes active, and the release lands well inside the
+  // submenu-opening delay, so the menu never advances.
   await moveTo(
     page,
-    offset(center, TOP_LEVEL_ITEMS.others.angle, NON_LEAF_HOVER_RADIUS),
+    offset(center, TOP_LEVEL_ITEMS.others.angle, SELECT_RADIUS),
   );
   await releaseAt(page);
 

--- a/src/engine/controller.test.ts
+++ b/src/engine/controller.test.ts
@@ -667,7 +667,7 @@ describe('createController', () => {
       items,
       parent,
       noviceDwellingTime: 100,
-      minSelectionDist: 40,
+      deadZoneRadius: 40,
     });
 
     const canceled = voidMock<[MarkingMenuCancelEvent<AnyModelNode>]>();
@@ -723,7 +723,7 @@ describe('createController', () => {
       ],
       parent,
       noviceDwellingTime: 100,
-      minSelectionDist: 40,
+      deadZoneRadius: 40,
     });
 
     const selected = voidMock<[MarkingMenuSelectEvent<AnyModelNode>]>();
@@ -763,7 +763,7 @@ describe('createController', () => {
       items,
       parent,
       noviceDwellingTime: 100,
-      minSelectionDist: 40,
+      deadZoneRadius: 40,
     });
 
     const selected = voidMock<[MarkingMenuSelectEvent<AnyModelNode>]>();
@@ -802,7 +802,7 @@ describe('createController', () => {
     const menuBefore = parent.querySelector('.marking-menu');
     expect(menuBefore).not.toBeNull();
 
-    // Still within `minSelectionDist`, so the active item stays null and the
+    // Still within `deadZoneRadius`, so the active item stays null and the
     // menu identity is unchanged: no DOM to patch, but a render pass still
     // runs.
     parent.dispatchEvent(pointer('pointermove', { clientX: 1, clientY: 0 }));
@@ -813,7 +813,7 @@ describe('createController', () => {
     controller.dispose();
   });
 
-  it('activates no item while the pointer stays within minSelectionDist of the menu center', () => {
+  it('activates no item while the pointer stays within the dead zone', () => {
     using _canvases = stubbedCanvasContexts();
     using _timers = fakeTimers();
     const parent = createParent();
@@ -821,7 +821,7 @@ describe('createController', () => {
       items,
       parent,
       noviceDwellingTime: 100,
-      minSelectionDist: 40,
+      deadZoneRadius: 40,
     });
 
     const moved = voidMock<[MarkingMenuMoveEvent<AnyModelNode>]>();
@@ -843,7 +843,7 @@ describe('createController', () => {
     controller.dispose();
   });
 
-  it('activates the nearest item by angle once beyond minSelectionDist, patching the DOM without recreating the menu, and distinguishes continued pointing at the same item from moving to a new one', () => {
+  it('activates the nearest item by angle once past the dead zone, patching the DOM without recreating the menu, and distinguishes continued pointing at the same item from moving to a new one', () => {
     using _canvases = stubbedCanvasContexts();
     using _timers = fakeTimers();
     const parent = createParent();
@@ -851,7 +851,7 @@ describe('createController', () => {
       items,
       parent,
       noviceDwellingTime: 100,
-      minSelectionDist: 40,
+      deadZoneRadius: 40,
     });
 
     const moved = vi.fn<() => void>();
@@ -908,7 +908,7 @@ describe('createController', () => {
       items,
       parent,
       noviceDwellingTime: 100,
-      minSelectionDist: 40,
+      deadZoneRadius: 40,
     });
 
     const seen: string[] = [];
@@ -990,7 +990,7 @@ describe('createController', () => {
       { id: 'up', label: 'Up' },
     ] as const;
 
-    it('dispatches open for the submenu and recreates the menu DOM for it, once the pointer dwells beyond minMenuSelectionDist on it', () => {
+    it('dispatches open for the submenu and recreates the menu DOM for it, once the pointer dwells past the dead zone on it', () => {
       using _canvases = stubbedCanvasContexts();
       using _timers = fakeTimers();
       const parent = createParent();
@@ -998,8 +998,7 @@ describe('createController', () => {
         items: submenuItems,
         parent,
         noviceDwellingTime: 100,
-        minSelectionDist: 40,
-        minMenuSelectionDist: 80,
+        deadZoneRadius: 40,
         submenuOpeningDelay: 100,
       });
 
@@ -1012,7 +1011,7 @@ describe('createController', () => {
       vi.advanceTimersByTime(100);
       const rootMenuDom = parent.querySelector('.marking-menu');
 
-      // Beyond minMenuSelectionDist (80) on "right", a submenu.
+      // Past the dead zone on "right", a submenu.
       parent.dispatchEvent(
         pointer('pointermove', { clientX: 100, clientY: 0 }),
       );
@@ -1035,8 +1034,7 @@ describe('createController', () => {
         items: submenuItems,
         parent,
         noviceDwellingTime: 100,
-        minSelectionDist: 40,
-        minMenuSelectionDist: 80,
+        deadZoneRadius: 40,
         submenuOpeningDelay: 100,
       });
 
@@ -1072,8 +1070,7 @@ describe('createController', () => {
         items: submenuItems,
         parent,
         noviceDwellingTime: 100,
-        minSelectionDist: 40,
-        minMenuSelectionDist: 80,
+        deadZoneRadius: 40,
         submenuOpeningDelay: 100,
       });
 
@@ -1096,7 +1093,7 @@ describe('createController', () => {
       vi.advanceTimersByTime(100); // Opens the submenu, centered at [100, 0]
       const submenu = openedMenu;
 
-      // Released back at the submenu's own centre: within minSelectionDist,
+      // Released back at the submenu's own centre: within the dead zone,
       // so nothing is active there.
       parent.dispatchEvent(pointer('pointerup', { clientX: 100, clientY: 0 }));
 

--- a/src/engine/controller.ts
+++ b/src/engine/controller.ts
@@ -32,13 +32,10 @@ export type EngineConfig = MarkingMenuInput &
     */
     readonly noviceDwellingTime?: number;
     /**
-    The minimum distance from the center to select an item.
-    */
-    readonly minSelectionDist?: number;
-    /**
-    The minimum distance from the center to open a sub-menu.
-    */
-    readonly minMenuSelectionDist?: number;
+     The radius around the menu center within which no item is active. Past
+     it an item becomes active, and dwelling on it opens its sub-menu.
+     */
+    readonly deadZoneRadius?: number;
     /**
     The dwelling delay before opening a sub-menu.
     */
@@ -108,9 +105,8 @@ class Controller<Config extends EngineConfig> implements MarkingMenuController<
       options: {
         movementsThreshold: config.movementsThreshold ?? 5,
         noviceDwellingTime: config.noviceDwellingTime ?? 1000 / 3,
-        minSelectionDist: config.minSelectionDist ?? 40,
-        minMenuSelectionDist: config.minMenuSelectionDist ?? 80,
-        submenuOpeningDelay: config.submenuOpeningDelay ?? 100,
+        deadZoneRadius: config.deadZoneRadius ?? 40,
+        submenuOpeningDelay: config.submenuOpeningDelay ?? 1000 / 3,
       },
       renderer,
       log: { ...defaultLogger, ...config.log },

--- a/src/engine/machine.test-d.ts
+++ b/src/engine/machine.test-d.ts
@@ -84,8 +84,7 @@ describe('StatesOf<typeof navigationMachine>', () => {
       options: {
         movementsThreshold: 5,
         noviceDwellingTime: 1,
-        minSelectionDist: 40,
-        minMenuSelectionDist: 80,
+        deadZoneRadius: 40,
         submenuOpeningDelay: 1,
       },
     });

--- a/src/engine/machine.test.ts
+++ b/src/engine/machine.test.ts
@@ -657,7 +657,7 @@ describe('navigationMachine', () => {
       ]);
     });
 
-    it('opens the submenu anywhere past the dead zone, without a second, farther threshold', () => {
+    it('opens the submenu just past the dead zone', () => {
       const host = navigationMachine.start({ model: submenuModel, options });
       openNovice(host);
       const opened = vi.fn<() => void>();

--- a/src/engine/machine.test.ts
+++ b/src/engine/machine.test.ts
@@ -56,8 +56,7 @@ const submenuModel = createModel({
 const options = {
   movementsThreshold: 5,
   noviceDwellingTime: 300,
-  minSelectionDist: 40,
-  minMenuSelectionDist: 80,
+  deadZoneRadius: 40,
   submenuOpeningDelay: 200,
 };
 
@@ -421,7 +420,7 @@ describe('navigationMachine', () => {
   });
 
   describe('novice phase: pointing at items', () => {
-    it('stays inactive while the pointer is within minSelectionDist of the menu center (objective 5)', () => {
+    it('stays inactive while the pointer is within the dead zone (objective 5)', () => {
       const host = startHost();
       const moved = vi.fn<(event: { active: unknown }) => void>();
       host.on('move', ({ data }) => {
@@ -442,7 +441,7 @@ describe('navigationMachine', () => {
       expect(changed).not.toHaveBeenCalled();
     });
 
-    it('activates the nearest item by angle once beyond minSelectionDist, and distinguishes a changed nearest item from continued pointing at the same one (objective 6)', () => {
+    it('activates the nearest item by angle once past the dead zone, and distinguishes a changed nearest item from continued pointing at the same one (objective 6)', () => {
       const host = startHost();
       const moved: unknown[] = [];
       host.on('move', ({ data }) => {
@@ -606,7 +605,7 @@ describe('navigationMachine', () => {
   });
 
   describe('novice phase: dwelling into a submenu (objectives 9, 11)', () => {
-    it('opens the submenu when the dwell fires beyond minMenuSelectionDist on a non-leaf active item', () => {
+    it('opens the submenu when the dwell fires on a non-leaf active item', () => {
       const host = navigationMachine.start({ model: submenuModel, options });
       const opened: unknown[] = [];
       host.on('open', ({ data }) => {
@@ -614,7 +613,7 @@ describe('navigationMachine', () => {
       });
 
       openNovice(host);
-      host.send('move', { position: [100, 0] }); // Beyond minMenuSelectionDist (80), activates "right"
+      host.send('move', { position: [100, 0] }); // Past the dead zone, activates "right"
       const submenu =
         host.current.name === 'novice' ? host.current.data.active : null;
       expect(submenu).not.toBeNull();
@@ -658,23 +657,22 @@ describe('navigationMachine', () => {
       ]);
     });
 
-    it('does not open when dwelling within minMenuSelectionDist, even on a non-leaf active item', () => {
+    it('opens the submenu anywhere past the dead zone, without a second, farther threshold', () => {
       const host = navigationMachine.start({ model: submenuModel, options });
       openNovice(host);
       const opened = vi.fn<() => void>();
       host.on('open', opened);
 
-      // Beyond minSelectionDist (40) so "right" is active, but within
-      // minMenuSelectionDist (80).
-      host.send('move', { position: [50, 0] });
-      const rootMenu =
-        host.current.name === 'novice' ? host.current.data.menu : null;
+      // Just past the dead zone (40): activation and dwelling share it.
+      host.send('move', { position: [41, 0] });
+      const submenu =
+        host.current.name === 'novice' ? host.current.data.active : null;
 
       host.send('dwell');
 
-      expect(opened).not.toHaveBeenCalled();
+      expect(opened).toHaveBeenCalledTimes(1);
       expect(host.current.name === 'novice' && host.current.data.menu).toBe(
-        rootMenu,
+        submenu,
       );
     });
 
@@ -697,7 +695,7 @@ describe('navigationMachine', () => {
       const opened = vi.fn<() => void>();
       host.on('open', opened);
 
-      host.send('move', { position: [10, 0] }); // Within minSelectionDist: active stays null
+      host.send('move', { position: [10, 0] }); // Within the dead zone: active stays null
       host.send('dwell');
 
       expect(opened).not.toHaveBeenCalled();

--- a/src/engine/machine.ts
+++ b/src/engine/machine.ts
@@ -37,8 +37,7 @@ import { noviceUpperStroke, projectLayout } from './layout-view.js';
 export type NavigationOptions = {
   readonly movementsThreshold: number;
   readonly noviceDwellingTime: number;
-  readonly minSelectionDist: number;
-  readonly minMenuSelectionDist: number;
+  readonly deadZoneRadius: number;
   readonly submenuOpeningDelay: number;
 };
 
@@ -449,9 +448,7 @@ export const navigationMachine = machine({
       const { menuCenter, options, menu, dwellAnchor } = fromData;
       const { azymuth, radius } = toPolar(position, menuCenter);
       const active =
-        radius < options.minSelectionDist
-          ? null
-          : menu.getNearestChild(azymuth);
+        radius < options.deadZoneRadius ? null : menu.getNearestChild(azymuth);
       return {
         ...fromData,
         active,
@@ -466,19 +463,14 @@ export const navigationMachine = machine({
       };
     },
 
-    // Pausing beyond `minMenuSelectionDist` on a non-leaf active item opens
-    // that submenu: a genuine phase change, even though the destination is
-    // named `novice` too. Anything else declines, and since no other row is
-    // declared for (novice, dwell), the dwell is silently dropped.
+    // Pausing on a non-leaf active item opens that submenu: a genuine phase
+    // change, even though the destination is named `novice` too. Anything
+    // else declines, and since no other row is declared for (novice, dwell),
+    // the dwell is silently dropped. No distance test of its own: an item
+    // is active only past the dead zone, the one threshold there is.
     'novice -dwell> novice'({ fromData, skip }) {
-      const { active, menuCenter, lastPosition, lowerStroke, options, model } =
-        fromData;
-      const { radius } = toPolar(lastPosition, menuCenter);
-      if (
-        active === null ||
-        active.isLeaf ||
-        radius <= options.minMenuSelectionDist
-      ) {
+      const { active, lastPosition, lowerStroke, options, model } = fromData;
+      if (active === null || active.isLeaf) {
         return skip();
       }
 
@@ -614,9 +606,9 @@ export const navigationMachine = machine({
     },
 
     // Same shape as `'startup -dwell> novice'`'s own `open`, one recursion
-    // level down: the row above already declined the input unless the
-    // dwell landed beyond `minMenuSelectionDist` on a non-leaf, so an
-    // eligible submenu is all this action ever announces.
+    // level down: the row above already declined the input unless the dwell
+    // landed on a non-leaf active item, so an eligible submenu is all this
+    // action ever announces.
     'novice -dwell> novice'({ toData, emit }) {
       emit(
         'open',

--- a/src/engine/machine.ts
+++ b/src/engine/machine.ts
@@ -467,7 +467,7 @@ export const navigationMachine = machine({
     // change, even though the destination is named `novice` too. Anything
     // else declines, and since no other row is declared for (novice, dwell),
     // the dwell is silently dropped. No distance test of its own: an item
-    // is active only past the dead zone, the one threshold there is.
+    // is active only past the dead zone, and that is the only threshold.
     'novice -dwell> novice'({ fromData, skip }) {
       const { active, lastPosition, lowerStroke, options, model } = fromData;
       if (active === null || active.isLeaf) {

--- a/src/engine/runtime.test.ts
+++ b/src/engine/runtime.test.ts
@@ -6,8 +6,7 @@ const model = createModel({ items: [{ id: 'right', label: 'Right' }] });
 const options = {
   movementsThreshold: 5,
   noviceDwellingTime: 300,
-  minSelectionDist: 40,
-  minMenuSelectionDist: 80,
+  deadZoneRadius: 40,
   submenuOpeningDelay: 200,
 };
 


### PR DESCRIPTION
Closes #265.

The menu had two distances from its center. Past 40 pixels an item became active. Past 80 pixels a pause on that item opened its submenu. Between the two lay a band where an item was highlighted but pausing on it did nothing, which is a state nothing in the design asks for and nothing on screen explains.

The two options become one, `deadZoneRadius`, defaulting to 40. Leave that radius and the nearest item is active; pause there and its submenu opens. The wedge-ring design this leads to draws that radius as a circle, so one number now governs both the behavior and, later, the drawing.

The dwell transition drops its own distance check. An item is active only past the dead zone, and both are computed from the same pointer position, so the check could never decline on its own.

`submenuOpeningDelay` also rises from 100 milliseconds to `1000 / 3`, matching `noviceDwellingTime`. Showing the menu and opening a submenu now take the same pause. This is for consistency between the two pauses, not a guard against opening a submenu by mistake: labels sit outside the ring and can be read without pointing into it.

Callers passing `minSelectionDist` or `minMenuSelectionDist` get a type error. In plain JavaScript the names are ignored, with no warning and no effect. Both land in the next major release, which has not shipped yet.

Try it in the demo: press and hold, move just past the center, and pause on `Others...`.

```bash
yarn test && yarn e2e
```

The unit suites carry the behavior change. One test that asserted the old band now asserts the opposite, that a dwell just past the dead zone opens the submenu. One end-to-end case used to be safe by geometry, releasing inside the band where no submenu could open, and now depends on the release beating the submenu delay, so it also asserts that only the root menu opened.

The options table in the README replaces both rows with the merged one.

Two changesets ship with this: one for the merged option, one for the new pause. Neither the wedge ring nor the theming API lands here; #263 tracks that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
