### PR TITLE
test: Cover valid uneven item directions

### DIFF
--- a/src/layout/__fixtures__/label-layout-corpus.ts
+++ b/src/layout/__fixtures__/label-layout-corpus.ts
@@ -92,6 +92,22 @@ export const clusteredAngles: LayoutInput = {
   clearances: DEFAULT_CLEARANCES,
 };
 
+// Valid manual angles create both the narrowest and widest wedge sectors.
+export const unevenSpacing: LayoutInput = {
+  plates: [
+    { angle: 0, label: 'Right' },
+    { angle: 45, label: 'Down-right' },
+    { angle: 90, label: 'Down' },
+    { angle: 270, label: 'Up' },
+  ].map(({ label, angle }) => ({
+    angle,
+    height: 20,
+    width: 24 + label.length * 8,
+  })),
+  ringRadius: DEFAULT_RING_RADIUS,
+  clearances: DEFAULT_CLEARANCES,
+};
+
 // Items on both sides of the 0/360 degree wrap.
 export const boundaryCrossing: LayoutInput = {
   plates: [350, 10, 90, 180, 270].map((angle) => ({
@@ -135,6 +151,7 @@ export const corpus: Record<string, LayoutInput> = {
   oneExtremeWidth,
   asymmetricWidths,
   clusteredAngles,
+  unevenSpacing,
   boundaryCrossing,
   default8ItemMenu,
 };

--- a/src/layout/__fixtures__/label-layout-corpus.ts
+++ b/src/layout/__fixtures__/label-layout-corpus.ts
@@ -12,6 +12,12 @@ const DEFAULT_CLEARANCES = {
   plateToConnector: 3,
 };
 
+const contentSizedPlate = (label: string, angle: number) => ({
+  angle,
+  height: 20,
+  width: 24 + label.length * 8,
+});
+
 function evenlySpaced(
   count: number,
   width: number,
@@ -99,11 +105,23 @@ export const unevenSpacing: LayoutInput = {
     { angle: 45, label: 'Down-right' },
     { angle: 90, label: 'Down' },
     { angle: 270, label: 'Up' },
-  ].map(({ label, angle }) => ({
-    angle,
-    height: 20,
-    width: 24 + label.length * 8,
-  })),
+  ].map(({ label, angle }) => contentSizedPlate(label, angle)),
+  ringRadius: DEFAULT_RING_RADIUS,
+  clearances: DEFAULT_CLEARANCES,
+};
+
+// The canvas's 20-degree pairs bypass model validation to stress layout alone.
+export const twentyDegreePairs: LayoutInput = {
+  plates: [
+    { angle: 0, label: 'Right' },
+    { angle: 20, label: 'Down-Right' },
+    { angle: 90, label: 'Others...' },
+    { angle: 160, label: 'Down-Left' },
+    { angle: 180, label: 'Left' },
+    { angle: 200, label: 'Up-Left' },
+    { angle: 270, label: 'Up' },
+    { angle: 340, label: 'Up-Right' },
+  ].map(({ label, angle }) => contentSizedPlate(label, angle)),
   ringRadius: DEFAULT_RING_RADIUS,
   clearances: DEFAULT_CLEARANCES,
 };
@@ -131,11 +149,7 @@ export const default8ItemMenu: LayoutInput = {
     'Print',
     'Share',
     'Recent documents',
-  ].map((label, index) => ({
-    angle: 45 * index,
-    width: 24 + label.length * 8,
-    height: 20,
-  })),
+  ].map((label, index) => contentSizedPlate(label, 45 * index)),
   ringRadius: DEFAULT_RING_RADIUS,
   clearances: DEFAULT_CLEARANCES,
 };
@@ -152,6 +166,7 @@ export const corpus: Record<string, LayoutInput> = {
   asymmetricWidths,
   clusteredAngles,
   unevenSpacing,
+  twentyDegreePairs,
   boundaryCrossing,
   default8ItemMenu,
 };

--- a/src/layout/__fixtures__/label-layout-corpus.ts
+++ b/src/layout/__fixtures__/label-layout-corpus.ts
@@ -12,11 +12,14 @@ const DEFAULT_CLEARANCES = {
   plateToConnector: 3,
 };
 
-const contentSizedPlate = (label: string, angle: number) => ({
-  angle,
-  height: 20,
-  width: 24 + label.length * 8,
-});
+const contentSizedPlates = (
+  items: ReadonlyArray<{ readonly angle: number; readonly label: string }>,
+) =>
+  items.map(({ angle, label }) => ({
+    angle,
+    height: 20,
+    width: 24 + label.length * 8,
+  }));
 
 function evenlySpaced(
   count: number,
@@ -100,12 +103,12 @@ export const clusteredAngles: LayoutInput = {
 
 // Valid manual angles create both the narrowest and widest wedge sectors.
 export const unevenSpacing: LayoutInput = {
-  plates: [
+  plates: contentSizedPlates([
     { angle: 0, label: 'Right' },
     { angle: 45, label: 'Down-right' },
     { angle: 90, label: 'Down' },
     { angle: 270, label: 'Up' },
-  ].map(({ label, angle }) => contentSizedPlate(label, angle)),
+  ]),
   ringRadius: DEFAULT_RING_RADIUS,
   clearances: DEFAULT_CLEARANCES,
 };
@@ -113,15 +116,15 @@ export const unevenSpacing: LayoutInput = {
 // The canvas's 20-degree pairs bypass model validation to stress layout alone.
 export const twentyDegreePairs: LayoutInput = {
   plates: [
-    { angle: 0, label: 'Right' },
-    { angle: 20, label: 'Down-Right' },
-    { angle: 90, label: 'Others...' },
-    { angle: 160, label: 'Down-Left' },
-    { angle: 180, label: 'Left' },
-    { angle: 200, label: 'Up-Left' },
-    { angle: 270, label: 'Up' },
-    { angle: 340, label: 'Up-Right' },
-  ].map(({ label, angle }) => contentSizedPlate(label, angle)),
+    { angle: 0, height: 20, width: 64 },
+    { angle: 20, height: 20, width: 104 },
+    { angle: 90, height: 20, width: 96 },
+    { angle: 160, height: 20, width: 96 },
+    { angle: 180, height: 20, width: 56 },
+    { angle: 200, height: 20, width: 80 },
+    { angle: 270, height: 20, width: 40 },
+    { angle: 340, height: 20, width: 88 },
+  ],
   ringRadius: DEFAULT_RING_RADIUS,
   clearances: DEFAULT_CLEARANCES,
 };
@@ -140,16 +143,18 @@ export const boundaryCrossing: LayoutInput = {
 // The exact production defaults at today's real maximum item count, with
 // realistic varied label widths: the benchmark case.
 export const default8ItemMenu: LayoutInput = {
-  plates: [
-    'Open',
-    'Save a copy',
-    'Close',
-    'Preferences',
-    'Export as PDF',
-    'Print',
-    'Share',
-    'Recent documents',
-  ].map((label, index) => contentSizedPlate(label, 45 * index)),
+  plates: contentSizedPlates(
+    [
+      'Open',
+      'Save a copy',
+      'Close',
+      'Preferences',
+      'Export as PDF',
+      'Print',
+      'Share',
+      'Recent documents',
+    ].map((label, index) => ({ angle: 45 * index, label })),
+  ),
   ringRadius: DEFAULT_RING_RADIUS,
   clearances: DEFAULT_CLEARANCES,
 };

--- a/src/layout/label-layout.test.ts
+++ b/src/layout/label-layout.test.ts
@@ -74,4 +74,13 @@ describe('solveLabelLayout', () => {
       Math.max(...contacts) * input.plates.length,
     );
   });
+
+  it('keeps the canvas 20-degree pairs close to the ring', () => {
+    const result = solveLabelLayout(corpusFixtures.twentyDegreePairs);
+    expect(result.oversized).toBe(false);
+    const contacts = result.plates.map((plate) =>
+      Math.hypot(...plate.connectorContact),
+    );
+    expect(Math.max(...contacts) - Math.min(...contacts)).toBeLessThan(4);
+  });
 });

--- a/src/layout/label-layout.test.ts
+++ b/src/layout/label-layout.test.ts
@@ -3,6 +3,9 @@ import { oversized } from './__fixtures__/label-layout-corpus.js';
 import { validateLabelLayout } from './__fixtures__/label-layout-validator.js';
 import { solveLabelLayout, type LayoutInput } from './label-layout.js';
 
+const contactRadii = (result: ReturnType<typeof solveLabelLayout>) =>
+  result.plates.map((plate) => Math.hypot(...plate.connectorContact));
+
 describe('solveLabelLayout', () => {
   describe.each(Object.entries(corpusFixtures.corpus))('%s', (_name, input) => {
     it('produces a layout that satisfies every hard constraint', () => {
@@ -66,9 +69,18 @@ describe('solveLabelLayout', () => {
     const input = corpusFixtures.oneExtremeWidth;
     const result = solveLabelLayout(input);
     expect(result.oversized).toBe(false);
-    const contacts = result.plates.map((plate) =>
-      Math.hypot(...plate.connectorContact),
+    const contacts = contactRadii(result);
+    const totalContact = contacts.reduce((sum, value) => sum + value, 0);
+    expect(totalContact).toBeLessThan(
+      Math.max(...contacts) * input.plates.length,
     );
+  });
+
+  it('compacts valid uneven spacing instead of moving every plate outward', () => {
+    const input = corpusFixtures.unevenSpacing;
+    const result = solveLabelLayout(input);
+    expect(result.oversized).toBe(false);
+    const contacts = contactRadii(result);
     const totalContact = contacts.reduce((sum, value) => sum + value, 0);
     expect(totalContact).toBeLessThan(
       Math.max(...contacts) * input.plates.length,
@@ -78,9 +90,7 @@ describe('solveLabelLayout', () => {
   it('keeps the canvas 20-degree pairs close to the ring', () => {
     const result = solveLabelLayout(corpusFixtures.twentyDegreePairs);
     expect(result.oversized).toBe(false);
-    const contacts = result.plates.map((plate) =>
-      Math.hypot(...plate.connectorContact),
-    );
+    const contacts = contactRadii(result);
     expect(Math.max(...contacts) - Math.min(...contacts)).toBeLessThan(4);
   });
 });

--- a/src/model.test.ts
+++ b/src/model.test.ts
@@ -89,6 +89,16 @@ describe('createModel', () => {
     );
   });
 
+  it('accepts valid uneven item directions', () => {
+    const menu = createModel({
+      items: [0, 45, 90, 270].map((angle) => ({
+        angle,
+        label: `Item ${angle}`,
+      })),
+    });
+    expect(menu.items.map((item) => item.angle)).toEqual([0, 45, 90, 270]);
+  });
+
   it('names a crowded nested level and its spacing', () => {
     expect(() =>
       createModel({

--- a/src/model.test.ts
+++ b/src/model.test.ts
@@ -99,6 +99,17 @@ describe('createModel', () => {
     expect(menu.items.map((item) => item.angle)).toEqual([0, 45, 90, 270]);
   });
 
+  it('rejects the canvas manual directions before layout', () => {
+    expect(() =>
+      createModel({
+        items: [0, 20, 90, 160, 180, 200, 270, 340].map((angle) => ({
+          angle,
+          label: `Item ${angle}`,
+        })),
+      }),
+    ).toThrow(/20 degrees between items.*recognizer needs at least 45/v);
+  });
+
   it('names a crowded nested level and its spacing', () => {
     expect(() =>
       createModel({


### PR DESCRIPTION
## Scope

Covers valid uneven item directions and the canvas's invalid 20-degree stress case. It does not implement wedge rendering.

The model rejects the canvas input before rendering because #273 sets a 45-degree recognizer floor. The solver still validates that input directly, keeping connector contact radii within 4px. [The issue findings](https://github.com/QuentinRoy/Marking-Menu/issues/271#issuecomment-5624339389) cover the wedge, bisection, label, anchoring, and limit decisions.

The tests accept a 45-degree minimum gap, check that uneven labels compact instead of using a uniform radius, reject the canvas configuration at model construction, and exercise its pairs in the label solver with fixed plate widths.

Verified with `yarn test`, `yarn typecheck`, `yarn lint`, `yarn format:check`, and `yarn build`.

Closes #271
