### PR TITLE
Preserve Changesets formatting with vendored Yarn

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,6 +5,7 @@
     { "repo": "QuentinRoy/Marking-Menu", "disableThanks": true }
   ],
   "commit": false,
+  "format": false,
   "fixed": [],
   "linked": [],
   "access": "public",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           publish: yarn changeset publish
+          version: yarn changeset:version
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "e2e:test": "playwright test --config e2e/playwright.config.ts",
     "prepare": "yarn build",
     "changeset": "changeset",
+    "changeset:version": "changeset version && prettier --write CHANGELOG.md package.json",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",


### PR DESCRIPTION
Changesets 3 detects a Yarn lockfile without `packageManager` as Yarn Classic. Its auto-format hook inserts a legacy `--` separator, causing Prettier to treat flags as file patterns and fail the Release workflow. Restoring `packageManager` would make hosted Renovate use Corepack again and undo the vendored-Yarn fix.

This turns off only Changesets’ auto-format hook. The new `changeset:version` command runs versioning and then formats `CHANGELOG.md` and `package.json` explicitly, and the Release action uses that command. Generated release output stays formatted without reintroducing Corepack downloads.

To verify locally, run:

```console
yarn format:check
yarn lint
yarn typecheck
yarn test
```

The full suite passes with 349 tests. A detached release simulation also generated the pending release files and confirmed that both outputs pass Prettier.