### PR TITLE
layout: solve conflict-free label placement instead of a fixed radius

### DIFF
--- a/.changeset/label-layout-solver.md
+++ b/.changeset/label-layout-solver.md
@@ -1,0 +1,10 @@
+---
+'marking-menu': minor
+---
+
+Labels now solve a compact, conflict-free layout when a menu is created
+instead of sitting at a fixed shared radius. Item directions, cyclic order,
+and gesture mapping are unchanged; only where each label renders relative to
+that direction can shift. A menu stays laid out for its lifetime; recreate
+it (as this library already does on item, label, font, or style changes) to
+relayout.

--- a/src/layout/label-layout-corpus.ts
+++ b/src/layout/label-layout-corpus.ts
@@ -1,0 +1,136 @@
+import type { LayoutInput } from './label-layout.js';
+
+// Named fixtures shared by the correctness and performance test files, kept
+// out of the published bundle (nothing under `src/index.ts` imports this
+// module). Matches the production CSS defaults in `menu.css` unless a
+// fixture needs otherwise.
+const DEFAULT_RING_RADIUS = 80;
+const DEFAULT_CLEARANCES = {
+  plateHorizontal: 14,
+  plateVertical: 7,
+  plateToRing: 12,
+  plateToConnector: 3,
+};
+
+function evenlySpaced(
+  count: number,
+  width: number,
+  height: number,
+): LayoutInput {
+  return {
+    plates: Array.from({ length: count }, (_, index) => ({
+      angle: (360 / count) * index,
+      width,
+      height,
+    })),
+    ringRadius: DEFAULT_RING_RADIUS,
+    clearances: DEFAULT_CLEARANCES,
+  };
+}
+
+export const evenlySpaced4 = evenlySpaced(4, 120, 20);
+export const evenlySpaced8 = evenlySpaced(8, 120, 20);
+// Forward-looking stress cases beyond today's real 8-item ceiling (#274).
+export const evenlySpaced12 = evenlySpaced(12, 100, 20);
+export const evenlySpaced16 = evenlySpaced(16, 90, 20);
+
+export const uniformWidths = evenlySpaced(8, 100, 24);
+
+export const alternatingWidths: LayoutInput = {
+  plates: Array.from({ length: 8 }, (_, index) => ({
+    angle: 45 * index,
+    width: index % 2 === 0 ? 60 : 160,
+    height: 20,
+  })),
+  ringRadius: DEFAULT_RING_RADIUS,
+  clearances: DEFAULT_CLEARANCES,
+};
+
+export const oneExtremeWidth: LayoutInput = {
+  plates: Array.from({ length: 8 }, (_, index) => ({
+    angle: 45 * index,
+    width: index === 0 ? 300 : 80,
+    height: 20,
+  })),
+  ringRadius: DEFAULT_RING_RADIUS,
+  clearances: DEFAULT_CLEARANCES,
+};
+
+export const asymmetricWidths: LayoutInput = {
+  plates: [60, 90, 130, 70, 200, 85, 110, 150].map((width, index) => ({
+    angle: 45 * index,
+    width,
+    height: 18 + (index % 3) * 4,
+  })),
+  ringRadius: DEFAULT_RING_RADIUS,
+  clearances: DEFAULT_CLEARANCES,
+};
+
+// Two items a fraction of a degree apart: within any deterministic work
+// budget, no shared radius separates them, so this must resolve `oversized`.
+export const oversized: LayoutInput = {
+  plates: [
+    { angle: 0, width: 120, height: 20 },
+    { angle: 0.3, width: 120, height: 20 },
+  ],
+  ringRadius: DEFAULT_RING_RADIUS,
+  clearances: DEFAULT_CLEARANCES,
+};
+
+// Several items packed into a narrow angular band alongside normally spaced
+// ones, to exercise tight association sectors.
+export const clusteredAngles: LayoutInput = {
+  plates: [0, 15, 30, 120, 180, 240, 300, 330].map((angle) => ({
+    angle,
+    width: 90,
+    height: 20,
+  })),
+  ringRadius: DEFAULT_RING_RADIUS,
+  clearances: DEFAULT_CLEARANCES,
+};
+
+// Items on both sides of the 0/360 degree wrap.
+export const boundaryCrossing: LayoutInput = {
+  plates: [350, 10, 90, 180, 270].map((angle) => ({
+    angle,
+    width: 100,
+    height: 20,
+  })),
+  ringRadius: DEFAULT_RING_RADIUS,
+  clearances: DEFAULT_CLEARANCES,
+};
+
+// The exact production defaults at today's real maximum item count, with
+// realistic varied label widths: the benchmark case.
+export const default8ItemMenu: LayoutInput = {
+  plates: [
+    'Open',
+    'Save a copy',
+    'Close',
+    'Preferences',
+    'Export as PDF',
+    'Print',
+    'Share',
+    'Recent documents',
+  ].map((label, index) => ({
+    angle: 45 * index,
+    width: 24 + label.length * 8,
+    height: 20,
+  })),
+  ringRadius: DEFAULT_RING_RADIUS,
+  clearances: DEFAULT_CLEARANCES,
+};
+
+export const corpus: Record<string, LayoutInput> = {
+  evenlySpaced4,
+  evenlySpaced8,
+  evenlySpaced12,
+  evenlySpaced16,
+  uniformWidths,
+  alternatingWidths,
+  oneExtremeWidth,
+  asymmetricWidths,
+  clusteredAngles,
+  boundaryCrossing,
+  default8ItemMenu,
+};

--- a/src/layout/label-layout-validator.ts
+++ b/src/layout/label-layout-validator.ts
@@ -1,0 +1,275 @@
+import { at } from '../utils.js';
+import type { LayoutInput, LayoutResult } from './label-layout.js';
+
+const EPSILON = 1e-7;
+
+export type LayoutValidation = {
+  readonly valid: boolean;
+  readonly failures: readonly string[];
+};
+
+type Vec2 = readonly [number, number];
+
+const direction = (angle: number): Vec2 => {
+  const radians = (angle * Math.PI) / 180;
+  return [Math.cos(radians), Math.sin(radians)];
+};
+
+const start = (input: LayoutInput, item: number): Vec2 => {
+  const [ux, uy] = direction(at(input.plates, item).angle);
+  return [input.ringRadius * ux, input.ringRadius * uy];
+};
+
+const distanceToBox = (
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+): number =>
+  Math.hypot(
+    Math.max(0, Math.abs(x) - width / 2),
+    Math.max(0, Math.abs(y) - height / 2),
+  );
+
+const isPointOnBoxBoundary = (
+  point: Vec2,
+  center: Vec2,
+  width: number,
+  height: number,
+): boolean => {
+  const x = Math.abs(point[0] - center[0]);
+  const y = Math.abs(point[1] - center[1]);
+  const isOnVertical =
+    Math.abs(x - width / 2) <= EPSILON && y <= height / 2 + EPSILON;
+  const isOnHorizontal =
+    Math.abs(y - height / 2) <= EPSILON && x <= width / 2 + EPSILON;
+  return isOnVertical || isOnHorizontal;
+};
+
+function doesSegmentHitBox(
+  from: Vec2,
+  to: Vec2,
+  center: Vec2,
+  halfWidth: number,
+  halfHeight: number,
+): boolean {
+  const min: Vec2 = [center[0] - halfWidth, center[1] - halfHeight];
+  const max: Vec2 = [center[0] + halfWidth, center[1] + halfHeight];
+  const delta: Vec2 = [to[0] - from[0], to[1] - from[1]];
+  let enter = 0;
+  let exit = 1;
+  for (const axis of [0, 1] as const) {
+    if (Math.abs(delta[axis]) <= EPSILON) {
+      if (
+        from[axis] < min[axis] - EPSILON ||
+        from[axis] > max[axis] + EPSILON
+      ) {
+        return false;
+      }
+    } else {
+      const first = (min[axis] - from[axis]) / delta[axis];
+      const second = (max[axis] - from[axis]) / delta[axis];
+      enter = Math.max(enter, Math.min(first, second));
+      exit = Math.min(exit, Math.max(first, second));
+    }
+  }
+
+  return enter <= exit + EPSILON;
+}
+
+const cross = (a: Vec2, b: Vec2, c: Vec2): number =>
+  (b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0]);
+
+const isOnSegment = (a: Vec2, b: Vec2, point: Vec2): boolean =>
+  Math.abs(cross(a, b, point)) <= EPSILON &&
+  point[0] >= Math.min(a[0], b[0]) - EPSILON &&
+  point[0] <= Math.max(a[0], b[0]) + EPSILON &&
+  point[1] >= Math.min(a[1], b[1]) - EPSILON &&
+  point[1] <= Math.max(a[1], b[1]) + EPSILON;
+
+function areSegmentsIntersecting(a: Vec2, b: Vec2, c: Vec2, d: Vec2): boolean {
+  const abC = cross(a, b, c);
+  const abD = cross(a, b, d);
+  const cdA = cross(c, d, a);
+  const cdB = cross(c, d, b);
+  if (
+    ((abC > EPSILON && abD < -EPSILON) || (abC < -EPSILON && abD > EPSILON)) &&
+    ((cdA > EPSILON && cdB < -EPSILON) || (cdA < -EPSILON && cdB > EPSILON))
+  ) {
+    return true;
+  }
+
+  return (
+    (Math.abs(abC) <= EPSILON && isOnSegment(a, b, c)) ||
+    (Math.abs(abD) <= EPSILON && isOnSegment(a, b, d)) ||
+    (Math.abs(cdA) <= EPSILON && isOnSegment(c, d, a)) ||
+    (Math.abs(cdB) <= EPSILON && isOnSegment(c, d, b))
+  );
+}
+
+const rayError = (angle: number, point: Vec2): number => {
+  const [ux, uy] = direction(angle);
+  return Math.abs(point[0] * uy - point[1] * ux);
+};
+
+function isSameCycle(
+  expected: readonly number[],
+  actual: readonly number[],
+): boolean {
+  if (expected.length !== actual.length) {
+    return false;
+  }
+
+  for (let offset = 0; offset < expected.length; offset += 1) {
+    if (
+      expected.every(
+        (item, index) => item === actual[(index + offset) % actual.length],
+      )
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ Re-derive every hard constraint from scratch, independent of the solver's
+ own bookkeeping: association sector via cyclic order, ring clearance,
+ plate separation, connector clearance, and that every coordinate is
+ finite. This is what makes "never return invalid geometry" a checked
+ guarantee rather than a hope.
+
+ @param input - The same input given to `solveLabelLayout`.
+ @param result - Its result.
+ @returns Whether every constraint holds, and a description of each one that doesn't.
+ */
+export function validateLabelLayout(
+  input: LayoutInput,
+  result: LayoutResult,
+): LayoutValidation {
+  const failures: string[] = [];
+  if (result.status === 'oversized') {
+    return { valid: true, failures };
+  }
+
+  if (result.plates.length !== input.plates.length) {
+    failures.push('plate count differs from input');
+  }
+
+  for (const [item, plate] of result.plates.entries()) {
+    const source = input.plates[item];
+    if (source === undefined) {
+      continue;
+    }
+
+    if (
+      [plate.x, plate.y, ...plate.connectorContact].some((value) =>
+        !Number.isFinite(value),
+      )
+    ) {
+      failures.push(`plate ${item} has a non-finite coordinate`);
+    }
+
+    if (rayError(source.angle, plate.connectorContact) > 0.001) {
+      failures.push(`connector ${item} left its fixed direction`);
+    }
+
+    const [ux, uy] = direction(source.angle);
+    if (
+      plate.connectorContact[0] * ux + plate.connectorContact[1] * uy <
+      input.ringRadius - EPSILON
+    ) {
+      failures.push(`connector ${item} points into the ring`);
+    }
+
+    if (
+      !isPointOnBoxBoundary(
+        plate.connectorContact,
+        [plate.x, plate.y],
+        source.width,
+        source.height,
+      )
+    ) {
+      failures.push(`connector ${item} misses its plate`);
+    }
+
+    if (
+      distanceToBox(plate.x, plate.y, source.width, source.height) <
+      input.ringRadius + input.clearances.plateToRing - 0.001
+    ) {
+      failures.push(`plate ${item} enters the ring clearance`);
+    }
+  }
+
+  for (let i = 0; i < result.plates.length; i += 1) {
+    for (let j = i + 1; j < result.plates.length; j += 1) {
+      const first = at(result.plates, i);
+      const second = at(result.plates, j);
+      const a = at(input.plates, i);
+      const b = at(input.plates, j);
+      const isSeparateX =
+        Math.abs(first.x - second.x) + EPSILON >=
+        (a.width + b.width) / 2 + input.clearances.plateHorizontal;
+      const isSeparateY =
+        Math.abs(first.y - second.y) + EPSILON >=
+        (a.height + b.height) / 2 + input.clearances.plateVertical;
+      if (!isSeparateX && !isSeparateY) {
+        failures.push(`plates ${i} and ${j} overlap`);
+      }
+
+      const margin = input.clearances.plateToConnector;
+      if (
+        doesSegmentHitBox(
+          start(input, i),
+          first.connectorContact,
+          [second.x, second.y],
+          b.width / 2 + margin,
+          b.height / 2 + margin,
+        )
+      ) {
+        failures.push(`connector ${i} interferes with plate ${j}`);
+      }
+
+      if (
+        doesSegmentHitBox(
+          start(input, j),
+          second.connectorContact,
+          [first.x, first.y],
+          a.width / 2 + margin,
+          a.height / 2 + margin,
+        )
+      ) {
+        failures.push(`connector ${j} interferes with plate ${i}`);
+      }
+
+      if (
+        areSegmentsIntersecting(
+          start(input, i),
+          first.connectorContact,
+          start(input, j),
+          second.connectorContact,
+        )
+      ) {
+        failures.push(`connectors ${i} and ${j} cross`);
+      }
+    }
+  }
+
+  const expectedOrder = input.plates
+    .map((plate, item) => ({ item, angle: ((plate.angle % 360) + 360) % 360 }))
+    .toSorted((a, b) => a.angle - b.angle)
+    .map(({ item }) => item);
+  const actualOrder = result.plates
+    .map((plate, item) => ({
+      item,
+      angle: (Math.atan2(plate.y, plate.x) + Math.PI * 2) % (Math.PI * 2),
+    }))
+    .toSorted((a, b) => a.angle - b.angle)
+    .map(({ item }) => item);
+  if (!isSameCycle(expectedOrder, actualOrder)) {
+    failures.push('plate centers change the cyclic item order');
+  }
+
+  return { valid: failures.length === 0, failures };
+}

--- a/src/layout/label-layout-validator.ts
+++ b/src/layout/label-layout-validator.ts
@@ -77,36 +77,6 @@ function doesSegmentHitBox(
   return enter <= exit + EPSILON;
 }
 
-const cross = (a: Vec2, b: Vec2, c: Vec2): number =>
-  (b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0]);
-
-const isOnSegment = (a: Vec2, b: Vec2, point: Vec2): boolean =>
-  Math.abs(cross(a, b, point)) <= EPSILON &&
-  point[0] >= Math.min(a[0], b[0]) - EPSILON &&
-  point[0] <= Math.max(a[0], b[0]) + EPSILON &&
-  point[1] >= Math.min(a[1], b[1]) - EPSILON &&
-  point[1] <= Math.max(a[1], b[1]) + EPSILON;
-
-function areSegmentsIntersecting(a: Vec2, b: Vec2, c: Vec2, d: Vec2): boolean {
-  const abC = cross(a, b, c);
-  const abD = cross(a, b, d);
-  const cdA = cross(c, d, a);
-  const cdB = cross(c, d, b);
-  if (
-    ((abC > EPSILON && abD < -EPSILON) || (abC < -EPSILON && abD > EPSILON)) &&
-    ((cdA > EPSILON && cdB < -EPSILON) || (cdA < -EPSILON && cdB > EPSILON))
-  ) {
-    return true;
-  }
-
-  return (
-    (Math.abs(abC) <= EPSILON && isOnSegment(a, b, c)) ||
-    (Math.abs(abD) <= EPSILON && isOnSegment(a, b, d)) ||
-    (Math.abs(cdA) <= EPSILON && isOnSegment(c, d, a)) ||
-    (Math.abs(cdB) <= EPSILON && isOnSegment(c, d, b))
-  );
-}
-
 const rayError = (angle: number, point: Vec2): number => {
   const [ux, uy] = direction(angle);
   return Math.abs(point[0] * uy - point[1] * ux);
@@ -139,6 +109,10 @@ function isSameCycle(
  plate separation, connector clearance, and that every coordinate is
  finite. This is what makes "never return invalid geometry" a checked
  guarantee rather than a hope.
+
+ Two connectors can never cross each other: each lies on its own item's
+ fixed ray from the origin, and `rayError` already confirms that, so no
+ separate segment-intersection check is needed.
 
  @param input - The same input given to `solveLabelLayout`.
  @param result - Its result.
@@ -241,17 +215,6 @@ export function validateLabelLayout(
         )
       ) {
         failures.push(`connector ${j} interferes with plate ${i}`);
-      }
-
-      if (
-        areSegmentsIntersecting(
-          start(input, i),
-          first.connectorContact,
-          start(input, j),
-          second.connectorContact,
-        )
-      ) {
-        failures.push(`connectors ${i} and ${j} cross`);
       }
     }
   }

--- a/src/layout/label-layout.perf.test.ts
+++ b/src/layout/label-layout.perf.test.ts
@@ -1,0 +1,22 @@
+import { at } from '../utils.js';
+import { default8ItemMenu } from './label-layout-corpus.js';
+import { solveLabelLayout } from './label-layout.js';
+
+// Solver-only timing evidence for the issue's ~50ms P95 production gate, at
+// today's real maximum of 8 items. A miss here is the documented trigger
+// for moving the solver to a Web Worker, not something to build ahead of.
+it('meets the ~50ms P95 solver-only budget at the intended max item count', () => {
+  const runs = 200;
+  const timings = Array.from({ length: runs }, () => {
+    const start = performance.now();
+    solveLabelLayout(default8ItemMenu);
+    return performance.now() - start;
+  }).toSorted((a, b) => a - b);
+  const p95 = at(timings, Math.floor(runs * 0.95));
+
+  console.log(
+    `label layout solver: median ${at(timings, Math.floor(runs / 2)).toFixed(2)}ms, ` +
+      `p95 ${p95.toFixed(2)}ms, worst ${at(timings, runs - 1).toFixed(2)}ms over ${runs} runs`,
+  );
+  expect(p95).toBeLessThanOrEqual(50);
+});

--- a/src/layout/label-layout.test.ts
+++ b/src/layout/label-layout.test.ts
@@ -1,0 +1,59 @@
+import * as corpusFixtures from './label-layout-corpus.js';
+import { oversized } from './label-layout-corpus.js';
+import { validateLabelLayout } from './label-layout-validator.js';
+import { solveLabelLayout, type LayoutInput } from './label-layout.js';
+
+describe('solveLabelLayout', () => {
+  describe.each(Object.entries(corpusFixtures.corpus))('%s', (_name, input) => {
+    it('produces a layout that satisfies every hard constraint', () => {
+      const result = solveLabelLayout(input);
+      const validation = validateLabelLayout(input, result);
+      expect(validation.failures).toEqual([]);
+      expect(validation.valid).toBe(true);
+    });
+
+    it('is deterministic across repeated solves of the same input', () => {
+      const first = solveLabelLayout(input);
+      const second = solveLabelLayout(input);
+      expect(JSON.stringify(second)).toBe(JSON.stringify(first));
+    });
+  });
+
+  it('reports an oversized result with no plates when nothing fits', () => {
+    const result = solveLabelLayout(oversized);
+    expect(result.status).toBe('oversized');
+    expect(result.plates).toEqual([]);
+    expect(validateLabelLayout(oversized, result).valid).toBe(true);
+  });
+
+  it('finds the provably optimal layout for a small, unconstrained case', () => {
+    // With two well-separated items and generous clearances, no candidate
+    // can beat the shared-radius layout on any objective: it is already the
+    // smallest contact radius that fits, with zero tangential shift.
+    const input: LayoutInput = {
+      plates: [
+        { angle: 0, width: 80, height: 20 },
+        { angle: 180, width: 80, height: 20 },
+      ],
+      ringRadius: 80,
+      clearances: {
+        plateHorizontal: 14,
+        plateVertical: 7,
+        plateToRing: 12,
+        plateToConnector: 3,
+      },
+    };
+    const result = solveLabelLayout(input);
+    expect(result.status).toBe('optimal');
+    expect(result.plates).toHaveLength(2);
+    for (const plate of result.plates) {
+      expect(plate.y).toBeCloseTo(0, 5);
+    }
+
+    const [first, second] = result.plates;
+    expect(Math.abs(first?.x ?? NaN)).toBeCloseTo(
+      Math.abs(second?.x ?? NaN),
+      5,
+    );
+  });
+});

--- a/src/layout/label-layout.ts
+++ b/src/layout/label-layout.ts
@@ -1,0 +1,886 @@
+import { at } from '../utils.js';
+import { validateLabelLayout } from './label-layout-validator.js';
+
+const EPSILON = 1e-7;
+
+type Vec2 = readonly [number, number];
+
+/**
+ A label plate to place, as measured from the rendered DOM: its item's fixed
+ clockwise angle in degrees (0 = right, matching `ModelItem.angle`) and its
+ rendered box size.
+ */
+export type LayoutPlateInput = {
+  readonly angle: number;
+  readonly width: number;
+  readonly height: number;
+};
+
+/**
+ Minimum required gaps, in pixels: between two plates (`plateHorizontal`/
+ `plateVertical`), between a plate and the ring (`plateToRing`), and between
+ a connector line and a plate it doesn't belong to (`plateToConnector`).
+ */
+export type LayoutClearances = {
+  readonly plateHorizontal: number;
+  readonly plateVertical: number;
+  readonly plateToRing: number;
+  readonly plateToConnector: number;
+};
+
+export type LayoutInput = {
+  readonly plates: readonly LayoutPlateInput[];
+  readonly ringRadius: number;
+  readonly clearances: LayoutClearances;
+};
+
+/**
+ `optimal`: the search exhausted every candidate combination.
+ `feasible`: a validated result, but the search hit its work limit before
+ proving no better one exists.
+ `oversized`: no valid layout exists at any shared radius; `plates` is empty.
+ */
+export type LayoutStatus = 'optimal' | 'feasible' | 'oversized';
+
+export type LayoutPlateResult = {
+  readonly x: number;
+  readonly y: number;
+  /**
+  Where the connector line meets this plate, as `[x, y]` relative to the
+  menu center. Always lies on the ray through the item's fixed angle.
+  */
+  readonly connectorContact: Vec2;
+};
+
+export type LayoutDiagnostics = {
+  /**
+  Search-tree nodes visited across every refinement pass.
+  */
+  readonly nodesExplored: number;
+  /**
+  Candidate pairs checked for a geometric conflict.
+  */
+  readonly conflictChecks: number;
+};
+
+export type LayoutResult = {
+  readonly status: LayoutStatus;
+  /**
+  Empty iff `status === 'oversized'`. Otherwise one entry per input plate, same order.
+  */
+  readonly plates: readonly LayoutPlateResult[];
+  readonly diagnostics: LayoutDiagnostics;
+};
+
+// -- Geometry --------------------------------------------------------------
+//
+// A plate is an axis-aligned box centered at (x, y), never rotated. Its
+// connector is the straight segment from a fixed point on the ring
+// (`start`, in the item's own angle direction) to `contact`, the point
+// where a ray cast from the origin in that same fixed direction first meets
+// the box. Because both ends lie on that one ray, the connector always
+// points in the item's fixed direction no matter how far the box has moved
+// sideways (tangentially) from it.
+
+const radians = (degrees: number): number => (degrees * Math.PI) / 180;
+
+const direction = (angle: number): { readonly u: Vec2; readonly v: Vec2 } => {
+  const a = radians(angle);
+  return { u: [Math.cos(a), Math.sin(a)], v: [-Math.sin(a), Math.cos(a)] };
+};
+
+const normalizeAngle = (angle: number): number => ((angle % 360) + 360) % 360;
+
+type AssociationSector = {
+  readonly angle: number;
+  readonly before: number;
+  readonly after: number;
+};
+
+type PreparedInput = {
+  readonly directions: ReadonlyArray<{ readonly u: Vec2; readonly v: Vec2 }>;
+  readonly starts: readonly Vec2[];
+  // Undefined for a single-plate menu, where no neighbor constrains it.
+  readonly sectors: ReadonlyArray<AssociationSector | undefined>;
+};
+
+/**
+ Precompute each plate's fixed radial/tangential axes, its ring start point,
+ and its association sector: half the angular gap to each cyclic neighbor,
+ the region within which its center must stay so plates never swap places.
+ */
+function prepareInput(input: LayoutInput): PreparedInput {
+  const directions = input.plates.map((plate) => direction(plate.angle));
+  const starts: Vec2[] = directions.map(({ u }) => [
+    input.ringRadius * u[0],
+    input.ringRadius * u[1],
+  ]);
+  const sectors: Array<AssociationSector | undefined> = Array.from({
+    length: input.plates.length,
+  });
+  if (input.plates.length >= 2) {
+    const order = input.plates
+      .map((plate, item) => ({ item, angle: normalizeAngle(plate.angle) }))
+      .toSorted((a, b) => (a.angle === b.angle ? a.item - b.item : a.angle - b.angle));
+    for (const [index, entry] of order.entries()) {
+      const previous = at(order, (index - 1 + order.length) % order.length);
+      const next = at(order, (index + 1) % order.length);
+      sectors[entry.item] = {
+        angle: entry.angle,
+        before: normalizeAngle(entry.angle - previous.angle) / 2,
+        after: normalizeAngle(next.angle - entry.angle) / 2,
+      };
+    }
+  }
+
+  return { directions, starts, sectors };
+}
+
+const distanceToBox = (
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+): number =>
+  Math.hypot(
+    Math.max(0, Math.abs(x) - width / 2),
+    Math.max(0, Math.abs(y) - height / 2),
+  );
+
+/**
+Distance along `ray` from the origin to where it enters `box`, or `null` if it misses.
+*/
+function rayBoxContact(
+  center: Vec2,
+  box: { readonly width: number; readonly height: number },
+  ray: Vec2,
+): number | null {
+  const min: Vec2 = [center[0] - box.width / 2, center[1] - box.height / 2];
+  const max: Vec2 = [center[0] + box.width / 2, center[1] + box.height / 2];
+  let enter = 0;
+  let exit = Infinity;
+  for (const axis of [0, 1] as const) {
+    if (Math.abs(ray[axis]) < EPSILON) {
+      if (min[axis] > 0 || max[axis] < 0) {
+        return null;
+      }
+    } else {
+      const a = min[axis] / ray[axis];
+      const b = max[axis] / ray[axis];
+      enter = Math.max(enter, Math.min(a, b));
+      exit = Math.min(exit, Math.max(a, b));
+    }
+  }
+
+  return exit + EPSILON < enter || exit < 0 ? null : enter;
+}
+
+// A candidate plate position: one item's box at a given (radial, tangent)
+// offset along its own fixed axes, with everything later checks need
+// precomputed once (box bounds, connector segment bounds).
+type Candidate = {
+  readonly item: number;
+  readonly x: number;
+  readonly y: number;
+  readonly radial: number;
+  readonly tangent: number;
+  readonly contactRadius: number;
+  readonly contact: Vec2;
+  readonly minX: number;
+  readonly maxX: number;
+  readonly minY: number;
+  readonly maxY: number;
+  readonly connectorStartX: number;
+  readonly connectorStartY: number;
+  readonly connectorDeltaX: number;
+  readonly connectorDeltaY: number;
+  readonly connectorMinX: number;
+  readonly connectorMaxX: number;
+  readonly connectorMinY: number;
+  readonly connectorMaxY: number;
+};
+
+/**
+The interval of ray-parameter `t` (a point `t * u`) that falls inside `box`, expanded by `margin`.
+*/
+function rayBoxInterval(
+  u: Vec2,
+  box: { minX: number; maxX: number; minY: number; maxY: number },
+  margin: number,
+): readonly [number, number] | null {
+  const minX = box.minX - margin;
+  const maxX = box.maxX + margin;
+  const minY = box.minY - margin;
+  const maxY = box.maxY + margin;
+  let enter = -Infinity;
+  let exit = Infinity;
+  if (Math.abs(u[0]) < EPSILON) {
+    if (minX > 0 || maxX < 0) {
+      return null;
+    }
+  } else {
+    const a = minX / u[0];
+    const b = maxX / u[0];
+    enter = Math.max(enter, Math.min(a, b));
+    exit = Math.min(exit, Math.max(a, b));
+  }
+
+  if (Math.abs(u[1]) < EPSILON) {
+    if (minY > 0 || maxY < 0) {
+      return null;
+    }
+  } else {
+    const a = minY / u[1];
+    const b = maxY / u[1];
+    enter = Math.max(enter, Math.min(a, b));
+    exit = Math.min(exit, Math.max(a, b));
+  }
+
+  return enter <= exit + EPSILON ? [enter, exit] : null;
+}
+
+/**
+Whether the segment from `connector`'s start to its contact passes within `margin` of `box`.
+*/
+function doesConnectorHitPlate(
+  connector: Candidate,
+  box: { minX: number; maxX: number; minY: number; maxY: number },
+  margin: number,
+): boolean {
+  const minX = box.minX - margin;
+  const maxX = box.maxX + margin;
+  const minY = box.minY - margin;
+  const maxY = box.maxY + margin;
+  if (
+    connector.connectorMaxX < minX - EPSILON ||
+    connector.connectorMinX > maxX + EPSILON ||
+    connector.connectorMaxY < minY - EPSILON ||
+    connector.connectorMinY > maxY + EPSILON
+  ) {
+    return false;
+  }
+
+  let enter = 0;
+  let exit = 1;
+  if (Math.abs(connector.connectorDeltaX) < EPSILON) {
+    if (connector.connectorStartX < minX || connector.connectorStartX > maxX) {
+      return false;
+    }
+  } else {
+    const a = (minX - connector.connectorStartX) / connector.connectorDeltaX;
+    const b = (maxX - connector.connectorStartX) / connector.connectorDeltaX;
+    enter = Math.max(enter, Math.min(a, b));
+    exit = Math.min(exit, Math.max(a, b));
+  }
+
+  if (Math.abs(connector.connectorDeltaY) < EPSILON) {
+    if (connector.connectorStartY < minY || connector.connectorStartY > maxY) {
+      return false;
+    }
+  } else {
+    const a = (minY - connector.connectorStartY) / connector.connectorDeltaY;
+    const b = (maxY - connector.connectorStartY) / connector.connectorDeltaY;
+    enter = Math.max(enter, Math.min(a, b));
+    exit = Math.min(exit, Math.max(a, b));
+  }
+
+  return enter <= exit + EPSILON;
+}
+
+/**
+Whether two candidates conflict: too close, or one's connector clips the other's plate.
+*/
+function hasConflict(
+  clearances: LayoutClearances,
+  first: Candidate,
+  second: Candidate,
+): boolean {
+  const isSeparateX =
+    first.maxX + clearances.plateHorizontal <= second.minX + EPSILON ||
+    second.maxX + clearances.plateHorizontal <= first.minX + EPSILON;
+  const isSeparateY =
+    first.maxY + clearances.plateVertical <= second.minY + EPSILON ||
+    second.maxY + clearances.plateVertical <= first.minY + EPSILON;
+  if (!isSeparateX && !isSeparateY) {
+    return true;
+  }
+
+  const margin = clearances.plateToConnector;
+  return (
+    doesConnectorHitPlate(first, second, margin) ||
+    doesConnectorHitPlate(second, first, margin)
+  );
+}
+
+/**
+A box's radial half-thickness along its own ray: how far its near edge sits behind its center.
+*/
+function halfDistance(plate: LayoutPlateInput): number {
+  const { u } = direction(plate.angle);
+  return Math.min(
+    Math.abs(u[0]) < EPSILON ? Infinity : plate.width / 2 / Math.abs(u[0]),
+    Math.abs(u[1]) < EPSILON ? Infinity : plate.height / 2 / Math.abs(u[1]),
+  );
+}
+
+function isInsideAssociationSector(
+  sector: AssociationSector | undefined,
+  x: number,
+  y: number,
+): boolean {
+  if (sector === undefined) {
+    return true;
+  }
+
+  const centerAngle = normalizeAngle((Math.atan2(y, x) * 180) / Math.PI);
+  const delta = ((centerAngle - sector.angle + 540) % 360) - 180;
+  return delta >= -sector.before - EPSILON && delta <= sector.after + EPSILON;
+}
+
+function makeCandidate(
+  input: LayoutInput,
+  prepared: PreparedInput,
+  item: number,
+  radial: number,
+  tangent: number,
+): Candidate | null {
+  const plate = at(input.plates, item);
+  const { u, v } = at(prepared.directions, item);
+  const x = radial * u[0] + tangent * v[0];
+  const y = radial * u[1] + tangent * v[1];
+  const contactRadius = rayBoxContact([x, y], plate, u);
+  if (
+    contactRadius === null ||
+    contactRadius < input.ringRadius ||
+    !isInsideAssociationSector(prepared.sectors[item], x, y) ||
+    distanceToBox(x, y, plate.width, plate.height) <
+      input.ringRadius + input.clearances.plateToRing - EPSILON
+  ) {
+    return null;
+  }
+
+  const [startX, startY] = at(prepared.starts, item);
+  const contactX = contactRadius * u[0];
+  const contactY = contactRadius * u[1];
+  return {
+    item,
+    x,
+    y,
+    radial,
+    tangent,
+    contactRadius,
+    contact: [contactX, contactY],
+    minX: x - plate.width / 2,
+    maxX: x + plate.width / 2,
+    minY: y - plate.height / 2,
+    maxY: y + plate.height / 2,
+    connectorStartX: startX,
+    connectorStartY: startY,
+    connectorDeltaX: contactX - startX,
+    connectorDeltaY: contactY - startY,
+    connectorMinX: Math.min(startX, contactX),
+    connectorMaxX: Math.max(startX, contactX),
+    connectorMinY: Math.min(startY, contactY),
+    connectorMaxY: Math.max(startY, contactY),
+  };
+}
+
+function isValidLayout(
+  clearances: LayoutClearances,
+  layout: ReadonlyArray<Candidate | null>,
+): layout is readonly Candidate[] {
+  const plates: Candidate[] = [];
+  for (const plate of layout) {
+    if (plate === null) {
+      return false;
+    }
+
+    plates.push(plate);
+  }
+
+  for (let i = 0; i < plates.length; i += 1) {
+    for (let j = i + 1; j < plates.length; j += 1) {
+      if (hasConflict(clearances, at(plates, i), at(plates, j))) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+// -- Objective ---------------------------------------------------------
+//
+// Lexicographic: compactness first (max, then total, connector-contact
+// radius), then how far a plate strayed tangentially from its ideal radial
+// anchor (max, then total), then how evenly plates are spread (maximize the
+// smallest neighbor gap, then minimize the spread between gaps).
+
+function neighborWhitespace(
+  input: LayoutInput,
+  plates: readonly Candidate[],
+): readonly number[] {
+  const order = input.plates
+    .map((plate, item) => ({ item, angle: normalizeAngle(plate.angle) }))
+    .toSorted((a, b) => a.angle - b.angle);
+  return order.map((entry, index) => {
+    const next = at(order, (index + 1) % order.length);
+    const a = at(plates, entry.item);
+    const b = at(plates, next.item);
+    const pa = at(input.plates, entry.item);
+    const pb = at(input.plates, next.item);
+    return Math.hypot(
+      Math.max(0, Math.abs(a.x - b.x) - (pa.width + pb.width) / 2),
+      Math.max(0, Math.abs(a.y - b.y) - (pa.height + pb.height) / 2),
+    );
+  });
+}
+
+// [maxContact, totalContact, maxTangent, totalTangent, -minWhitespace, gapSpread],
+// compared lexicographically, in that priority order.
+type Score = readonly [number, number, number, number, number, number];
+
+function score(input: LayoutInput, plates: readonly Candidate[]): Score {
+  const contacts = plates.map((plate) => plate.contactRadius);
+  const shifts = plates.map((plate) => Math.abs(plate.tangent));
+  const gaps = neighborWhitespace(input, plates);
+  return [
+    Math.max(...contacts),
+    contacts.reduce((sum, value) => sum + value, 0),
+    Math.max(...shifts),
+    shifts.reduce((sum, value) => sum + value, 0),
+    -Math.min(...gaps),
+    Math.max(...gaps) - Math.min(...gaps),
+  ];
+}
+
+/**
+Lexicographic compare, each element rounded to 3 decimals to ignore float noise.
+*/
+function compareScores(a: Score, b: Score): number {
+  for (const [index, element] of a.entries()) {
+    const difference = Math.round(element * 1000) - Math.round(at(b, index) * 1000);
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+
+  return 0;
+}
+
+// -- Shared-radius fallback ----------------------------------------------
+//
+// Every plate at the same shared contact radius, tangent 0. Fast, always
+// correct when any layout exists, and the seed every search starts from,
+// so the adaptive search can never do worse than this.
+
+type SolveResult = {
+  readonly status: LayoutStatus;
+  readonly plates: readonly Candidate[];
+  readonly nodesExplored: number;
+  readonly conflictChecks: number;
+};
+
+function solveSharedRadius(
+  input: LayoutInput,
+  prepared: PreparedInput,
+): SolveResult {
+  const first = Math.ceil(input.ringRadius + input.clearances.plateToRing);
+  // Any configuration the model's minimum angular gap allows can be made
+  // conflict-free by a radius this large: every plate's own diagonal is
+  // enough slack to clear both the ring and every other plate.
+  const cap =
+    first +
+    input.plates.reduce(
+      (sum, plate) => sum + Math.hypot(plate.width, plate.height),
+      0,
+    );
+  for (let contact = first; contact <= cap; contact += 1) {
+    const plates = input.plates.map((plate, item) =>
+      makeCandidate(input, prepared, item, contact + halfDistance(plate), 0),
+    );
+    if (isValidLayout(input.clearances, plates)) {
+      return {
+        status: 'optimal',
+        plates,
+        nodesExplored: contact - first + 1,
+        conflictChecks: 0,
+      };
+    }
+  }
+
+  return {
+    status: 'oversized',
+    plates: [],
+    nodesExplored: cap - first + 1,
+    conflictChecks: 0,
+  };
+}
+
+// -- Candidate domains -----------------------------------------------------
+
+function buildDomains(
+  input: LayoutInput,
+  prepared: PreparedInput,
+  baseline: readonly Candidate[],
+  resolution: number,
+  prior?: readonly Candidate[],
+): ReadonlyArray<readonly Candidate[]> {
+  return input.plates.map((plate, item) => {
+    const seen = new Set<string>();
+    const candidates: Candidate[] = [];
+    const add = (candidate: Candidate | null): void => {
+      // `baseline` is a shared-radius layout, so every plate in it has the
+      // same contactRadius by construction: index 0 stands for all of them.
+      if (
+        candidate === null ||
+        candidate.contactRadius > at(baseline, 0).contactRadius + EPSILON
+      ) {
+        return;
+      }
+
+      const key = `${Math.round(candidate.x * 1000)},${Math.round(candidate.y * 1000)}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        candidates.push(candidate);
+      }
+    };
+
+    const base = prior?.[item];
+    const { u } = at(prepared.directions, item);
+    const tangentLimit =
+      (plate.width / 2) * Math.abs(u[1]) + (plate.height / 2) * Math.abs(u[0]);
+    if (base === undefined) {
+      const min = input.ringRadius + halfDistance(plate);
+      const max = at(baseline, item).radial + tangentLimit * 0.8;
+      const tangentFractions = [-0.8, -0.4, 0, 0.4, 0.8];
+      for (let radial = min; radial <= max; radial += resolution) {
+        for (const fraction of tangentFractions) {
+          add(
+            makeCandidate(
+              input,
+              prepared,
+              item,
+              radial,
+              tangentLimit * 0.8 * fraction,
+            ),
+          );
+        }
+      }
+    } else {
+      for (const dr of [-1, -0.5, 0, 0.5, 1]) {
+        for (const dt of [-1, -0.5, 0, 0.5, 1]) {
+          add(
+            makeCandidate(
+              input,
+              prepared,
+              item,
+              base.radial + dr * resolution,
+              base.tangent + dt * resolution,
+            ),
+          );
+        }
+      }
+    }
+
+    add(at(baseline, item));
+    return candidates.toSorted((a, b) =>
+      compareScores(
+        [a.contactRadius, Math.abs(a.tangent), 0, 0, 0, 0],
+        [b.contactRadius, Math.abs(b.tangent), 0, 0, 0, 0],
+      ),
+    );
+  });
+}
+
+// -- Joint search ------------------------------------------------------
+//
+// Exact branch-and-bound over the Cartesian product of per-item candidate
+// domains: picks the still-unassigned item with fewest remaining
+// candidates, tries each in order, prunes a branch once its best-possible
+// outcome can't beat the incumbent, and stops after a fixed number of tree
+// nodes so the result never depends on how fast the machine is.
+
+// A candidate tagged with a stable id for the lifetime of one `search` call,
+// so per-pair conflict results can be cached in flat arrays instead of a map.
+type SearchCandidate = Candidate & { readonly searchId: number };
+
+function search(
+  input: LayoutInput,
+  prepared: PreparedInput,
+  rawDomains: ReadonlyArray<readonly Candidate[]>,
+  seed: readonly Candidate[],
+  nodeLimit: number,
+): SolveResult {
+  const { clearances } = input;
+
+  let nextId = 0;
+  const domains: ReadonlyArray<readonly SearchCandidate[]> = rawDomains.map(
+    (domain) =>
+      domain.map((candidate) => ({ ...candidate, searchId: nextId++ })),
+  );
+  const candidateCount = nextId;
+
+  const conflictRows: Array<Uint8Array | undefined> = Array.from({
+    length: candidateCount,
+  });
+  let best: readonly Candidate[] = seed;
+  let bestScore = score(input, best);
+  const selected: Array<SearchCandidate | undefined> = Array.from({
+    length: domains.length,
+  });
+  let nodes = 0;
+  let conflictChecks = 0;
+  let isStopped = false;
+
+  const isConflicting = (
+    first: SearchCandidate,
+    second: SearchCandidate,
+  ): boolean => {
+    const low = Math.min(first.searchId, second.searchId);
+    const high = Math.max(first.searchId, second.searchId);
+    let row = at(conflictRows, low);
+    row ??= new Uint8Array(candidateCount);
+    conflictRows[low] = row;
+    const cached = row[high];
+    if (cached !== 0) {
+      return cached === 2;
+    }
+
+    const isSeparateX =
+      first.maxX + clearances.plateHorizontal <= second.minX + EPSILON ||
+      second.maxX + clearances.plateHorizontal <= first.minX + EPSILON;
+    const isSeparateY =
+      first.maxY + clearances.plateVertical <= second.minY + EPSILON ||
+      second.maxY + clearances.plateVertical <= first.minY + EPSILON;
+    // Does first's connector (travelling along first's own ray) clip
+    // second's box, and vice versa? `isConflicting` is itself memoized
+    // above, so this only ever runs once per pair: no need to precompute
+    // it for every candidate up front.
+    const firstInterval = rayBoxInterval(
+      at(prepared.directions, first.item).u,
+      second,
+      clearances.plateToConnector,
+    );
+    const secondInterval = rayBoxInterval(
+      at(prepared.directions, second.item).u,
+      first,
+      clearances.plateToConnector,
+    );
+    const isFirstConnectorHitting =
+      firstInterval !== null &&
+      firstInterval[0] <= first.contactRadius + EPSILON &&
+      firstInterval[1] + EPSILON >= input.ringRadius;
+    const isSecondConnectorHitting =
+      secondInterval !== null &&
+      secondInterval[0] <= second.contactRadius + EPSILON &&
+      secondInterval[1] + EPSILON >= input.ringRadius;
+    const isResult =
+      (!isSeparateX && !isSeparateY) ||
+      isFirstConnectorHitting ||
+      isSecondConnectorHitting;
+    row[high] = isResult ? 2 : 1;
+    return isResult;
+  };
+
+  const visit = (
+    depth: number,
+    availableDomains: ReadonlyArray<readonly SearchCandidate[]>,
+  ): void => {
+    if (nodes >= nodeLimit) {
+      isStopped = true;
+      return;
+    }
+
+    nodes += 1;
+    if (depth === domains.length) {
+      const candidateScore = score(input, selected as SearchCandidate[]);
+      if (compareScores(candidateScore, bestScore) < 0) {
+        best = [...selected] as SearchCandidate[];
+        bestScore = candidateScore;
+      }
+
+      return;
+    }
+
+    let item = -1;
+    let available: readonly SearchCandidate[] = [];
+    let lowerMaxContact = 0;
+    let lowerTotalContact = 0;
+    for (const chosen of selected) {
+      if (chosen === undefined) {
+        continue;
+      }
+
+      lowerMaxContact = Math.max(lowerMaxContact, chosen.contactRadius);
+      lowerTotalContact += chosen.contactRadius;
+    }
+
+    for (let index = 0; index < domains.length; index += 1) {
+      if (selected[index] !== undefined) {
+        continue;
+      }
+
+      const choices = at(availableDomains, index);
+      if (choices.length === 0) {
+        return;
+      }
+
+      let minimumContact = Infinity;
+      for (const candidate of choices) {
+        minimumContact = Math.min(minimumContact, candidate.contactRadius);
+      }
+
+      lowerMaxContact = Math.max(lowerMaxContact, minimumContact);
+      lowerTotalContact += minimumContact;
+      if (item < 0 || choices.length < available.length) {
+        item = index;
+        available = choices;
+      }
+    }
+
+    if (
+      compareScores(
+        [lowerMaxContact, lowerTotalContact, 0, 0, 0, 0],
+        [bestScore[0], bestScore[1], 0, 0, 0, 0],
+      ) > 0
+    ) {
+      return;
+    }
+
+    // Narrow every still-open domain to candidates that don't conflict with
+    // `candidate`, or `null` if that empties one of them. Its own function
+    // so the early exit is a `return`, not a `break`/`continue` reaching
+    // across the `visit` recursion's own loop nesting.
+    const narrowDomains = (
+      candidate: SearchCandidate,
+    ): ReadonlyArray<readonly SearchCandidate[]> | null => {
+      const nextDomains = [...availableDomains];
+      for (let index = 0; index < domains.length; index += 1) {
+        if (selected[index] !== undefined) {
+          continue;
+        }
+
+        const choices: SearchCandidate[] = [];
+        for (const other of at(availableDomains, index)) {
+          conflictChecks += 1;
+          if (!isConflicting(candidate, other)) {
+            choices.push(other);
+          }
+        }
+
+        if (choices.length === 0) {
+          return null;
+        }
+
+        nextDomains[index] = choices;
+      }
+
+      return nextDomains;
+    };
+
+    for (const candidate of available) {
+      selected[item] = candidate;
+      const nextDomains = narrowDomains(candidate);
+      if (nextDomains !== null) {
+        visit(depth + 1, nextDomains);
+      }
+
+      selected[item] = undefined;
+      if (isStopped) {
+        return;
+      }
+    }
+  };
+
+  visit(0, domains);
+  return {
+    plates: best,
+    nodesExplored: nodes,
+    conflictChecks,
+    status: isStopped ? 'feasible' : 'optimal',
+  };
+}
+
+/**
+Deterministic search-tree node budget: smaller as item count grows, so a solve always finishes quickly.
+*/
+function nodeLimitFor(count: number): number {
+  if (count <= 8) {
+    return 2000;
+  }
+
+  if (count <= 12) {
+    return 1000;
+  }
+
+  return 75;
+}
+
+/**
+ Place every label plate so it stays compact, clear of the ring and other
+ plates, and inside its item's fixed direction, using strict adaptive global
+ candidate search. Deterministic: the same input always produces the same
+ output, and the search stops after a fixed amount of work rather than a
+ time limit.
+
+ Computing this is the caller's job to do once, from measured plate sizes,
+ when a menu is created; see `createMenu`. It does not read the DOM and
+ does not know how its result will be rendered.
+
+ @param input - Fixed item angles, measured plate sizes, ring radius, and
+ required clearances.
+ @returns The solved layout, or an explicit `'oversized'` result with no
+ plates if no valid layout exists at any shared radius.
+ */
+export function solveLabelLayout(input: LayoutInput): LayoutResult {
+  const prepared = prepareInput(input);
+  const baseline = solveSharedRadius(input, prepared);
+  if (baseline.status === 'oversized') {
+    return {
+      status: 'oversized',
+      plates: [],
+      diagnostics: { nodesExplored: baseline.nodesExplored, conflictChecks: 0 },
+    };
+  }
+
+  const nodeLimit = nodeLimitFor(input.plates.length);
+  let domains = buildDomains(input, prepared, baseline.plates, 12);
+  let result = search(input, prepared, domains, baseline.plates, nodeLimit);
+  let { nodesExplored } = result;
+  let { conflictChecks } = result;
+  let isOptimal = result.status === 'optimal';
+  for (const resolution of [4, 1]) {
+    domains = buildDomains(
+      input,
+      prepared,
+      baseline.plates,
+      resolution,
+      result.plates,
+    );
+    result = search(input, prepared, domains, result.plates, nodeLimit);
+    nodesExplored += result.nodesExplored;
+    conflictChecks += result.conflictChecks;
+    isOptimal &&= result.status === 'optimal';
+  }
+
+  const plates = result.plates.map((plate) => ({
+    x: plate.x,
+    y: plate.y,
+    connectorContact: plate.contact,
+  }));
+  const layoutResult: LayoutResult = {
+    status: isOptimal ? 'optimal' : 'feasible',
+    plates,
+    diagnostics: { nodesExplored, conflictChecks },
+  };
+
+  const validation = validateLabelLayout(input, layoutResult);
+  if (!validation.valid) {
+    throw new Error(
+      `Label layout solver produced an invalid layout: ${validation.failures.join('; ')}`,
+    );
+  }
+
+  return layoutResult;
+}

--- a/src/layout/menu.css
+++ b/src/layout/menu.css
@@ -25,6 +25,14 @@
   --line-color: var(--item-background);
   --active-line-color: var(--active-item-background);
 
+  /* Minimum gaps the label-layout solver keeps: between two plates
+     (horizontal/vertical), between a plate and the ring, and between a
+     connector line and a plate it doesn't belong to. */
+  --item-horizontal-gap: 14px;
+  --item-vertical-gap: 7px;
+  --item-ring-gap: 12px;
+  --item-connector-gap: 3px;
+
   /* The two following variables must be set from JS. */
   --center-x: 0px;
   --center-y: 0px;
@@ -87,6 +95,23 @@
   height: var(--line-thickness);
   transform-origin: center left;
   transform: rotate(var(--angle));
+}
+
+/* Once the label-layout solver finds a conflict-free arrangement, `--x`,
+   `--y`, and `--contact-radius` (set from JS, in the same pixel coordinates
+   as `--center-x`/`--center-y`: right and down positive) replace the fixed
+   shared radius above. `.marking-menu` gets `.solved` only when the solver
+   didn't report the menu as oversized: an oversized menu keeps rendering
+   every label at the fixed radius, unmodified, rather than with no layout
+   at all. */
+.marking-menu.solved .marking-menu-item .marking-menu-label {
+  left: calc(var(--x) - var(--item-box-width) / 2);
+  top: calc(var(--y) - var(--item-box-height) / 2);
+  bottom: auto;
+}
+
+.marking-menu.solved .marking-menu-item .marking-menu-line {
+  width: calc(var(--contact-radius) + var(--item-radius) + var(--line-thickness));
 }
 
 .marking-menu-item.active {

--- a/src/layout/menu.test.ts
+++ b/src/layout/menu.test.ts
@@ -9,6 +9,65 @@ const createModel = (itemNb = 0): MenuLayoutModel => ({
   })),
 });
 
+// Evenly spread, so a solved layout has room to place every label without
+// forcing `oversized` at a realistic size.
+const createSpreadModel = (itemNb: number): MenuLayoutModel => ({
+  items: Array.from({ length: itemNb }, (_, i) => ({
+    label: `item-${i}-name`,
+    angle: (360 / itemNb) * i,
+    key: `item-${i}-key`,
+  })),
+});
+
+/**
+ JSDOM never lays elements out, so `offsetWidth`/`offsetHeight` are always
+ 0. Stub every element's to a fixed size for the duration of the block.
+ */
+const stubbedLabelSize = (width: number, height: number): Disposable => {
+  const widthSpy = vi
+    .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
+    .mockReturnValue(width);
+  const heightSpy = vi
+    .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+    .mockReturnValue(height);
+  return {
+    [Symbol.dispose]() {
+      widthSpy.mockRestore();
+      heightSpy.mockRestore();
+    },
+  };
+};
+
+/**
+ The label-layout solver's ring radius and clearances aren't set from any
+ stylesheet under test (`?inline` CSS imports resolve to an empty string
+ here). Set them as inline style on `parent` instead, which `main`
+ inherits, exactly as it would inherit them from a real stylesheet.
+ */
+const withSolverConfig = (
+  parent: HTMLElement,
+  overrides: Partial<{
+    menuRadius: number;
+    horizontalGap: number;
+    verticalGap: number;
+    ringGap: number;
+    connectorGap: number;
+  }> = {},
+): void => {
+  const {
+    menuRadius = 80,
+    horizontalGap = 14,
+    verticalGap = 7,
+    ringGap = 12,
+    connectorGap = 3,
+  } = overrides;
+  parent.style.setProperty('--menu-radius', `${menuRadius}px`);
+  parent.style.setProperty('--item-horizontal-gap', `${horizontalGap}px`);
+  parent.style.setProperty('--item-vertical-gap', `${verticalGap}px`);
+  parent.style.setProperty('--item-ring-gap', `${ringGap}px`);
+  parent.style.setProperty('--item-connector-gap', `${connectorGap}px`);
+};
+
 describe('createMenu', () => {
   it('renders', () => {
     const div = document.createElement('div');
@@ -162,5 +221,84 @@ describe('createMenu', () => {
     expect(() => {
       menu.setActive(model.items[0]?.key ?? null);
     }).not.toThrow();
+  });
+
+  it('solves a conflict-free layout once labels can be measured', () => {
+    using _size = stubbedLabelSize(80, 20);
+    const div = document.createElement('div');
+    withSolverConfig(div);
+    createMenu({
+      parent: div,
+      model: createSpreadModel(8),
+      center: [30, 50],
+      doc: document,
+    });
+
+    const main = div.querySelector('.marking-menu');
+    expect(main?.classList.contains('solved')).toBe(true);
+    const items = [...div.querySelectorAll<HTMLElement>('.marking-menu-item')];
+    expect(items).toHaveLength(8);
+    for (const item of items) {
+      expect(item.style.getPropertyValue('--x')).not.toBe('');
+      expect(item.style.getPropertyValue('--y')).not.toBe('');
+      expect(item.style.getPropertyValue('--contact-radius')).not.toBe('');
+    }
+  });
+
+  it('leaves the fallback rendering unmodified when the solver reports the menu as oversized', () => {
+    using _size = stubbedLabelSize(120, 20);
+    const div = document.createElement('div');
+    withSolverConfig(div);
+    createMenu({
+      parent: div,
+      // Two items a fraction of a degree apart: no shared radius, however
+      // large, separates them within the solver's deterministic work limit.
+      model: {
+        items: [
+          { label: 'item-0-name', angle: 0, key: 'item-0-key' },
+          { label: 'item-1-name', angle: 0.3, key: 'item-1-key' },
+        ],
+      },
+      center: [30, 50],
+      doc: document,
+    });
+
+    const main = div.querySelector('.marking-menu');
+    expect(main?.classList.contains('solved')).toBe(false);
+    const items = [...div.querySelectorAll<HTMLElement>('.marking-menu-item')];
+    for (const item of items) {
+      expect(item.style.getPropertyValue('--x')).toBe('');
+    }
+  });
+
+  it('reads the ring radius and clearances from the CSS custom properties in scope', () => {
+    using _size = stubbedLabelSize(80, 20);
+    const narrowRing = document.createElement('div');
+    withSolverConfig(narrowRing, { menuRadius: 80 });
+    createMenu({
+      parent: narrowRing,
+      model: createSpreadModel(8),
+      center: [30, 50],
+      doc: document,
+    });
+
+    const wideRing = document.createElement('div');
+    withSolverConfig(wideRing, { menuRadius: 200 });
+    createMenu({
+      parent: wideRing,
+      model: createSpreadModel(8),
+      center: [30, 50],
+      doc: document,
+    });
+
+    const contactRadius = (parent: HTMLElement): number =>
+      // Trailing "px" needs stripping; `Number` alone can't do that.
+      // eslint-disable-next-line unicorn/prefer-number-coercion -- see above.
+      Number.parseFloat(
+        parent
+          .querySelector<HTMLElement>('.marking-menu-item')
+          ?.style.getPropertyValue('--contact-radius') ?? '',
+      );
+    expect(contactRadius(wideRing)).toBeGreaterThan(contactRadius(narrowRing));
   });
 });

--- a/src/layout/menu.ts
+++ b/src/layout/menu.ts
@@ -1,4 +1,5 @@
-import { degreesToRadians, type Point } from '../utils.js';
+import { at, degreesToRadians, type Point } from '../utils.js';
+import { solveLabelLayout } from './label-layout.js';
 import menuStyles from './menu.css?inline';
 
 let hasInjectedStyles = false;
@@ -66,7 +67,10 @@ export type Menu = {
 // Items may be styled differently near a corner, so the connecting line meets
 // the label squarely. Which corner applies depends on the quadrant the item's
 // angle falls in, not on any exact angle: an axis-aligned angle (0, 90, 180,
-// 270) sits between two quadrants and gets no corner class.
+// 270) sits between two quadrants and gets no corner class. This stays keyed
+// on the angle alone, unaffected by the solved layout below: the connector
+// always approaches a plate along that same fixed direction, whatever
+// tangential offset the solver gave the plate.
 const CORNER_ITEM_CLASSES = [
   'bottom-right-item',
   'bottom-left-item',
@@ -120,6 +124,68 @@ const template = (
   return main;
 };
 
+function readPixels(style: CSSStyleDeclaration, property: string): number {
+  // `getPropertyValue` returns the raw declared value (e.g. "80px"); unlike
+  // `Number`, `parseFloat` strips that unit suffix instead of yielding NaN.
+  // eslint-disable-next-line unicorn/prefer-number-coercion -- see above.
+  return Number.parseFloat(style.getPropertyValue(property));
+}
+
+/**
+ Measure `main`'s rendered label boxes, solve their layout once, and apply
+ the result. If the solver reports the menu is oversized, leave `main` as
+ `template` built it: every label at the shared fixed radius `menu.css`
+ already renders unconditionally, still valid, just not conflict-free.
+ */
+function applySolvedLayout(
+  main: HTMLDivElement,
+  items: readonly MenuLayoutItem[],
+  doc: Document,
+): void {
+  const itemElements = [
+    ...main.querySelectorAll<HTMLElement>('.marking-menu-item'),
+  ];
+  const labelElements = itemElements.map((element) => {
+    const label = element.querySelector<HTMLElement>('.marking-menu-label');
+    if (label === null) {
+      throw new Error('Menu item element is missing its label.');
+    }
+
+    return label;
+  });
+  const plates = items.map((item, index) => ({
+    angle: item.angle,
+    width: at(labelElements, index).offsetWidth,
+    height: at(labelElements, index).offsetHeight,
+  }));
+
+  const style = (doc.defaultView ?? globalThis).getComputedStyle(main);
+  const result = solveLabelLayout({
+    plates,
+    ringRadius: readPixels(style, '--menu-radius'),
+    clearances: {
+      plateHorizontal: readPixels(style, '--item-horizontal-gap'),
+      plateVertical: readPixels(style, '--item-vertical-gap'),
+      plateToRing: readPixels(style, '--item-ring-gap'),
+      plateToConnector: readPixels(style, '--item-connector-gap'),
+    },
+  });
+  if (result.status === 'oversized') {
+    return;
+  }
+
+  main.classList.add('solved');
+  for (const [index, element] of itemElements.entries()) {
+    const plate = at(result.plates, index);
+    element.style.setProperty('--x', `${plate.x}px`);
+    element.style.setProperty('--y', `${plate.y}px`);
+    element.style.setProperty(
+      '--contact-radius',
+      `${Math.hypot(...plate.connectorContact)}px`,
+    );
+  }
+}
+
 /**
  Create the Menu display.
 
@@ -147,7 +213,12 @@ export function createMenu({
 
   // Create the DOM.
   const main = template({ items: model.items, center }, doc);
+  // Attach before measuring: a detached element's `offsetWidth`/`offsetHeight`
+  // are always 0. Everything from here through `applySolvedLayout` runs
+  // synchronously in this one call, so the unsolved layout is never
+  // painted: a browser only paints between tasks, never mid-function.
   parent.append(main);
+  applySolvedLayout(main, model.items, doc);
 
   // Clear any  active items.
   const clearActiveItems = () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -90,6 +90,22 @@ export const angle = (
 };
 
 /**
+ Read `array[index]`, trusting the caller that `index` is in range.
+
+ `noUncheckedIndexedAccess` types every array access as possibly
+ `undefined`; use this at a call site where that index is already known
+ valid by construction (a modulo-wrapped cyclic index, or one array indexed
+ by another built from it) instead of a non-null assertion.
+
+ @param array - The array to read from.
+ @param index - An index already known to be within `array`'s bounds.
+ @returns The element at `index`.
+ */
+export function at<T>(array: readonly T[], index: number): T {
+  return array[index] as T;
+}
+
+/**
  Find the entry of `list` ranked highest by `comp`.
 
  @param list - A list of items.


### PR DESCRIPTION
## Summary

Every label sat at a fixed shared radius computed in CSS trig, with unmeasured 120×20px boxes and no collision handling. This ports the winning strategy from the `prototype/label-solver` experiment (strict adaptive global candidate search, evidenced there against a shared-radius baseline and a rejected 4px-tolerance variant) into a production geometry module and wires it into the renderer:

- `src/layout/label-layout.ts` solves plate positions from measured label boxes, ring geometry, and clearances, using exact branch-and-bound search over a candidate lattice under a deterministic work limit. Falls back to a shared-radius layout when no better one is found within budget, and reports an explicit `oversized` result (empty plates) when even that fails.
- `src/layout/label-layout-validator.ts` independently re-derives every hard constraint (association sector, cyclic order, ring clearance, plate separation, connector clearance, finiteness) without reusing the solver's own bookkeeping, and gates the solver's own output before it's ever returned.
- `src/layout/menu.ts` measures each rendered label right after attaching it to the document, solves once, and applies the result via new `--x`/`--y`/`--contact-radius` CSS custom properties. `menu.css` keeps its existing fixed-radius rules as the safety net for an oversized report, so a menu whose labels don't fit at any shared radius still renders instead of throwing.
- `src/utils.ts` gained one small helper, `at<T>(array, index): T`, for the "index known safe by construction, but `noUncheckedIndexedAccess` types it as possibly undefined" pattern that showed up identically in three files.

The solver-only production benchmark (`src/layout/label-layout.perf.test.ts`) measures a ~3-6ms p95 at today's real maximum of 8 items, well under the issue's ~50ms gate, so no Web Worker or async menu lifecycle was added.

Closes #267.

## Test plan

- [x] `yarn typecheck` and `yarn lint` clean (only pre-existing-shape `max-params` warnings on functions ported faithfully from the algorithm, each param independently meaningful)
- [x] `yarn test` — 377 tests pass, including new hard-constraint, determinism, oversized-status, and small-provable-optimum tests across a representative corpus (uniform/alternating/extreme label widths, clustered angles, boundary-crossing angles, and 12/16-item stress cases beyond today's real 8-item ceiling)
- [x] Solver-only benchmark passes the ~50ms p95 production gate with wide margin
- [x] Verified in a real browser (the playground demo) that the sign convention is correct across all 8 compass directions, both visually and by reading the solved `--x`/`--y` back against each label's actual rendered position

🤖 Generated with [Claude Code](https://claude.com/claude-code)