### PR TITLE
layout: solve conflict-free label placement instead of a fixed radius

### DIFF
--- a/.changeset/label-layout-solver.md
+++ b/.changeset/label-layout-solver.md
@@ -1,0 +1,10 @@
+---
+'marking-menu': minor
+---
+
+Labels now solve a compact, conflict-free layout when a menu is created
+instead of sitting at a fixed shared radius. Item directions, cyclic order,
+and gesture mapping are unchanged; only where each label renders relative to
+that direction can shift. A menu stays laid out for its lifetime; recreate
+it (as this library already does on item, label, font, or style changes) to
+relayout.

--- a/src/layout/label-layout-corpus.ts
+++ b/src/layout/label-layout-corpus.ts
@@ -1,0 +1,136 @@
+import type { LayoutInput } from './label-layout.js';
+
+// Named fixtures shared by the correctness and performance test files, kept
+// out of the published bundle (nothing under `src/index.ts` imports this
+// module). Matches the production CSS defaults in `menu.css` unless a
+// fixture needs otherwise.
+const DEFAULT_RING_RADIUS = 80;
+const DEFAULT_CLEARANCES = {
+  plateHorizontal: 14,
+  plateVertical: 7,
+  plateToRing: 12,
+  plateToConnector: 3,
+};
+
+function evenlySpaced(
+  count: number,
+  width: number,
+  height: number,
+): LayoutInput {
+  return {
+    plates: Array.from({ length: count }, (_, index) => ({
+      angle: (360 / count) * index,
+      width,
+      height,
+    })),
+    ringRadius: DEFAULT_RING_RADIUS,
+    clearances: DEFAULT_CLEARANCES,
+  };
+}
+
+export const evenlySpaced4 = evenlySpaced(4, 120, 20);
+export const evenlySpaced8 = evenlySpaced(8, 120, 20);
+// Forward-looking stress cases beyond today's real 8-item ceiling (#274).
+export const evenlySpaced12 = evenlySpaced(12, 100, 20);
+export const evenlySpaced16 = evenlySpaced(16, 90, 20);
+
+export const uniformWidths = evenlySpaced(8, 100, 24);
+
+export const alternatingWidths: LayoutInput = {
+  plates: Array.from({ length: 8 }, (_, index) => ({
+    angle: 45 * index,
+    width: index % 2 === 0 ? 60 : 160,
+    height: 20,
+  })),
+  ringRadius: DEFAULT_RING_RADIUS,
+  clearances: DEFAULT_CLEARANCES,
+};
+
+export const oneExtremeWidth: LayoutInput = {
+  plates: Array.from({ length: 8 }, (_, index) => ({
+    angle: 45 * index,
+    width: index === 0 ? 300 : 80,
+    height: 20,
+  })),
+  ringRadius: DEFAULT_RING_RADIUS,
+  clearances: DEFAULT_CLEARANCES,
+};
+
+export const asymmetricWidths: LayoutInput = {
+  plates: [60, 90, 130, 70, 200, 85, 110, 150].map((width, index) => ({
+    angle: 45 * index,
+    width,
+    height: 18 + (index % 3) * 4,
+  })),
+  ringRadius: DEFAULT_RING_RADIUS,
+  clearances: DEFAULT_CLEARANCES,
+};
+
+// Two items a fraction of a degree apart: no shared radius, however large,
+// separates them, so this must resolve `oversized`.
+export const oversized: LayoutInput = {
+  plates: [
+    { angle: 0, width: 120, height: 20 },
+    { angle: 0.3, width: 120, height: 20 },
+  ],
+  ringRadius: DEFAULT_RING_RADIUS,
+  clearances: DEFAULT_CLEARANCES,
+};
+
+// Several items packed into a narrow angular band alongside normally spaced
+// ones, to exercise tight association sectors.
+export const clusteredAngles: LayoutInput = {
+  plates: [0, 15, 30, 120, 180, 240, 300, 330].map((angle) => ({
+    angle,
+    width: 90,
+    height: 20,
+  })),
+  ringRadius: DEFAULT_RING_RADIUS,
+  clearances: DEFAULT_CLEARANCES,
+};
+
+// Items on both sides of the 0/360 degree wrap.
+export const boundaryCrossing: LayoutInput = {
+  plates: [350, 10, 90, 180, 270].map((angle) => ({
+    angle,
+    width: 100,
+    height: 20,
+  })),
+  ringRadius: DEFAULT_RING_RADIUS,
+  clearances: DEFAULT_CLEARANCES,
+};
+
+// The exact production defaults at today's real maximum item count, with
+// realistic varied label widths: the benchmark case.
+export const default8ItemMenu: LayoutInput = {
+  plates: [
+    'Open',
+    'Save a copy',
+    'Close',
+    'Preferences',
+    'Export as PDF',
+    'Print',
+    'Share',
+    'Recent documents',
+  ].map((label, index) => ({
+    angle: 45 * index,
+    width: 24 + label.length * 8,
+    height: 20,
+  })),
+  ringRadius: DEFAULT_RING_RADIUS,
+  clearances: DEFAULT_CLEARANCES,
+};
+
+export const corpus: Record<string, LayoutInput> = {
+  evenlySpaced4,
+  evenlySpaced8,
+  evenlySpaced12,
+  evenlySpaced16,
+  uniformWidths,
+  alternatingWidths,
+  oneExtremeWidth,
+  asymmetricWidths,
+  clusteredAngles,
+  boundaryCrossing,
+  default8ItemMenu,
+};

--- a/src/layout/label-layout-corpus.ts
+++ b/src/layout/label-layout-corpus.ts
@@ -28,6 +28,9 @@ function evenlySpaced(
   };
 }
 
+// A single item has no cyclic neighbor, so no association sector constrains it.
+export const singleItem = evenlySpaced(1, 120, 20);
+
 export const evenlySpaced4 = evenlySpaced(4, 120, 20);
 export const evenlySpaced8 = evenlySpaced(8, 120, 20);
 // Forward-looking stress cases beyond today's real 8-item ceiling (#274).
@@ -122,6 +125,7 @@ export const default8ItemMenu: LayoutInput = {
 };
 
 export const corpus: Record<string, LayoutInput> = {
+  singleItem,
   evenlySpaced4,
   evenlySpaced8,
   evenlySpaced12,

--- a/src/layout/label-layout-validator.test.ts
+++ b/src/layout/label-layout-validator.test.ts
@@ -1,0 +1,151 @@
+import { validateLabelLayout } from './label-layout-validator.js';
+import type { LayoutInput, LayoutResult } from './label-layout.js';
+
+const clearances = {
+  plateHorizontal: 14,
+  plateVertical: 7,
+  plateToRing: 12,
+  plateToConnector: 3,
+};
+
+describe('validateLabelLayout', () => {
+  it('passes an oversized result through unchecked', () => {
+    const input: LayoutInput = { plates: [], ringRadius: 80, clearances };
+    expect(
+      validateLabelLayout(input, { oversized: true, plates: [] }).valid,
+    ).toBe(true);
+  });
+
+  it('flags a non-finite coordinate and a connector that misses its plate', () => {
+    const input: LayoutInput = {
+      plates: [{ angle: 0, width: 100, height: 20 }],
+      ringRadius: 80,
+      clearances,
+    };
+    const result: LayoutResult = {
+      oversized: false,
+      plates: [{ x: NaN, y: 0, connectorContact: [80, 0] }],
+    };
+    const { failures } = validateLabelLayout(input, result);
+    expect(failures).toContain('plate 0 has a non-finite coordinate');
+    expect(failures).toContain('connector 0 misses its plate');
+  });
+
+  it('flags a connector that leaves its fixed direction', () => {
+    const input: LayoutInput = {
+      plates: [{ angle: 90, width: 100, height: 20 }],
+      ringRadius: 80,
+      clearances,
+    };
+    const result: LayoutResult = {
+      oversized: false,
+      // Angle 90 points straight up (x = 0); this contact sits off that ray.
+      plates: [{ x: 0, y: 150, connectorContact: [50, 80] }],
+    };
+    expect(validateLabelLayout(input, result).failures).toContain(
+      'connector 0 left its fixed direction',
+    );
+  });
+
+  it('flags a connector pointing into the ring and a plate inside the ring clearance', () => {
+    const input: LayoutInput = {
+      plates: [{ angle: 180, width: 100, height: 20 }],
+      ringRadius: 80,
+      clearances,
+    };
+    const result: LayoutResult = {
+      oversized: false,
+      plates: [{ x: -10, y: 0, connectorContact: [-10, 0] }],
+    };
+    const { failures } = validateLabelLayout(input, result);
+    expect(failures).toContain('connector 0 points into the ring');
+    expect(failures).toContain('plate 0 enters the ring clearance');
+  });
+
+  it('flags a mismatched plate count', () => {
+    const input: LayoutInput = {
+      plates: [
+        { angle: 0, width: 100, height: 20 },
+        { angle: 90, width: 100, height: 20 },
+      ],
+      ringRadius: 80,
+      clearances,
+    };
+    const result: LayoutResult = {
+      oversized: false,
+      plates: [{ x: 150, y: 0, connectorContact: [80, 0] }],
+    };
+    expect(validateLabelLayout(input, result).failures).toContain(
+      'plate count differs from input',
+    );
+  });
+
+  it('flags overlapping plates', () => {
+    const input: LayoutInput = {
+      plates: [
+        { angle: 0, width: 100, height: 20 },
+        { angle: 90, width: 100, height: 20 },
+      ],
+      ringRadius: 80,
+      clearances,
+    };
+    const result: LayoutResult = {
+      oversized: false,
+      plates: [
+        { x: 150, y: 0, connectorContact: [100, 0] },
+        // 10px away on both axes: well inside the required gaps.
+        { x: 150, y: 10, connectorContact: [0, 80] },
+      ],
+    };
+    expect(validateLabelLayout(input, result).failures).toContain(
+      'plates 0 and 1 overlap',
+    );
+  });
+
+  it('flags a connector interfering with a neighboring plate', () => {
+    const input: LayoutInput = {
+      plates: [
+        { angle: 0, width: 100, height: 20 },
+        { angle: 90, width: 100, height: 20 },
+      ],
+      ringRadius: 80,
+      clearances,
+    };
+    const result: LayoutResult = {
+      oversized: false,
+      plates: [
+        // Contact (300, 0) sits on this plate's own boundary, but the
+        // segment from the ring to it runs straight through plate 1's box.
+        { x: 350, y: 0, connectorContact: [300, 0] },
+        { x: 150, y: 0, connectorContact: [0, 80] },
+      ],
+    };
+    expect(validateLabelLayout(input, result).failures).toContain(
+      'connector 0 interferes with plate 1',
+    );
+  });
+
+  it('flags plate centers that change the cyclic item order', () => {
+    const input: LayoutInput = {
+      plates: [
+        { angle: 0, width: 40, height: 20 },
+        { angle: 90, width: 40, height: 20 },
+        { angle: 180, width: 40, height: 20 },
+      ],
+      ringRadius: 80,
+      clearances,
+    };
+    const result: LayoutResult = {
+      oversized: false,
+      plates: [
+        { x: 150, y: 0, connectorContact: [80, 0] },
+        // Items 1 and 2 sit at each other's expected position.
+        { x: -150, y: 0, connectorContact: [0, 80] },
+        { x: 0, y: 150, connectorContact: [-80, 0] },
+      ],
+    };
+    expect(validateLabelLayout(input, result).failures).toContain(
+      'plate centers change the cyclic item order',
+    );
+  });
+});

--- a/src/layout/label-layout-validator.ts
+++ b/src/layout/label-layout-validator.ts
@@ -1,0 +1,239 @@
+import { at, type Point } from '../utils.js';
+import type { LayoutInput, LayoutResult } from './label-layout.js';
+
+// Re-derives every hard constraint from scratch, independent of the
+// solver's own bookkeeping, so "never return invalid geometry" is a
+// checked guarantee rather than a hope. Test support only: not shipped
+// with the production module.
+
+const EPSILON = 1e-7;
+
+export type LayoutValidation = {
+  readonly valid: boolean;
+  readonly failures: readonly string[];
+};
+
+const direction = (angle: number): Point => {
+  const radians = (angle * Math.PI) / 180;
+  return [Math.cos(radians), Math.sin(radians)];
+};
+
+const start = (input: LayoutInput, item: number): Point => {
+  const [ux, uy] = direction(at(input.plates, item).angle);
+  return [input.ringRadius * ux, input.ringRadius * uy];
+};
+
+const distanceToBox = (
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+): number =>
+  Math.hypot(
+    Math.max(0, Math.abs(x) - width / 2),
+    Math.max(0, Math.abs(y) - height / 2),
+  );
+
+const isPointOnBoxBoundary = (
+  point: Point,
+  center: Point,
+  width: number,
+  height: number,
+): boolean => {
+  const x = Math.abs(point[0] - center[0]);
+  const y = Math.abs(point[1] - center[1]);
+  const isOnVertical =
+    Math.abs(x - width / 2) <= EPSILON && y <= height / 2 + EPSILON;
+  const isOnHorizontal =
+    Math.abs(y - height / 2) <= EPSILON && x <= width / 2 + EPSILON;
+  return isOnVertical || isOnHorizontal;
+};
+
+function doesSegmentHitBox(
+  from: Point,
+  to: Point,
+  center: Point,
+  halfWidth: number,
+  halfHeight: number,
+): boolean {
+  const min: Point = [center[0] - halfWidth, center[1] - halfHeight];
+  const max: Point = [center[0] + halfWidth, center[1] + halfHeight];
+  const delta: Point = [to[0] - from[0], to[1] - from[1]];
+  let enter = 0;
+  let exit = 1;
+  for (const axis of [0, 1] as const) {
+    if (Math.abs(delta[axis]) <= EPSILON) {
+      if (
+        from[axis] < min[axis] - EPSILON ||
+        from[axis] > max[axis] + EPSILON
+      ) {
+        return false;
+      }
+    } else {
+      const first = (min[axis] - from[axis]) / delta[axis];
+      const second = (max[axis] - from[axis]) / delta[axis];
+      enter = Math.max(enter, Math.min(first, second));
+      exit = Math.min(exit, Math.max(first, second));
+    }
+  }
+
+  return enter <= exit + EPSILON;
+}
+
+const rayError = (angle: number, point: Point): number => {
+  const [ux, uy] = direction(angle);
+  return Math.abs(point[0] * uy - point[1] * ux);
+};
+
+function isSameCycle(
+  expected: readonly number[],
+  actual: readonly number[],
+): boolean {
+  if (expected.length !== actual.length) {
+    return false;
+  }
+
+  for (let offset = 0; offset < expected.length; offset += 1) {
+    if (
+      expected.every(
+        (item, index) => item === actual[(index + offset) % actual.length],
+      )
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ Independently re-check every hard constraint of a solved layout: association
+ sector via cyclic order, ring clearance, plate separation, connector
+ clearance, and that every coordinate is finite.
+
+ Two connectors can never cross each other: each lies on its own item's
+ fixed ray from the origin, and `rayError` already confirms that, so no
+ separate segment-intersection check is needed.
+
+ @param input - The same input given to `solveLabelLayout`.
+ @param result - Its result.
+ @returns Whether every constraint holds, and a description of each one that doesn't.
+ */
+export function validateLabelLayout(
+  input: LayoutInput,
+  result: LayoutResult,
+): LayoutValidation {
+  const failures: string[] = [];
+  if (result.oversized) {
+    return { valid: true, failures };
+  }
+
+  if (result.plates.length !== input.plates.length) {
+    failures.push('plate count differs from input');
+  }
+
+  for (const [item, plate] of result.plates.entries()) {
+    const source = input.plates[item];
+    if (source === undefined) {
+      continue;
+    }
+
+    if (
+      [plate.x, plate.y, ...plate.connectorContact].some(
+        (value) => !Number.isFinite(value),
+      )
+    ) {
+      failures.push(`plate ${item} has a non-finite coordinate`);
+    }
+
+    if (rayError(source.angle, plate.connectorContact) > 0.001) {
+      failures.push(`connector ${item} left its fixed direction`);
+    }
+
+    const [ux, uy] = direction(source.angle);
+    if (
+      plate.connectorContact[0] * ux + plate.connectorContact[1] * uy <
+      input.ringRadius - EPSILON
+    ) {
+      failures.push(`connector ${item} points into the ring`);
+    }
+
+    if (
+      !isPointOnBoxBoundary(
+        plate.connectorContact,
+        [plate.x, plate.y],
+        source.width,
+        source.height,
+      )
+    ) {
+      failures.push(`connector ${item} misses its plate`);
+    }
+
+    if (
+      distanceToBox(plate.x, plate.y, source.width, source.height) <
+      input.ringRadius + input.clearances.plateToRing - 0.001
+    ) {
+      failures.push(`plate ${item} enters the ring clearance`);
+    }
+  }
+
+  for (let i = 0; i < result.plates.length; i += 1) {
+    for (let j = i + 1; j < result.plates.length; j += 1) {
+      const first = at(result.plates, i);
+      const second = at(result.plates, j);
+      const a = at(input.plates, i);
+      const b = at(input.plates, j);
+      const isSeparateX =
+        Math.abs(first.x - second.x) + EPSILON >=
+        (a.width + b.width) / 2 + input.clearances.plateHorizontal;
+      const isSeparateY =
+        Math.abs(first.y - second.y) + EPSILON >=
+        (a.height + b.height) / 2 + input.clearances.plateVertical;
+      if (!isSeparateX && !isSeparateY) {
+        failures.push(`plates ${i} and ${j} overlap`);
+      }
+
+      const margin = input.clearances.plateToConnector;
+      if (
+        doesSegmentHitBox(
+          start(input, i),
+          first.connectorContact,
+          [second.x, second.y],
+          b.width / 2 + margin,
+          b.height / 2 + margin,
+        )
+      ) {
+        failures.push(`connector ${i} interferes with plate ${j}`);
+      }
+
+      if (
+        doesSegmentHitBox(
+          start(input, j),
+          second.connectorContact,
+          [first.x, first.y],
+          a.width / 2 + margin,
+          a.height / 2 + margin,
+        )
+      ) {
+        failures.push(`connector ${j} interferes with plate ${i}`);
+      }
+    }
+  }
+
+  const expectedOrder = input.plates
+    .map((plate, item) => ({ item, angle: ((plate.angle % 360) + 360) % 360 }))
+    .toSorted((a, b) => a.angle - b.angle)
+    .map(({ item }) => item);
+  const actualOrder = result.plates
+    .map((plate, item) => ({
+      item,
+      angle: (Math.atan2(plate.y, plate.x) + Math.PI * 2) % (Math.PI * 2),
+    }))
+    .toSorted((a, b) => a.angle - b.angle)
+    .map(({ item }) => item);
+  if (!isSameCycle(expectedOrder, actualOrder)) {
+    failures.push('plate centers change the cyclic item order');
+  }
+
+  return { valid: failures.length === 0, failures };
+}

--- a/src/layout/label-layout.perf.test.ts
+++ b/src/layout/label-layout.perf.test.ts
@@ -1,0 +1,22 @@
+import { at } from '../utils.js';
+import { default8ItemMenu } from './label-layout-corpus.js';
+import { solveLabelLayout } from './label-layout.js';
+
+// Solver-only timing evidence for the issue's ~50ms P95 production gate, at
+// today's real maximum of 8 items. A miss here is the documented trigger
+// for moving the solver to a Web Worker, not something to build ahead of.
+it('meets the ~50ms P95 solver-only budget at the intended max item count', () => {
+  const runs = 200;
+  const timings = Array.from({ length: runs }, () => {
+    const start = performance.now();
+    solveLabelLayout(default8ItemMenu);
+    return performance.now() - start;
+  }).toSorted((a, b) => a - b);
+  const p95 = at(timings, Math.floor(runs * 0.95));
+
+  console.log(
+    `label layout solver: median ${at(timings, Math.floor(runs / 2)).toFixed(2)}ms, ` +
+      `p95 ${p95.toFixed(2)}ms, worst ${at(timings, runs - 1).toFixed(2)}ms over ${runs} runs`,
+  );
+  expect(p95).toBeLessThanOrEqual(50);
+});

--- a/src/layout/label-layout.test.ts
+++ b/src/layout/label-layout.test.ts
@@ -1,0 +1,77 @@
+import * as corpusFixtures from './label-layout-corpus.js';
+import { oversized } from './label-layout-corpus.js';
+import { validateLabelLayout } from './label-layout-validator.js';
+import { solveLabelLayout, type LayoutInput } from './label-layout.js';
+
+describe('solveLabelLayout', () => {
+  describe.each(Object.entries(corpusFixtures.corpus))('%s', (_name, input) => {
+    it('produces a layout that satisfies every hard constraint', () => {
+      const result = solveLabelLayout(input);
+      const validation = validateLabelLayout(input, result);
+      expect(validation.failures).toEqual([]);
+      expect(validation.valid).toBe(true);
+    });
+
+    it('is deterministic across repeated solves of the same input', () => {
+      const first = solveLabelLayout(input);
+      const second = solveLabelLayout(input);
+      expect(JSON.stringify(second)).toBe(JSON.stringify(first));
+    });
+  });
+
+  it('reports an oversized result with no plates when nothing fits', () => {
+    const result = solveLabelLayout(oversized);
+    expect(result.oversized).toBe(true);
+    expect(result.plates).toEqual([]);
+    expect(validateLabelLayout(oversized, result).valid).toBe(true);
+  });
+
+  it('leaves the shared-radius layout untouched when no greedy move improves it', () => {
+    // Two items on opposite sides with generous clearances: no move can
+    // beat the shared-radius layout on any measure, so greedy compaction
+    // must be a no-op.
+    const input: LayoutInput = {
+      plates: [
+        { angle: 0, width: 80, height: 20 },
+        { angle: 180, width: 80, height: 20 },
+      ],
+      ringRadius: 80,
+      clearances: {
+        plateHorizontal: 14,
+        plateVertical: 7,
+        plateToRing: 12,
+        plateToConnector: 3,
+      },
+    };
+    const result = solveLabelLayout(input);
+    expect(result.oversized).toBe(false);
+    expect(result.plates).toHaveLength(2);
+    for (const plate of result.plates) {
+      expect(plate.y).toBeCloseTo(0, 5);
+    }
+
+    const [first, second] = result.plates;
+    expect(Math.abs(first?.x ?? NaN)).toBeCloseTo(
+      Math.abs(second?.x ?? NaN),
+      5,
+    );
+  });
+
+  it('compacts a crowded menu closer than a uniform shared radius would sit', () => {
+    // One much wider plate among evenly spaced narrow ones: a shared
+    // radius must clear the wide plate everywhere, pushing every other
+    // plate out with it. Greedy compaction should pull the narrow plates
+    // back in, so the total connector-contact radius drops below what
+    // every plate sitting at the widest one's radius would total.
+    const input = corpusFixtures.oneExtremeWidth;
+    const result = solveLabelLayout(input);
+    expect(result.oversized).toBe(false);
+    const contacts = result.plates.map((plate) =>
+      Math.hypot(...plate.connectorContact),
+    );
+    const totalContact = contacts.reduce((sum, value) => sum + value, 0);
+    expect(totalContact).toBeLessThan(
+      Math.max(...contacts) * input.plates.length,
+    );
+  });
+});

--- a/src/layout/label-layout.ts
+++ b/src/layout/label-layout.ts
@@ -1,0 +1,477 @@
+import { at, type EmptyTuple, type Point } from '../utils.js';
+
+const EPSILON = 1e-7;
+
+/**
+ A label plate to place: its item's fixed clockwise angle in degrees (0 =
+ right, matching `ModelItem.angle`) and its rendered box size.
+ */
+export type LayoutPlateInput = {
+  readonly angle: number;
+  readonly width: number;
+  readonly height: number;
+};
+
+/**
+ Minimum gaps, in pixels: between two plates (`plateHorizontal`/
+ `plateVertical`), a plate and the ring (`plateToRing`), and a connector and
+ a plate it doesn't belong to (`plateToConnector`).
+ */
+export type LayoutClearances = {
+  readonly plateHorizontal: number;
+  readonly plateVertical: number;
+  readonly plateToRing: number;
+  readonly plateToConnector: number;
+};
+
+export type LayoutInput = {
+  readonly plates: readonly LayoutPlateInput[];
+  readonly ringRadius: number;
+  readonly clearances: LayoutClearances;
+};
+
+export type LayoutPlateResult = {
+  readonly x: number;
+  readonly y: number;
+  /**
+  Where the connector meets this plate, `[x, y]` relative to the menu center.
+  */
+  readonly connectorContact: Point;
+};
+
+/**
+`oversized`'s `plates` is always empty: no shared radius keeps every plate clear.
+*/
+export type LayoutResult =
+  | { readonly oversized: false; readonly plates: readonly LayoutPlateResult[] }
+  | { readonly oversized: true; readonly plates: EmptyTuple };
+
+// A plate is an axis-aligned box centered at (x, y). Its connector runs
+// from a fixed point on the ring to where a ray from the origin, cast in
+// the item's fixed angle, first meets the box: it always points that
+// direction no matter how far the box has shifted sideways from it.
+
+const direction = (angle: number): { readonly u: Point; readonly v: Point } => {
+  const a = (angle * Math.PI) / 180;
+  return { u: [Math.cos(a), Math.sin(a)], v: [-Math.sin(a), Math.cos(a)] };
+};
+
+const normalizeAngle = (angle: number): number => ((angle % 360) + 360) % 360;
+
+type AssociationSector = {
+  readonly angle: number;
+  readonly before: number;
+  readonly after: number;
+};
+
+type PreparedInput = {
+  readonly directions: ReadonlyArray<{ readonly u: Point; readonly v: Point }>;
+  readonly starts: readonly Point[];
+  // Undefined for a single-plate menu, where no neighbor constrains it.
+  readonly sectors: ReadonlyArray<AssociationSector | undefined>;
+};
+
+// Precompute each plate's fixed radial/tangential axes, ring start point,
+// and association sector (half the angular gap to each cyclic neighbor:
+// the region its center must stay in so plates never swap places).
+function prepareInput(input: LayoutInput): PreparedInput {
+  const directions = input.plates.map((plate) => direction(plate.angle));
+  const starts: Point[] = directions.map(({ u }) => [
+    input.ringRadius * u[0],
+    input.ringRadius * u[1],
+  ]);
+  const sectors: Array<AssociationSector | undefined> = Array.from({
+    length: input.plates.length,
+  });
+  if (input.plates.length >= 2) {
+    const order = input.plates
+      .map((plate, item) => ({ item, angle: normalizeAngle(plate.angle) }))
+      .toSorted((a, b) =>
+        a.angle === b.angle ? a.item - b.item : a.angle - b.angle,
+      );
+    for (const [index, entry] of order.entries()) {
+      const previous = at(order, (index - 1 + order.length) % order.length);
+      const next = at(order, (index + 1) % order.length);
+      sectors[entry.item] = {
+        angle: entry.angle,
+        before: normalizeAngle(entry.angle - previous.angle) / 2,
+        after: normalizeAngle(next.angle - entry.angle) / 2,
+      };
+    }
+  }
+
+  return { directions, starts, sectors };
+}
+
+const distanceToBox = (
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+): number =>
+  Math.hypot(
+    Math.max(0, Math.abs(x) - width / 2),
+    Math.max(0, Math.abs(y) - height / 2),
+  );
+
+type Box = {
+  readonly minX: number;
+  readonly maxX: number;
+  readonly minY: number;
+  readonly maxY: number;
+};
+
+/**
+The interval of `t` where `origin + t * delta` lies inside `box`, or `null` if it never does.
+*/
+function clipToBox(
+  origin: Point,
+  delta: Point,
+  box: Box,
+): readonly [number, number] | null {
+  let enter = -Infinity;
+  let exit = Infinity;
+  for (const [o, d, min, max] of [
+    [origin[0], delta[0], box.minX, box.maxX],
+    [origin[1], delta[1], box.minY, box.maxY],
+  ] as const) {
+    if (Math.abs(d) < EPSILON) {
+      if (o < min || o > max) {
+        return null;
+      }
+    } else {
+      const a = (min - o) / d;
+      const b = (max - o) / d;
+      enter = Math.max(enter, Math.min(a, b));
+      exit = Math.min(exit, Math.max(a, b));
+    }
+  }
+
+  return enter <= exit + EPSILON ? [enter, exit] : null;
+}
+
+/**
+Distance along unit `ray` from the origin to where it enters `box`, or `null` if it misses (behind the origin, or never).
+*/
+function rayBoxContact(
+  center: Point,
+  box: { readonly width: number; readonly height: number },
+  ray: Point,
+): number | null {
+  const interval = clipToBox([0, 0], ray, {
+    minX: center[0] - box.width / 2,
+    maxX: center[0] + box.width / 2,
+    minY: center[1] - box.height / 2,
+    maxY: center[1] + box.height / 2,
+  });
+  return interval === null || interval[1] < 0 ? null : Math.max(interval[0], 0);
+}
+
+/**
+Whether the segment from `start` to `end` passes within `margin` of `box`.
+*/
+function doesSegmentHitBox(
+  start: Point,
+  end: Point,
+  box: Box,
+  margin: number,
+): boolean {
+  const interval = clipToBox(start, [end[0] - start[0], end[1] - start[1]], {
+    minX: box.minX - margin,
+    maxX: box.maxX + margin,
+    minY: box.minY - margin,
+    maxY: box.maxY + margin,
+  });
+  return (
+    interval !== null && interval[0] <= 1 + EPSILON && interval[1] >= -EPSILON
+  );
+}
+
+// A plate at a given (radial, tangent) offset along its own fixed axes.
+type Candidate = {
+  readonly item: number;
+  readonly x: number;
+  readonly y: number;
+  readonly radial: number;
+  readonly tangent: number;
+  readonly contactRadius: number;
+  readonly contact: Point;
+  readonly minX: number;
+  readonly maxX: number;
+  readonly minY: number;
+  readonly maxY: number;
+};
+
+/**
+Whether two candidates conflict: too close, or one's connector clips the other's plate.
+*/
+function hasConflict(
+  clearances: LayoutClearances,
+  starts: readonly Point[],
+  first: Candidate,
+  second: Candidate,
+): boolean {
+  const isSeparateX =
+    first.maxX + clearances.plateHorizontal <= second.minX + EPSILON ||
+    second.maxX + clearances.plateHorizontal <= first.minX + EPSILON;
+  const isSeparateY =
+    first.maxY + clearances.plateVertical <= second.minY + EPSILON ||
+    second.maxY + clearances.plateVertical <= first.minY + EPSILON;
+  if (!isSeparateX && !isSeparateY) {
+    return true;
+  }
+
+  const margin = clearances.plateToConnector;
+  return (
+    doesSegmentHitBox(at(starts, first.item), first.contact, second, margin) ||
+    doesSegmentHitBox(at(starts, second.item), second.contact, first, margin)
+  );
+}
+
+/**
+A box's radial half-thickness along its own ray: how far its near edge sits behind its center.
+*/
+function halfDistance(plate: LayoutPlateInput): number {
+  const { u } = direction(plate.angle);
+  return Math.min(
+    Math.abs(u[0]) < EPSILON ? Infinity : plate.width / 2 / Math.abs(u[0]),
+    Math.abs(u[1]) < EPSILON ? Infinity : plate.height / 2 / Math.abs(u[1]),
+  );
+}
+
+function isInsideAssociationSector(
+  sector: AssociationSector | undefined,
+  x: number,
+  y: number,
+): boolean {
+  if (sector === undefined) {
+    return true;
+  }
+
+  const centerAngle = normalizeAngle((Math.atan2(y, x) * 180) / Math.PI);
+  const delta = ((centerAngle - sector.angle + 540) % 360) - 180;
+  return delta >= -sector.before - EPSILON && delta <= sector.after + EPSILON;
+}
+
+// Place plate `item` at the given offset, or `null` if that leaves its
+// association sector, or lets the plate or connector enter the ring.
+function makeCandidate(
+  input: LayoutInput,
+  prepared: PreparedInput,
+  item: number,
+  offset: { readonly radial: number; readonly tangent: number },
+): Candidate | null {
+  const { radial, tangent } = offset;
+  const plate = at(input.plates, item);
+  const { u, v } = at(prepared.directions, item);
+  const x = radial * u[0] + tangent * v[0];
+  const y = radial * u[1] + tangent * v[1];
+  const contactRadius = rayBoxContact([x, y], plate, u);
+  if (
+    contactRadius === null ||
+    contactRadius < input.ringRadius ||
+    !isInsideAssociationSector(prepared.sectors[item], x, y) ||
+    distanceToBox(x, y, plate.width, plate.height) <
+      input.ringRadius + input.clearances.plateToRing - EPSILON
+  ) {
+    return null;
+  }
+
+  return {
+    item,
+    x,
+    y,
+    radial,
+    tangent,
+    contactRadius,
+    contact: [contactRadius * u[0], contactRadius * u[1]],
+    minX: x - plate.width / 2,
+    maxX: x + plate.width / 2,
+    minY: y - plate.height / 2,
+    maxY: y + plate.height / 2,
+  };
+}
+
+function isValidLayout(
+  clearances: LayoutClearances,
+  starts: readonly Point[],
+  layout: readonly Candidate[],
+): boolean {
+  for (let i = 0; i < layout.length; i += 1) {
+    for (let j = i + 1; j < layout.length; j += 1) {
+      if (hasConflict(clearances, starts, at(layout, i), at(layout, j))) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+// Quality is lexicographic and smaller is better: compactness first (max,
+// then total, connector-contact radius), then how far a plate strayed
+// tangentially from its ideal radial anchor (max, then total).
+type Quality = readonly [number, number, number, number];
+
+function quality(plates: readonly Candidate[]): Quality {
+  const contacts = plates.map((plate) => plate.contactRadius);
+  const shifts = plates.map((plate) => Math.abs(plate.tangent));
+  return [
+    Math.max(...contacts),
+    contacts.reduce((sum, value) => sum + value, 0),
+    Math.max(...shifts),
+    shifts.reduce((sum, value) => sum + value, 0),
+  ];
+}
+
+/**
+Whether `next` is a real improvement over `previous`, each rounded to 3 decimals to ignore float noise.
+*/
+function isBetter(next: Quality, previous: Quality): boolean {
+  for (const [index, element] of next.entries()) {
+    const difference =
+      Math.round(element * 1000) - Math.round(at(previous, index) * 1000);
+    if (difference !== 0) {
+      return difference < 0;
+    }
+  }
+
+  return false;
+}
+
+/**
+ Step 1: every plate at the same shared contact radius, tangent 0, scanned
+ one pixel at a time outward from the ring. The fastest layout that is
+ correct whenever any layout exists at all.
+ */
+function solveSharedRadius(
+  input: LayoutInput,
+  prepared: PreparedInput,
+): readonly Candidate[] | null {
+  const first = Math.ceil(input.ringRadius + input.clearances.plateToRing);
+  // Any configuration the model's minimum angular gap allows can be made
+  // conflict-free by a radius this large: every plate's own diagonal is
+  // enough slack to clear both the ring and every other plate.
+  const cap =
+    first +
+    input.plates.reduce(
+      (sum, plate) => sum + Math.hypot(plate.width, plate.height),
+      0,
+    );
+  for (let contact = first; contact <= cap; contact += 1) {
+    const plates = input.plates.map((plate, item) =>
+      makeCandidate(input, prepared, item, {
+        radial: contact + halfDistance(plate),
+        tangent: 0,
+      }),
+    );
+    if (
+      plates.every((plate) => plate !== null) &&
+      isValidLayout(input.clearances, prepared.starts, plates)
+    ) {
+      return plates;
+    }
+  }
+
+  return null;
+}
+
+// Steps 2-4: repeatedly nudge each plate inward (radial) or sideways
+// (tangent), inside its association sector. Keep a move only when the
+// whole layout stays valid and its quality improves. Step size shrinks
+// once a full pass finds no more improving move at the current size.
+const STEP_SIZES = [16, 8, 4, 2, 1];
+
+type Move = {
+  readonly plates: readonly Candidate[];
+  readonly quality: Quality;
+};
+
+/**
+Try nudging plate `item` inward or sideways by `step`; the best resulting layout that improves on `best`, or `null`.
+*/
+function bestMoveFor(
+  input: LayoutInput,
+  prepared: PreparedInput,
+  plates: readonly Candidate[],
+  item: number,
+  step: number,
+  best: Quality,
+): Move | null {
+  const plate = at(plates, item);
+  const offsets = [
+    { radial: plate.radial - step, tangent: plate.tangent },
+    { radial: plate.radial, tangent: plate.tangent + step },
+    { radial: plate.radial, tangent: plate.tangent - step },
+  ];
+  let found: Move | null = null;
+  for (const offset of offsets) {
+    const candidate = makeCandidate(input, prepared, item, offset);
+    if (candidate === null) {
+      continue;
+    }
+
+    const attempt = plates.map((current, index) =>
+      index === item ? candidate : current,
+    );
+    if (!isValidLayout(input.clearances, prepared.starts, attempt)) {
+      continue;
+    }
+
+    const attemptQuality = quality(attempt);
+    if (isBetter(attemptQuality, found?.quality ?? best)) {
+      found = { plates: attempt, quality: attemptQuality };
+    }
+  }
+
+  return found;
+}
+
+function compact(
+  input: LayoutInput,
+  prepared: PreparedInput,
+  seed: readonly Candidate[],
+): readonly Candidate[] {
+  let plates = seed;
+  let best = quality(plates);
+  for (const step of STEP_SIZES) {
+    let isImproved = true;
+    while (isImproved) {
+      isImproved = false;
+      for (const item of plates.keys()) {
+        const found = bestMoveFor(input, prepared, plates, item, step, best);
+        if (found !== null) {
+          plates = found.plates;
+          best = found.quality;
+          isImproved = true;
+        }
+      }
+    }
+  }
+
+  return plates;
+}
+
+/**
+ Place every label plate compact, clear of the ring and other plates, and
+ inside its item's fixed direction: a shared-radius layout, then
+ deterministic greedy compaction. The same input always produces the same
+ output. Called once per menu creation; see `createMenu`.
+ */
+export function solveLabelLayout(input: LayoutInput): LayoutResult {
+  const prepared = prepareInput(input);
+  const baseline = solveSharedRadius(input, prepared);
+  if (baseline === null) {
+    return { oversized: true, plates: [] };
+  }
+
+  const plates = compact(input, prepared, baseline);
+  return {
+    oversized: false,
+    plates: plates.map((plate) => ({
+      x: plate.x,
+      y: plate.y,
+      connectorContact: plate.contact,
+    })),
+  };
+}

--- a/src/layout/menu.css
+++ b/src/layout/menu.css
@@ -25,6 +25,14 @@
   --line-color: var(--item-background);
   --active-line-color: var(--active-item-background);
 
+  /* Minimum gaps the label-layout solver keeps: between two plates
+     (horizontal/vertical), between a plate and the ring, and between a
+     connector line and a plate it doesn't belong to. */
+  --item-horizontal-gap: 14px;
+  --item-vertical-gap: 7px;
+  --item-ring-gap: 12px;
+  --item-connector-gap: 3px;
+
   /* The two following variables must be set from JS. */
   --center-x: 0px;
   --center-y: 0px;
@@ -87,6 +95,25 @@
   height: var(--line-thickness);
   transform-origin: center left;
   transform: rotate(var(--angle));
+}
+
+/* Once the label-layout solver finds a conflict-free arrangement, `--x`,
+   `--y`, and `--contact-radius` (set from JS, in the same pixel coordinates
+   as `--center-x`/`--center-y`: right and down positive) replace the fixed
+   shared radius above. `.marking-menu` gets `.solved` only when the solver
+   didn't report the menu as oversized: an oversized menu keeps rendering
+   every label at the fixed radius, unmodified, rather than with no layout
+   at all. */
+.marking-menu.solved .marking-menu-item .marking-menu-label {
+  left: calc(var(--x) - var(--item-box-width) / 2);
+  top: calc(var(--y) - var(--item-box-height) / 2);
+  bottom: auto;
+}
+
+.marking-menu.solved .marking-menu-item .marking-menu-line {
+  width: calc(
+    var(--contact-radius) + var(--item-radius) + var(--line-thickness)
+  );
 }
 
 .marking-menu-item.active {

--- a/src/layout/menu.test.ts
+++ b/src/layout/menu.test.ts
@@ -9,6 +9,65 @@ const createModel = (itemNb = 0): MenuLayoutModel => ({
   })),
 });
 
+// Evenly spread, so a solved layout has room to place every label without
+// forcing `oversized` at a realistic size.
+const createSpreadModel = (itemNb: number): MenuLayoutModel => ({
+  items: Array.from({ length: itemNb }, (_, i) => ({
+    label: `item-${i}-name`,
+    angle: (360 / itemNb) * i,
+    key: `item-${i}-key`,
+  })),
+});
+
+/**
+ JSDOM never lays elements out, so `offsetWidth`/`offsetHeight` are always
+ 0. Stub every element's to a fixed size for the duration of the block.
+ */
+const stubbedLabelSize = (width: number, height: number): Disposable => {
+  const widthSpy = vi
+    .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
+    .mockReturnValue(width);
+  const heightSpy = vi
+    .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+    .mockReturnValue(height);
+  return {
+    [Symbol.dispose]() {
+      widthSpy.mockRestore();
+      heightSpy.mockRestore();
+    },
+  };
+};
+
+/**
+ The label-layout solver's ring radius and clearances aren't set from any
+ stylesheet under test (`?inline` CSS imports resolve to an empty string
+ here). Set them as inline style on `parent` instead, which `main`
+ inherits, exactly as it would inherit them from a real stylesheet.
+ */
+const withSolverConfig = (
+  parent: HTMLElement,
+  overrides: Partial<{
+    menuRadius: number;
+    horizontalGap: number;
+    verticalGap: number;
+    ringGap: number;
+    connectorGap: number;
+  }> = {},
+): void => {
+  const {
+    menuRadius = 80,
+    horizontalGap = 14,
+    verticalGap = 7,
+    ringGap = 12,
+    connectorGap = 3,
+  } = overrides;
+  parent.style.setProperty('--menu-radius', `${menuRadius}px`);
+  parent.style.setProperty('--item-horizontal-gap', `${horizontalGap}px`);
+  parent.style.setProperty('--item-vertical-gap', `${verticalGap}px`);
+  parent.style.setProperty('--item-ring-gap', `${ringGap}px`);
+  parent.style.setProperty('--item-connector-gap', `${connectorGap}px`);
+};
+
 describe('createMenu', () => {
   it('renders', () => {
     const div = document.createElement('div');
@@ -162,5 +221,84 @@ describe('createMenu', () => {
     expect(() => {
       menu.setActive(model.items[0]?.key ?? null);
     }).not.toThrow();
+  });
+
+  it('solves a conflict-free layout once labels can be measured', () => {
+    using _size = stubbedLabelSize(80, 20);
+    const div = document.createElement('div');
+    withSolverConfig(div);
+    createMenu({
+      parent: div,
+      model: createSpreadModel(8),
+      center: [30, 50],
+      doc: document,
+    });
+
+    const main = div.querySelector('.marking-menu');
+    expect(main?.classList.contains('solved')).toBe(true);
+    const items = [...div.querySelectorAll<HTMLElement>('.marking-menu-item')];
+    expect(items).toHaveLength(8);
+    for (const item of items) {
+      expect(item.style.getPropertyValue('--x')).not.toBe('');
+      expect(item.style.getPropertyValue('--y')).not.toBe('');
+      expect(item.style.getPropertyValue('--contact-radius')).not.toBe('');
+    }
+  });
+
+  it('leaves the fallback rendering unmodified when the solver reports the menu as oversized', () => {
+    using _size = stubbedLabelSize(120, 20);
+    const div = document.createElement('div');
+    withSolverConfig(div);
+    createMenu({
+      parent: div,
+      // Two items a fraction of a degree apart: no shared radius, however
+      // large, separates them within the solver's deterministic work limit.
+      model: {
+        items: [
+          { label: 'item-0-name', angle: 0, key: 'item-0-key' },
+          { label: 'item-1-name', angle: 0.3, key: 'item-1-key' },
+        ],
+      },
+      center: [30, 50],
+      doc: document,
+    });
+
+    const main = div.querySelector('.marking-menu');
+    expect(main?.classList.contains('solved')).toBe(false);
+    const items = [...div.querySelectorAll<HTMLElement>('.marking-menu-item')];
+    for (const item of items) {
+      expect(item.style.getPropertyValue('--x')).toBe('');
+    }
+  });
+
+  it('reads the ring radius and clearances from the CSS custom properties in scope', () => {
+    using _size = stubbedLabelSize(80, 20);
+    const narrowRing = document.createElement('div');
+    withSolverConfig(narrowRing, { menuRadius: 80 });
+    createMenu({
+      parent: narrowRing,
+      model: createSpreadModel(8),
+      center: [30, 50],
+      doc: document,
+    });
+
+    const wideRing = document.createElement('div');
+    withSolverConfig(wideRing, { menuRadius: 200 });
+    createMenu({
+      parent: wideRing,
+      model: createSpreadModel(8),
+      center: [30, 50],
+      doc: document,
+    });
+
+    const contactRadius = (parent: HTMLElement): number =>
+      // Trailing "px" needs stripping; `Number` alone can't do that.
+      // eslint-disable-next-line unicorn/prefer-number-coercion -- see above.
+      Number.parseFloat(
+        parent
+          .querySelector<HTMLElement>('.marking-menu-item')
+          ?.style.getPropertyValue('--contact-radius') ?? '',
+      );
+    expect(contactRadius(wideRing)).toBeGreaterThan(contactRadius(narrowRing));
   });
 });

--- a/src/layout/menu.ts
+++ b/src/layout/menu.ts
@@ -1,4 +1,5 @@
-import { degreesToRadians, type Point } from '../utils.js';
+import { at, degreesToRadians, type Point } from '../utils.js';
+import { solveLabelLayout } from './label-layout.js';
 import menuStyles from './menu.css?inline';
 
 let hasInjectedStyles = false;
@@ -66,7 +67,10 @@ export type Menu = {
 // Items may be styled differently near a corner, so the connecting line meets
 // the label squarely. Which corner applies depends on the quadrant the item's
 // angle falls in, not on any exact angle: an axis-aligned angle (0, 90, 180,
-// 270) sits between two quadrants and gets no corner class.
+// 270) sits between two quadrants and gets no corner class. This stays keyed
+// on the angle alone, unaffected by the solved layout below: the connector
+// always approaches a plate along that same fixed direction, whatever
+// tangential offset the solver gave the plate.
 const CORNER_ITEM_CLASSES = [
   'bottom-right-item',
   'bottom-left-item',
@@ -120,6 +124,68 @@ const template = (
   return main;
 };
 
+function readPixels(style: CSSStyleDeclaration, property: string): number {
+  // `getPropertyValue` returns the raw declared value (e.g. "80px"); unlike
+  // `Number`, `parseFloat` strips that unit suffix instead of yielding NaN.
+  // eslint-disable-next-line unicorn/prefer-number-coercion -- see above.
+  return Number.parseFloat(style.getPropertyValue(property));
+}
+
+/**
+ Measure `main`'s rendered label boxes, solve their layout once, and apply
+ the result. If the solver reports the menu is oversized, leave `main` as
+ `template` built it: every label at the shared fixed radius `menu.css`
+ already renders unconditionally, still valid, just not conflict-free.
+ */
+function applySolvedLayout(
+  main: HTMLDivElement,
+  items: readonly MenuLayoutItem[],
+  doc: Document,
+): void {
+  const itemElements = [
+    ...main.querySelectorAll<HTMLElement>('.marking-menu-item'),
+  ];
+  const labelElements = itemElements.map((element) => {
+    const label = element.querySelector<HTMLElement>('.marking-menu-label');
+    if (label === null) {
+      throw new Error('Menu item element is missing its label.');
+    }
+
+    return label;
+  });
+  const plates = items.map((item, index) => ({
+    angle: item.angle,
+    width: at(labelElements, index).offsetWidth,
+    height: at(labelElements, index).offsetHeight,
+  }));
+
+  const style = (doc.defaultView ?? globalThis).getComputedStyle(main);
+  const result = solveLabelLayout({
+    plates,
+    ringRadius: readPixels(style, '--menu-radius'),
+    clearances: {
+      plateHorizontal: readPixels(style, '--item-horizontal-gap'),
+      plateVertical: readPixels(style, '--item-vertical-gap'),
+      plateToRing: readPixels(style, '--item-ring-gap'),
+      plateToConnector: readPixels(style, '--item-connector-gap'),
+    },
+  });
+  if (result.oversized) {
+    return;
+  }
+
+  main.classList.add('solved');
+  for (const [index, element] of itemElements.entries()) {
+    const plate = at(result.plates, index);
+    element.style.setProperty('--x', `${plate.x}px`);
+    element.style.setProperty('--y', `${plate.y}px`);
+    element.style.setProperty(
+      '--contact-radius',
+      `${Math.hypot(...plate.connectorContact)}px`,
+    );
+  }
+}
+
 /**
  Create the Menu display.
 
@@ -147,7 +213,12 @@ export function createMenu({
 
   // Create the DOM.
   const main = template({ items: model.items, center }, doc);
+  // Attach before measuring: a detached element's `offsetWidth`/`offsetHeight`
+  // are always 0. Everything from here through `applySolvedLayout` runs
+  // synchronously in this one call, so the unsolved layout is never
+  // painted: a browser only paints between tasks, never mid-function.
   parent.append(main);
+  applySolvedLayout(main, model.items, doc);
 
   // Clear any  active items.
   const clearActiveItems = () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -90,6 +90,22 @@ export const angle = (
 };
 
 /**
+ Read `array[index]`, trusting the caller that `index` is in range.
+
+ `noUncheckedIndexedAccess` types every array access as possibly
+ `undefined`; use this at a call site where that index is already known
+ valid by construction (a modulo-wrapped cyclic index, or one array indexed
+ by another built from it) instead of a non-null assertion.
+
+ @param array - The array to read from.
+ @param index - An index already known to be within `array`'s bounds.
+ @returns The element at `index`.
+ */
+export function at<T>(array: readonly T[], index: number): T {
+  return array[index] as T;
+}
+
+/**
  Find the entry of `list` ranked highest by `comp`.
 
  @param list - A list of items.


### PR DESCRIPTION
Every label in the wedge-ring menu sat at one fixed shared radius, computed directly in CSS trig, against an unmeasured 120x20 pixel box. Nothing checked whether two labels collided, whether a label crossed into the protected ring, or whether a label's box happened to cover a neighboring item's connector line. Issue #267 asked for a small, deterministic geometry module that measures the real rendered labels and places them without those conflicts, staying compact as a menu grows past eight items.

A first attempt at this (#288) chose adaptive global candidate search and landed at 886 solver lines plus a 275-line runtime validator; it was rejected as too much code for the problem. A follow-up experiment on the `prototype/label-solver` branch compared that search against a much smaller alternative across four, eight, twelve, and sixteen item menus, and found the smaller algorithm matched or beat it on both association and overall appearance in nearly every case.

This change implements that smaller algorithm. `solveLabelLayout` first scans outward from the ring in one-pixel steps for the smallest shared radius at which every label clears the ring, every pair of labels clears each other, and no label's box crosses a neighboring connector. It then runs deterministic greedy compaction on top of that: at shrinking step sizes, it tries moving each label inward along its own direction or sideways within the angular sector it's allowed to occupy, keeping a move only when the whole layout stays valid and its quality (compactness, then closeness to its ideal direction) improves. If no shared radius exists at all, it reports an explicit oversized result rather than ever returning invalid geometry. `createMenu` measures each label's real rendered box right after attaching it to the document, solves once, and applies the result through new `--x`, `--y`, and `--contact-radius` custom properties; a menu whose labels can't fit at any radius keeps rendering at the old fixed radius instead of throwing.

To verify by hand, run the demo playground (`yarn demo:dev`, open `/playground/`, switch to the Layout tab) with a mix of short and long item labels and check that the rendered plates never overlap or cross a neighbor's connector line.

The solver is checked against a representative corpus (evenly spaced, uniform, alternating, and asymmetric widths; clustered and boundary-crossing angles; a deliberately oversized case) through an independent validator that re-derives every hard constraint from scratch rather than reusing the solver's own bookkeeping, plus determinism tests and a benchmark. The benchmark measures under 1 millisecond at the 95th percentile for today's real eight-item maximum, well inside the roughly 50 millisecond budget the issue set, so the solver stays synchronous with no worker or asynchronous menu lifecycle.

Closes #267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)