### PR TITLE
test: Isolate layout test fixtures

### DIFF
--- a/src/layout/__fixtures__/label-layout-corpus.ts
+++ b/src/layout/__fixtures__/label-layout-corpus.ts
@@ -1,4 +1,4 @@
-import type { LayoutInput } from './label-layout.js';
+import type { LayoutInput } from '../label-layout.js';
 
 // Named fixtures shared by the correctness and performance test files, kept
 // out of the published bundle (nothing under `src/index.ts` imports this

--- a/src/layout/__fixtures__/label-layout-validator.ts
+++ b/src/layout/__fixtures__/label-layout-validator.ts
@@ -1,10 +1,9 @@
-import { at, type Point } from '../utils.js';
-import type { LayoutInput, LayoutResult } from './label-layout.js';
+import { at, type Point } from '../../utils.js';
+import type { LayoutInput, LayoutResult } from '../label-layout.js';
 
 // Re-derives every hard constraint from scratch, independent of the
 // solver's own bookkeeping, so "never return invalid geometry" is a
-// checked guarantee rather than a hope. Test support only: not shipped
-// with the production module.
+// checked guarantee rather than a hope.
 
 const EPSILON = 1e-7;
 

--- a/src/layout/label-layout-validator.test.ts
+++ b/src/layout/label-layout-validator.test.ts
@@ -1,4 +1,4 @@
-import { validateLabelLayout } from './label-layout-validator.js';
+import { validateLabelLayout } from './__fixtures__/label-layout-validator.js';
 import type { LayoutInput, LayoutResult } from './label-layout.js';
 
 const clearances = {

--- a/src/layout/label-layout.perf.test.ts
+++ b/src/layout/label-layout.perf.test.ts
@@ -1,5 +1,5 @@
 import { at } from '../utils.js';
-import { default8ItemMenu } from './label-layout-corpus.js';
+import { default8ItemMenu } from './__fixtures__/label-layout-corpus.js';
 import { solveLabelLayout } from './label-layout.js';
 
 // Solver-only timing evidence for the issue's ~50ms P95 production gate, at

--- a/src/layout/label-layout.test.ts
+++ b/src/layout/label-layout.test.ts
@@ -1,5 +1,5 @@
-import * as corpusFixtures from './label-layout-corpus.js';
-import { oversized } from './label-layout-corpus.js';
+import * as corpusFixtures from './__fixtures__/label-layout-corpus.js';
+import { oversized } from './__fixtures__/label-layout-corpus.js';
 import { validateLabelLayout } from './label-layout-validator.js';
 import { solveLabelLayout, type LayoutInput } from './label-layout.js';
 

--- a/src/layout/label-layout.test.ts
+++ b/src/layout/label-layout.test.ts
@@ -1,6 +1,6 @@
 import * as corpusFixtures from './__fixtures__/label-layout-corpus.js';
 import { oversized } from './__fixtures__/label-layout-corpus.js';
-import { validateLabelLayout } from './label-layout-validator.js';
+import { validateLabelLayout } from './__fixtures__/label-layout-validator.js';
 import { solveLabelLayout, type LayoutInput } from './label-layout.js';
 
 describe('solveLabelLayout', () => {


### PR DESCRIPTION
Moves the label-layout corpus and independent validator into `src/layout/__fixtures__/`.

The modules serve tests and a benchmark only. The source-tree audit found no other test-support modules outside fixture directories.

Verified with `yarn test`, `yarn typecheck`, `yarn lint`, `yarn format:check`, and `yarn build`.
