### PR TITLE
Remove angles test dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "@vitejs/plugin-react": "^6.1.1",
     "@vitest/coverage-v8": "^5.0.0",
     "@vitest/eslint-plugin": "^1.6.27",
-    "angles": "^0.5.1",
     "class-variance-authority": "^0.7.1",
     "cn": "^0.2.5",
     "codemirror-json-schema": "^0.8.1",

--- a/src/recognizer/recognize-mm-stroke.test.ts
+++ b/src/recognizer/recognize-mm-stroke.test.ts
@@ -1,11 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { promisify } from 'node:util';
-import angles from 'angles';
 import { parse as csvParseCallback } from 'csv-parse';
 import { type Mock } from 'vitest';
 import type { ModelItem } from '../types.js';
-import type { Point } from '../utils.js';
+import { deltaAngle, type Point } from '../utils.js';
 import {
   analyzeMarkingMenuStroke,
   divideLongestSegment,
@@ -271,7 +270,7 @@ describe('recognizeMarkingMenuStroke', () => {
       );
       // Make sure the angle is close to the expected stroke angle (mock model dynamically)
       expect(
-        angles.distance(selection?.requestedAngle ?? NaN, strokeAngle) <
+        Math.abs(deltaAngle(selection?.requestedAngle ?? NaN, strokeAngle)) <
           precision,
       ).toBe(true);
     };
@@ -304,19 +303,21 @@ describe('recognizeMarkingMenuStroke', () => {
       );
       // Make sure the angle is close to the expected stroke angle (mock model dynamically).
       expect(
-        angles.distance(selection?.requestedAngle ?? NaN, strokeAngles[2]) <
-          precision,
-      ).toBe(true);
-      expect(
-        angles.distance(
-          selection?.parent?.requestedAngle ?? NaN,
-          strokeAngles[1],
+        Math.abs(
+          deltaAngle(selection?.requestedAngle ?? NaN, strokeAngles[2]),
         ) < precision,
       ).toBe(true);
       expect(
-        angles.distance(
-          selection?.parent?.parent?.requestedAngle ?? NaN,
-          strokeAngles[0],
+        Math.abs(
+          deltaAngle(selection?.parent?.requestedAngle ?? NaN, strokeAngles[1]),
+        ) < precision,
+      ).toBe(true);
+      expect(
+        Math.abs(
+          deltaAngle(
+            selection?.parent?.parent?.requestedAngle ?? NaN,
+            strokeAngles[0],
+          ),
         ) < precision,
       ).toBe(true);
       expect(selection?.parent?.parent?.parent).toBe(model);
@@ -377,11 +378,11 @@ describe('recognizeMarkingMenuStroke', () => {
     });
     // The selection is the depth 2 menu: it is returned as is by requireMenu.
     expect(selection?.isLeaf).toBe(false);
-    expect(angles.distance(selection?.requestedAngle ?? NaN, 90) < 15).toBe(
-      true,
-    );
     expect(
-      angles.distance(selection?.parent?.requestedAngle ?? NaN, 90) < 15,
+      Math.abs(deltaAngle(selection?.requestedAngle ?? NaN, 90)) < 15,
+    ).toBe(true);
+    expect(
+      Math.abs(deltaAngle(selection?.parent?.requestedAngle ?? NaN, 90)) < 15,
     ).toBe(true);
     expect(selection?.parent?.parent).toBe(model);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4045,13 +4045,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"angles@npm:^0.5.1":
-  version: 0.5.1
-  resolution: "angles@npm:0.5.1"
-  checksum: 10c0/021387936d00281440b93845842641423517e05eed2ebec66458b85fb4f80730ad3565aea8c6b821666bf97da3b83087f5fb7814f85b8ddf8b6b1cbcd4981d92
-  languageName: node
-  linkType: hard
-
 "ansi-escapes@npm:^7.0.0":
   version: 7.3.0
   resolution: "ansi-escapes@npm:7.3.0"
@@ -6530,7 +6523,6 @@ __metadata:
     "@vitejs/plugin-react": "npm:^6.1.1"
     "@vitest/coverage-v8": "npm:^5.0.0"
     "@vitest/eslint-plugin": "npm:^1.6.27"
-    angles: "npm:^0.5.1"
     class-variance-authority: "npm:^0.7.1"
     cn: "npm:^0.2.5"
     codemirror-json-schema: "npm:^0.8.1"


### PR DESCRIPTION
`angles` was used only to compare expected and recognized directions in the stroke tests. The package has a small maintenance footprint and is not needed by the published library.

The tests now use the existing `deltaAngle` helper and take its absolute value, preserving comparisons across the 0°/360° boundary. The change removes `angles` from the manifest and lockfile.

Verify with:

```sh
yarn test
yarn typecheck
yarn lint
```