### PR TITLE
Minify the library build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,7 +52,7 @@ export default defineConfig({
       fileName: 'index',
       formats: ['es'],
     },
-    minify: false,
+    minify: true,
     rolldownOptions: {
       output: { banner },
     },


### PR DESCRIPTION
Marking Menu currently ships an unminified ESM library bundle, making the published package larger than necessary.

Enable Vite’s standard minifier for the library build. This optimizes the code while retaining the ESM output behavior required by downstream bundlers.

Verified with `yarn build`.