### PR TITLE
Isolate menu theming in a shadow root

### DIFF
--- a/.changeset/shadow-root-theming.md
+++ b/.changeset/shadow-root-theming.md
@@ -1,0 +1,8 @@
+---
+'marking-menu': major
+---
+
+Render menus in an open shadow root on the existing `.marking-menu` wrapper.
+Page-level legacy class selectors no longer reach the menu. Replace the label and
+connector theme properties with the `--mm-*` names, and style repeated menu
+boxes through the `plate`, `label`, and `connector` parts.

--- a/e2e/tests/dispatch-ordering.spec.ts
+++ b/e2e/tests/dispatch-ordering.spec.ts
@@ -62,8 +62,10 @@ test('commit → render → dispatch ordering: a listener observes the complete 
     // `open`: the menu's DOM must already carry every item by the time the
     // listener runs, not an empty or partially built menu.
     mm.on('open', (event) => {
+      const menuRoot = element.querySelector('.marking-menu')?.shadowRoot;
       observations.push({
-        domItemCount: element.querySelectorAll('.marking-menu-item').length,
+        domItemCount:
+          menuRoot?.querySelectorAll('.marking-menu-item').length ?? 0,
         eventItemCount: event.menu.items.length,
         type: 'open',
       });
@@ -74,7 +76,9 @@ test('commit → render → dispatch ordering: a listener observes the complete 
     // per-level `key`, not the consumer-supplied `id`, hence comparing
     // against `event.active.key`.
     mm.on('change', (event) => {
-      const activeElement = element.querySelector('.marking-menu-item.active');
+      const activeElement = element
+        .querySelector('.marking-menu')
+        ?.shadowRoot?.querySelector('.marking-menu-item.active');
       observations.push({
         domActiveId:
           activeElement instanceof HTMLElement

--- a/src/engine/controller.test.ts
+++ b/src/engine/controller.test.ts
@@ -44,6 +44,13 @@ const items = [
 const voidMock = <Arguments extends readonly unknown[]>() =>
   vi.fn<(...args: Arguments) => void>();
 
+const activeMenuItems = (parent: HTMLElement): HTMLElement[] => [
+  ...(parent
+    .querySelector<HTMLElement>('.marking-menu')
+    ?.shadowRoot?.querySelectorAll<HTMLElement>('.marking-menu-item.active') ??
+    []),
+];
+
 describe('createController', () => {
   it('dispatches select carrying the leaf a straight drag recognizes', () => {
     using _canvases = stubbedCanvasContexts();
@@ -836,9 +843,7 @@ describe('createController', () => {
     expect(moved).toHaveBeenCalledTimes(1);
     expect(moved.mock.calls[0]?.[0].active).toBeNull();
     expect(changed).not.toHaveBeenCalled();
-    expect(parent.querySelectorAll('.marking-menu-item.active')).toHaveLength(
-      0,
-    );
+    expect(activeMenuItems(parent)).toHaveLength(0);
 
     controller.dispose();
   });
@@ -883,19 +888,17 @@ describe('createController', () => {
 
     // The menu DOM is patched in place, not recreated.
     expect(parent.querySelector('.marking-menu')).toBe(menuBefore);
-    const activeItems = parent.querySelectorAll('.marking-menu-item.active');
+    const activeItems = activeMenuItems(parent);
     expect(activeItems).toHaveLength(1);
     // "right" is the first described item, so its library-assigned key is
-    // "0" — `dataset.itemId` is keyed on that, not on the caller's own `id`.
+    // "0", `dataset.itemId` is keyed on that, not on the caller's own `id`.
     expect((activeItems[0] as HTMLElement).dataset.itemId).toBe('0');
 
     // Continued pointing at the same item: another `move`, no further `change`.
     parent.dispatchEvent(pointer('pointermove', { clientX: 110, clientY: 0 }));
     expect(moved).toHaveBeenCalledTimes(2);
     expect(changed).toHaveBeenCalledTimes(1);
-    expect(parent.querySelectorAll('.marking-menu-item.active')).toHaveLength(
-      1,
-    );
+    expect(activeMenuItems(parent)).toHaveLength(1);
 
     controller.dispose();
   });

--- a/src/engine/renderer.test.ts
+++ b/src/engine/renderer.test.ts
@@ -61,6 +61,12 @@ const createStackingRenderer = (parent: HTMLElement) =>
     gestureFeedbackStrokeWidth: feedbackStrokeWidth,
   });
 
+const menuItems = (parent: HTMLElement): HTMLElement[] => [
+  ...(parent
+    .querySelector<HTMLElement>('.marking-menu')
+    ?.shadowRoot?.querySelectorAll<HTMLElement>('.marking-menu-item') ?? []),
+];
+
 /**
  A parent placed away from the viewport's top-left, which is what tells a
  stroke drawn in client coordinates apart from one drawn in the parent's.
@@ -148,7 +154,8 @@ describe('createRenderer', () => {
     const parent = document.createElement('div');
     const renderer = createRenderer<typeof model>({ parent });
     const activeCount = () =>
-      parent.querySelectorAll('.marking-menu-item.active').length;
+      menuItems(parent).filter((item) => item.classList.contains('active'))
+        .length;
 
     renderer.render({
       cursor: 'none',
@@ -157,9 +164,9 @@ describe('createRenderer', () => {
       lowerStroke: null,
     });
     expect(activeCount()).toBe(1);
-    expect(parent.querySelector('[data-item-id="0"]')?.classList).toContain(
-      'active',
-    );
+    expect(
+      menuItems(parent).find((item) => item.dataset.itemId === '0')?.classList,
+    ).toContain('active');
 
     // Same activeKey, same menu identity: the skip branch.
     renderer.render({
@@ -178,9 +185,9 @@ describe('createRenderer', () => {
       lowerStroke: null,
     });
     expect(activeCount()).toBe(1);
-    expect(parent.querySelector('[data-item-id="1"]')?.classList).toContain(
-      'active',
-    );
+    expect(
+      menuItems(parent).find((item) => item.dataset.itemId === '1')?.classList,
+    ).toContain('active');
 
     renderer.dispose();
   });

--- a/src/layout/__snapshots__/menu.test.ts.snap
+++ b/src/layout/__snapshots__/menu.test.ts.snap
@@ -6,62 +6,91 @@ exports[`createMenu > can be removed 1`] = `
     class="marking-menu"
     style="--center-x: 30px; --center-y: 50px;"
   >
-    <div
-      class="marking-menu-item"
-      data-item-id="item-0-key"
-      style="--angle: 0deg; --cosine: 1; --sine: 0;"
-    >
+    #shadow-root
+      <style />
       <div
-        class="marking-menu-line"
+        class="marking-menu-layout-probe marking-menu-layout-probe--ring-radius"
       />
       <div
-        class="marking-menu-label"
-      >
-        item-0-name
-      </div>
-    </div>
-    <div
-      class="marking-menu-item bottom-right-item"
-      data-item-id="item-1-key"
-      style="--angle: 10deg; --cosine: 0.984807753012208; --sine: -0.17364817766693033;"
-    >
-      <div
-        class="marking-menu-line"
+        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-horizontal"
       />
       <div
-        class="marking-menu-label"
-      >
-        item-1-name
-      </div>
-    </div>
-    <div
-      class="marking-menu-item bottom-right-item active"
-      data-item-id="item-2-key"
-      style="--angle: 20deg; --cosine: 0.9396926207859084; --sine: -0.3420201433256687;"
-    >
-      <div
-        class="marking-menu-line"
+        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-vertical"
       />
       <div
-        class="marking-menu-label"
-      >
-        item-2-name
-      </div>
-    </div>
-    <div
-      class="marking-menu-item bottom-right-item"
-      data-item-id="item-3-key"
-      style="--angle: 30deg; --cosine: 0.8660254037844387; --sine: -0.49999999999999994;"
-    >
-      <div
-        class="marking-menu-line"
+        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-ring"
       />
       <div
-        class="marking-menu-label"
+        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-connector"
+      />
+      <div
+        class="marking-menu-item"
+        data-item-id="item-0-key"
+        part="plate"
+        style="--angle: 0deg; --cosine: 1; --sine: 0;"
       >
-        item-3-name
+        <div
+          class="marking-menu-line"
+          part="connector"
+        />
+        <div
+          class="marking-menu-label"
+          part="label"
+        >
+          item-0-name
+        </div>
       </div>
-    </div>
+      <div
+        class="marking-menu-item bottom-right-item"
+        data-item-id="item-1-key"
+        part="plate"
+        style="--angle: 10deg; --cosine: 0.984807753012208; --sine: -0.17364817766693033;"
+      >
+        <div
+          class="marking-menu-line"
+          part="connector"
+        />
+        <div
+          class="marking-menu-label"
+          part="label"
+        >
+          item-1-name
+        </div>
+      </div>
+      <div
+        class="marking-menu-item bottom-right-item active"
+        data-item-id="item-2-key"
+        part="plate plate--active"
+        style="--angle: 20deg; --cosine: 0.9396926207859084; --sine: -0.3420201433256687;"
+      >
+        <div
+          class="marking-menu-line"
+          part="connector connector--active"
+        />
+        <div
+          class="marking-menu-label"
+          part="label label--active"
+        >
+          item-2-name
+        </div>
+      </div>
+      <div
+        class="marking-menu-item bottom-right-item"
+        data-item-id="item-3-key"
+        part="plate"
+        style="--angle: 30deg; --cosine: 0.8660254037844387; --sine: -0.49999999999999994;"
+      >
+        <div
+          class="marking-menu-line"
+          part="connector"
+        />
+        <div
+          class="marking-menu-label"
+          part="label"
+        >
+          item-3-name
+        </div>
+      </div>
   </div>
 </div>
 `;
@@ -74,90 +103,125 @@ exports[`createMenu > renders 1`] = `
     class="marking-menu"
     style="--center-x: 30px; --center-y: 50px;"
   >
-    <div
-      class="marking-menu-item"
-      data-item-id="item-0-key"
-      style="--angle: 0deg; --cosine: 1; --sine: 0;"
-    >
+    #shadow-root
+      <style />
       <div
-        class="marking-menu-line"
+        class="marking-menu-layout-probe marking-menu-layout-probe--ring-radius"
       />
       <div
-        class="marking-menu-label"
-      >
-        item-0-name
-      </div>
-    </div>
-    <div
-      class="marking-menu-item bottom-right-item"
-      data-item-id="item-1-key"
-      style="--angle: 10deg; --cosine: 0.984807753012208; --sine: -0.17364817766693033;"
-    >
-      <div
-        class="marking-menu-line"
+        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-horizontal"
       />
       <div
-        class="marking-menu-label"
-      >
-        item-1-name
-      </div>
-    </div>
-    <div
-      class="marking-menu-item bottom-right-item"
-      data-item-id="item-2-key"
-      style="--angle: 20deg; --cosine: 0.9396926207859084; --sine: -0.3420201433256687;"
-    >
-      <div
-        class="marking-menu-line"
+        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-vertical"
       />
       <div
-        class="marking-menu-label"
-      >
-        item-2-name
-      </div>
-    </div>
-    <div
-      class="marking-menu-item bottom-right-item"
-      data-item-id="item-3-key"
-      style="--angle: 30deg; --cosine: 0.8660254037844387; --sine: -0.49999999999999994;"
-    >
-      <div
-        class="marking-menu-line"
+        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-ring"
       />
       <div
-        class="marking-menu-label"
-      >
-        item-3-name
-      </div>
-    </div>
-    <div
-      class="marking-menu-item bottom-right-item"
-      data-item-id="item-4-key"
-      style="--angle: 40deg; --cosine: 0.766044443118978; --sine: -0.6427876096865393;"
-    >
-      <div
-        class="marking-menu-line"
+        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-connector"
       />
       <div
-        class="marking-menu-label"
+        class="marking-menu-item"
+        data-item-id="item-0-key"
+        part="plate"
+        style="--angle: 0deg; --cosine: 1; --sine: 0;"
       >
-        item-4-name
+        <div
+          class="marking-menu-line"
+          part="connector"
+        />
+        <div
+          class="marking-menu-label"
+          part="label"
+        >
+          item-0-name
+        </div>
       </div>
-    </div>
-    <div
-      class="marking-menu-item bottom-right-item active"
-      data-item-id="item-5-key"
-      style="--angle: 50deg; --cosine: 0.6427876096865394; --sine: -0.766044443118978;"
-    >
       <div
-        class="marking-menu-line"
-      />
-      <div
-        class="marking-menu-label"
+        class="marking-menu-item bottom-right-item"
+        data-item-id="item-1-key"
+        part="plate"
+        style="--angle: 10deg; --cosine: 0.984807753012208; --sine: -0.17364817766693033;"
       >
-        item-5-name
+        <div
+          class="marking-menu-line"
+          part="connector"
+        />
+        <div
+          class="marking-menu-label"
+          part="label"
+        >
+          item-1-name
+        </div>
       </div>
-    </div>
+      <div
+        class="marking-menu-item bottom-right-item"
+        data-item-id="item-2-key"
+        part="plate"
+        style="--angle: 20deg; --cosine: 0.9396926207859084; --sine: -0.3420201433256687;"
+      >
+        <div
+          class="marking-menu-line"
+          part="connector"
+        />
+        <div
+          class="marking-menu-label"
+          part="label"
+        >
+          item-2-name
+        </div>
+      </div>
+      <div
+        class="marking-menu-item bottom-right-item"
+        data-item-id="item-3-key"
+        part="plate"
+        style="--angle: 30deg; --cosine: 0.8660254037844387; --sine: -0.49999999999999994;"
+      >
+        <div
+          class="marking-menu-line"
+          part="connector"
+        />
+        <div
+          class="marking-menu-label"
+          part="label"
+        >
+          item-3-name
+        </div>
+      </div>
+      <div
+        class="marking-menu-item bottom-right-item"
+        data-item-id="item-4-key"
+        part="plate"
+        style="--angle: 40deg; --cosine: 0.766044443118978; --sine: -0.6427876096865393;"
+      >
+        <div
+          class="marking-menu-line"
+          part="connector"
+        />
+        <div
+          class="marking-menu-label"
+          part="label"
+        >
+          item-4-name
+        </div>
+      </div>
+      <div
+        class="marking-menu-item bottom-right-item active"
+        data-item-id="item-5-key"
+        part="plate plate--active"
+        style="--angle: 50deg; --cosine: 0.6427876096865394; --sine: -0.766044443118978;"
+      >
+        <div
+          class="marking-menu-line"
+          part="connector connector--active"
+        />
+        <div
+          class="marking-menu-label"
+          part="label label--active"
+        >
+          item-5-name
+        </div>
+      </div>
   </div>
 </div>
 `;
@@ -168,62 +232,91 @@ exports[`createMenu > renders without active element 1`] = `
     class="marking-menu"
     style="--center-x: 30px; --center-y: 50px;"
   >
-    <div
-      class="marking-menu-item"
-      data-item-id="item-0-key"
-      style="--angle: 0deg; --cosine: 1; --sine: 0;"
-    >
+    #shadow-root
+      <style />
       <div
-        class="marking-menu-line"
+        class="marking-menu-layout-probe marking-menu-layout-probe--ring-radius"
       />
       <div
-        class="marking-menu-label"
-      >
-        item-0-name
-      </div>
-    </div>
-    <div
-      class="marking-menu-item bottom-right-item"
-      data-item-id="item-1-key"
-      style="--angle: 10deg; --cosine: 0.984807753012208; --sine: -0.17364817766693033;"
-    >
-      <div
-        class="marking-menu-line"
+        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-horizontal"
       />
       <div
-        class="marking-menu-label"
-      >
-        item-1-name
-      </div>
-    </div>
-    <div
-      class="marking-menu-item bottom-right-item"
-      data-item-id="item-2-key"
-      style="--angle: 20deg; --cosine: 0.9396926207859084; --sine: -0.3420201433256687;"
-    >
-      <div
-        class="marking-menu-line"
+        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-vertical"
       />
       <div
-        class="marking-menu-label"
-      >
-        item-2-name
-      </div>
-    </div>
-    <div
-      class="marking-menu-item bottom-right-item"
-      data-item-id="item-3-key"
-      style="--angle: 30deg; --cosine: 0.8660254037844387; --sine: -0.49999999999999994;"
-    >
-      <div
-        class="marking-menu-line"
+        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-ring"
       />
       <div
-        class="marking-menu-label"
+        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-connector"
+      />
+      <div
+        class="marking-menu-item"
+        data-item-id="item-0-key"
+        part="plate"
+        style="--angle: 0deg; --cosine: 1; --sine: 0;"
       >
-        item-3-name
+        <div
+          class="marking-menu-line"
+          part="connector"
+        />
+        <div
+          class="marking-menu-label"
+          part="label"
+        >
+          item-0-name
+        </div>
       </div>
-    </div>
+      <div
+        class="marking-menu-item bottom-right-item"
+        data-item-id="item-1-key"
+        part="plate"
+        style="--angle: 10deg; --cosine: 0.984807753012208; --sine: -0.17364817766693033;"
+      >
+        <div
+          class="marking-menu-line"
+          part="connector"
+        />
+        <div
+          class="marking-menu-label"
+          part="label"
+        >
+          item-1-name
+        </div>
+      </div>
+      <div
+        class="marking-menu-item bottom-right-item"
+        data-item-id="item-2-key"
+        part="plate"
+        style="--angle: 20deg; --cosine: 0.9396926207859084; --sine: -0.3420201433256687;"
+      >
+        <div
+          class="marking-menu-line"
+          part="connector"
+        />
+        <div
+          class="marking-menu-label"
+          part="label"
+        >
+          item-2-name
+        </div>
+      </div>
+      <div
+        class="marking-menu-item bottom-right-item"
+        data-item-id="item-3-key"
+        part="plate"
+        style="--angle: 30deg; --cosine: 0.8660254037844387; --sine: -0.49999999999999994;"
+      >
+        <div
+          class="marking-menu-line"
+          part="connector"
+        />
+        <div
+          class="marking-menu-label"
+          part="label"
+        >
+          item-3-name
+        </div>
+      </div>
   </div>
 </div>
 `;
@@ -234,62 +327,91 @@ exports[`createMenu > update the active element 1`] = `
     class="marking-menu"
     style="--center-x: 30px; --center-y: 50px;"
   >
-    <div
-      class="marking-menu-item"
-      data-item-id="item-0-key"
-      style="--angle: 0deg; --cosine: 1; --sine: 0;"
-    >
+    #shadow-root
+      <style />
       <div
-        class="marking-menu-line"
+        class="marking-menu-layout-probe marking-menu-layout-probe--ring-radius"
       />
       <div
-        class="marking-menu-label"
-      >
-        item-0-name
-      </div>
-    </div>
-    <div
-      class="marking-menu-item bottom-right-item"
-      data-item-id="item-1-key"
-      style="--angle: 10deg; --cosine: 0.984807753012208; --sine: -0.17364817766693033;"
-    >
-      <div
-        class="marking-menu-line"
+        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-horizontal"
       />
       <div
-        class="marking-menu-label"
-      >
-        item-1-name
-      </div>
-    </div>
-    <div
-      class="marking-menu-item bottom-right-item active"
-      data-item-id="item-2-key"
-      style="--angle: 20deg; --cosine: 0.9396926207859084; --sine: -0.3420201433256687;"
-    >
-      <div
-        class="marking-menu-line"
+        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-vertical"
       />
       <div
-        class="marking-menu-label"
-      >
-        item-2-name
-      </div>
-    </div>
-    <div
-      class="marking-menu-item bottom-right-item"
-      data-item-id="item-3-key"
-      style="--angle: 30deg; --cosine: 0.8660254037844387; --sine: -0.49999999999999994;"
-    >
-      <div
-        class="marking-menu-line"
+        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-ring"
       />
       <div
-        class="marking-menu-label"
+        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-connector"
+      />
+      <div
+        class="marking-menu-item"
+        data-item-id="item-0-key"
+        part="plate"
+        style="--angle: 0deg; --cosine: 1; --sine: 0;"
       >
-        item-3-name
+        <div
+          class="marking-menu-line"
+          part="connector"
+        />
+        <div
+          class="marking-menu-label"
+          part="label"
+        >
+          item-0-name
+        </div>
       </div>
-    </div>
+      <div
+        class="marking-menu-item bottom-right-item"
+        data-item-id="item-1-key"
+        part="plate"
+        style="--angle: 10deg; --cosine: 0.984807753012208; --sine: -0.17364817766693033;"
+      >
+        <div
+          class="marking-menu-line"
+          part="connector"
+        />
+        <div
+          class="marking-menu-label"
+          part="label"
+        >
+          item-1-name
+        </div>
+      </div>
+      <div
+        class="marking-menu-item bottom-right-item active"
+        data-item-id="item-2-key"
+        part="plate plate--active"
+        style="--angle: 20deg; --cosine: 0.9396926207859084; --sine: -0.3420201433256687;"
+      >
+        <div
+          class="marking-menu-line"
+          part="connector connector--active"
+        />
+        <div
+          class="marking-menu-label"
+          part="label label--active"
+        >
+          item-2-name
+        </div>
+      </div>
+      <div
+        class="marking-menu-item bottom-right-item"
+        data-item-id="item-3-key"
+        part="plate"
+        style="--angle: 30deg; --cosine: 0.8660254037844387; --sine: -0.49999999999999994;"
+      >
+        <div
+          class="marking-menu-line"
+          part="connector"
+        />
+        <div
+          class="marking-menu-label"
+          part="label"
+        >
+          item-3-name
+        </div>
+      </div>
   </div>
 </div>
 `;
@@ -300,62 +422,91 @@ exports[`createMenu > update the active element 2`] = `
     class="marking-menu"
     style="--center-x: 30px; --center-y: 50px;"
   >
-    <div
-      class="marking-menu-item"
-      data-item-id="item-0-key"
-      style="--angle: 0deg; --cosine: 1; --sine: 0;"
-    >
+    #shadow-root
+      <style />
       <div
-        class="marking-menu-line"
+        class="marking-menu-layout-probe marking-menu-layout-probe--ring-radius"
       />
       <div
-        class="marking-menu-label"
-      >
-        item-0-name
-      </div>
-    </div>
-    <div
-      class="marking-menu-item bottom-right-item active"
-      data-item-id="item-1-key"
-      style="--angle: 10deg; --cosine: 0.984807753012208; --sine: -0.17364817766693033;"
-    >
-      <div
-        class="marking-menu-line"
+        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-horizontal"
       />
       <div
-        class="marking-menu-label"
-      >
-        item-1-name
-      </div>
-    </div>
-    <div
-      class="marking-menu-item bottom-right-item"
-      data-item-id="item-2-key"
-      style="--angle: 20deg; --cosine: 0.9396926207859084; --sine: -0.3420201433256687;"
-    >
-      <div
-        class="marking-menu-line"
+        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-vertical"
       />
       <div
-        class="marking-menu-label"
-      >
-        item-2-name
-      </div>
-    </div>
-    <div
-      class="marking-menu-item bottom-right-item"
-      data-item-id="item-3-key"
-      style="--angle: 30deg; --cosine: 0.8660254037844387; --sine: -0.49999999999999994;"
-    >
-      <div
-        class="marking-menu-line"
+        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-ring"
       />
       <div
-        class="marking-menu-label"
+        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-connector"
+      />
+      <div
+        class="marking-menu-item"
+        data-item-id="item-0-key"
+        part="plate"
+        style="--angle: 0deg; --cosine: 1; --sine: 0;"
       >
-        item-3-name
+        <div
+          class="marking-menu-line"
+          part="connector"
+        />
+        <div
+          class="marking-menu-label"
+          part="label"
+        >
+          item-0-name
+        </div>
       </div>
-    </div>
+      <div
+        class="marking-menu-item bottom-right-item active"
+        data-item-id="item-1-key"
+        part="plate plate--active"
+        style="--angle: 10deg; --cosine: 0.984807753012208; --sine: -0.17364817766693033;"
+      >
+        <div
+          class="marking-menu-line"
+          part="connector connector--active"
+        />
+        <div
+          class="marking-menu-label"
+          part="label label--active"
+        >
+          item-1-name
+        </div>
+      </div>
+      <div
+        class="marking-menu-item bottom-right-item"
+        data-item-id="item-2-key"
+        part="plate"
+        style="--angle: 20deg; --cosine: 0.9396926207859084; --sine: -0.3420201433256687;"
+      >
+        <div
+          class="marking-menu-line"
+          part="connector"
+        />
+        <div
+          class="marking-menu-label"
+          part="label"
+        >
+          item-2-name
+        </div>
+      </div>
+      <div
+        class="marking-menu-item bottom-right-item"
+        data-item-id="item-3-key"
+        part="plate"
+        style="--angle: 30deg; --cosine: 0.8660254037844387; --sine: -0.49999999999999994;"
+      >
+        <div
+          class="marking-menu-line"
+          part="connector"
+        />
+        <div
+          class="marking-menu-label"
+          part="label"
+        >
+          item-3-name
+        </div>
+      </div>
   </div>
 </div>
 `;

--- a/src/layout/__snapshots__/menu.test.ts.snap
+++ b/src/layout/__snapshots__/menu.test.ts.snap
@@ -9,24 +9,8 @@ exports[`createMenu > can be removed 1`] = `
     #shadow-root
       <style />
       <div
-        class="marking-menu-layout-probe marking-menu-layout-probe--ring-radius"
-      />
-      <div
-        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-horizontal"
-      />
-      <div
-        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-vertical"
-      />
-      <div
-        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-ring"
-      />
-      <div
-        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-connector"
-      />
-      <div
         class="marking-menu-item"
         data-item-id="item-0-key"
-        part="plate"
         style="--angle: 0deg; --cosine: 1; --sine: 0;"
       >
         <div
@@ -35,7 +19,7 @@ exports[`createMenu > can be removed 1`] = `
         />
         <div
           class="marking-menu-label"
-          part="label"
+          part="plate label"
         >
           item-0-name
         </div>
@@ -43,7 +27,6 @@ exports[`createMenu > can be removed 1`] = `
       <div
         class="marking-menu-item bottom-right-item"
         data-item-id="item-1-key"
-        part="plate"
         style="--angle: 10deg; --cosine: 0.984807753012208; --sine: -0.17364817766693033;"
       >
         <div
@@ -52,7 +35,7 @@ exports[`createMenu > can be removed 1`] = `
         />
         <div
           class="marking-menu-label"
-          part="label"
+          part="plate label"
         >
           item-1-name
         </div>
@@ -60,7 +43,6 @@ exports[`createMenu > can be removed 1`] = `
       <div
         class="marking-menu-item bottom-right-item active"
         data-item-id="item-2-key"
-        part="plate plate--active"
         style="--angle: 20deg; --cosine: 0.9396926207859084; --sine: -0.3420201433256687;"
       >
         <div
@@ -69,7 +51,7 @@ exports[`createMenu > can be removed 1`] = `
         />
         <div
           class="marking-menu-label"
-          part="label label--active"
+          part="plate label plate--active label--active"
         >
           item-2-name
         </div>
@@ -77,7 +59,6 @@ exports[`createMenu > can be removed 1`] = `
       <div
         class="marking-menu-item bottom-right-item"
         data-item-id="item-3-key"
-        part="plate"
         style="--angle: 30deg; --cosine: 0.8660254037844387; --sine: -0.49999999999999994;"
       >
         <div
@@ -86,7 +67,7 @@ exports[`createMenu > can be removed 1`] = `
         />
         <div
           class="marking-menu-label"
-          part="label"
+          part="plate label"
         >
           item-3-name
         </div>
@@ -106,24 +87,8 @@ exports[`createMenu > renders 1`] = `
     #shadow-root
       <style />
       <div
-        class="marking-menu-layout-probe marking-menu-layout-probe--ring-radius"
-      />
-      <div
-        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-horizontal"
-      />
-      <div
-        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-vertical"
-      />
-      <div
-        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-ring"
-      />
-      <div
-        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-connector"
-      />
-      <div
         class="marking-menu-item"
         data-item-id="item-0-key"
-        part="plate"
         style="--angle: 0deg; --cosine: 1; --sine: 0;"
       >
         <div
@@ -132,7 +97,7 @@ exports[`createMenu > renders 1`] = `
         />
         <div
           class="marking-menu-label"
-          part="label"
+          part="plate label"
         >
           item-0-name
         </div>
@@ -140,7 +105,6 @@ exports[`createMenu > renders 1`] = `
       <div
         class="marking-menu-item bottom-right-item"
         data-item-id="item-1-key"
-        part="plate"
         style="--angle: 10deg; --cosine: 0.984807753012208; --sine: -0.17364817766693033;"
       >
         <div
@@ -149,7 +113,7 @@ exports[`createMenu > renders 1`] = `
         />
         <div
           class="marking-menu-label"
-          part="label"
+          part="plate label"
         >
           item-1-name
         </div>
@@ -157,7 +121,6 @@ exports[`createMenu > renders 1`] = `
       <div
         class="marking-menu-item bottom-right-item"
         data-item-id="item-2-key"
-        part="plate"
         style="--angle: 20deg; --cosine: 0.9396926207859084; --sine: -0.3420201433256687;"
       >
         <div
@@ -166,7 +129,7 @@ exports[`createMenu > renders 1`] = `
         />
         <div
           class="marking-menu-label"
-          part="label"
+          part="plate label"
         >
           item-2-name
         </div>
@@ -174,7 +137,6 @@ exports[`createMenu > renders 1`] = `
       <div
         class="marking-menu-item bottom-right-item"
         data-item-id="item-3-key"
-        part="plate"
         style="--angle: 30deg; --cosine: 0.8660254037844387; --sine: -0.49999999999999994;"
       >
         <div
@@ -183,7 +145,7 @@ exports[`createMenu > renders 1`] = `
         />
         <div
           class="marking-menu-label"
-          part="label"
+          part="plate label"
         >
           item-3-name
         </div>
@@ -191,7 +153,6 @@ exports[`createMenu > renders 1`] = `
       <div
         class="marking-menu-item bottom-right-item"
         data-item-id="item-4-key"
-        part="plate"
         style="--angle: 40deg; --cosine: 0.766044443118978; --sine: -0.6427876096865393;"
       >
         <div
@@ -200,7 +161,7 @@ exports[`createMenu > renders 1`] = `
         />
         <div
           class="marking-menu-label"
-          part="label"
+          part="plate label"
         >
           item-4-name
         </div>
@@ -208,7 +169,6 @@ exports[`createMenu > renders 1`] = `
       <div
         class="marking-menu-item bottom-right-item active"
         data-item-id="item-5-key"
-        part="plate plate--active"
         style="--angle: 50deg; --cosine: 0.6427876096865394; --sine: -0.766044443118978;"
       >
         <div
@@ -217,7 +177,7 @@ exports[`createMenu > renders 1`] = `
         />
         <div
           class="marking-menu-label"
-          part="label label--active"
+          part="plate label plate--active label--active"
         >
           item-5-name
         </div>
@@ -235,24 +195,8 @@ exports[`createMenu > renders without active element 1`] = `
     #shadow-root
       <style />
       <div
-        class="marking-menu-layout-probe marking-menu-layout-probe--ring-radius"
-      />
-      <div
-        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-horizontal"
-      />
-      <div
-        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-vertical"
-      />
-      <div
-        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-ring"
-      />
-      <div
-        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-connector"
-      />
-      <div
         class="marking-menu-item"
         data-item-id="item-0-key"
-        part="plate"
         style="--angle: 0deg; --cosine: 1; --sine: 0;"
       >
         <div
@@ -261,7 +205,7 @@ exports[`createMenu > renders without active element 1`] = `
         />
         <div
           class="marking-menu-label"
-          part="label"
+          part="plate label"
         >
           item-0-name
         </div>
@@ -269,7 +213,6 @@ exports[`createMenu > renders without active element 1`] = `
       <div
         class="marking-menu-item bottom-right-item"
         data-item-id="item-1-key"
-        part="plate"
         style="--angle: 10deg; --cosine: 0.984807753012208; --sine: -0.17364817766693033;"
       >
         <div
@@ -278,7 +221,7 @@ exports[`createMenu > renders without active element 1`] = `
         />
         <div
           class="marking-menu-label"
-          part="label"
+          part="plate label"
         >
           item-1-name
         </div>
@@ -286,7 +229,6 @@ exports[`createMenu > renders without active element 1`] = `
       <div
         class="marking-menu-item bottom-right-item"
         data-item-id="item-2-key"
-        part="plate"
         style="--angle: 20deg; --cosine: 0.9396926207859084; --sine: -0.3420201433256687;"
       >
         <div
@@ -295,7 +237,7 @@ exports[`createMenu > renders without active element 1`] = `
         />
         <div
           class="marking-menu-label"
-          part="label"
+          part="plate label"
         >
           item-2-name
         </div>
@@ -303,7 +245,6 @@ exports[`createMenu > renders without active element 1`] = `
       <div
         class="marking-menu-item bottom-right-item"
         data-item-id="item-3-key"
-        part="plate"
         style="--angle: 30deg; --cosine: 0.8660254037844387; --sine: -0.49999999999999994;"
       >
         <div
@@ -312,7 +253,7 @@ exports[`createMenu > renders without active element 1`] = `
         />
         <div
           class="marking-menu-label"
-          part="label"
+          part="plate label"
         >
           item-3-name
         </div>
@@ -330,24 +271,8 @@ exports[`createMenu > update the active element 1`] = `
     #shadow-root
       <style />
       <div
-        class="marking-menu-layout-probe marking-menu-layout-probe--ring-radius"
-      />
-      <div
-        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-horizontal"
-      />
-      <div
-        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-vertical"
-      />
-      <div
-        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-ring"
-      />
-      <div
-        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-connector"
-      />
-      <div
         class="marking-menu-item"
         data-item-id="item-0-key"
-        part="plate"
         style="--angle: 0deg; --cosine: 1; --sine: 0;"
       >
         <div
@@ -356,7 +281,7 @@ exports[`createMenu > update the active element 1`] = `
         />
         <div
           class="marking-menu-label"
-          part="label"
+          part="plate label"
         >
           item-0-name
         </div>
@@ -364,7 +289,6 @@ exports[`createMenu > update the active element 1`] = `
       <div
         class="marking-menu-item bottom-right-item"
         data-item-id="item-1-key"
-        part="plate"
         style="--angle: 10deg; --cosine: 0.984807753012208; --sine: -0.17364817766693033;"
       >
         <div
@@ -373,7 +297,7 @@ exports[`createMenu > update the active element 1`] = `
         />
         <div
           class="marking-menu-label"
-          part="label"
+          part="plate label"
         >
           item-1-name
         </div>
@@ -381,7 +305,6 @@ exports[`createMenu > update the active element 1`] = `
       <div
         class="marking-menu-item bottom-right-item active"
         data-item-id="item-2-key"
-        part="plate plate--active"
         style="--angle: 20deg; --cosine: 0.9396926207859084; --sine: -0.3420201433256687;"
       >
         <div
@@ -390,7 +313,7 @@ exports[`createMenu > update the active element 1`] = `
         />
         <div
           class="marking-menu-label"
-          part="label label--active"
+          part="plate label plate--active label--active"
         >
           item-2-name
         </div>
@@ -398,7 +321,6 @@ exports[`createMenu > update the active element 1`] = `
       <div
         class="marking-menu-item bottom-right-item"
         data-item-id="item-3-key"
-        part="plate"
         style="--angle: 30deg; --cosine: 0.8660254037844387; --sine: -0.49999999999999994;"
       >
         <div
@@ -407,7 +329,7 @@ exports[`createMenu > update the active element 1`] = `
         />
         <div
           class="marking-menu-label"
-          part="label"
+          part="plate label"
         >
           item-3-name
         </div>
@@ -425,24 +347,8 @@ exports[`createMenu > update the active element 2`] = `
     #shadow-root
       <style />
       <div
-        class="marking-menu-layout-probe marking-menu-layout-probe--ring-radius"
-      />
-      <div
-        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-horizontal"
-      />
-      <div
-        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-vertical"
-      />
-      <div
-        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-ring"
-      />
-      <div
-        class="marking-menu-layout-probe marking-menu-layout-probe--plate-gap-connector"
-      />
-      <div
         class="marking-menu-item"
         data-item-id="item-0-key"
-        part="plate"
         style="--angle: 0deg; --cosine: 1; --sine: 0;"
       >
         <div
@@ -451,7 +357,7 @@ exports[`createMenu > update the active element 2`] = `
         />
         <div
           class="marking-menu-label"
-          part="label"
+          part="plate label"
         >
           item-0-name
         </div>
@@ -459,7 +365,6 @@ exports[`createMenu > update the active element 2`] = `
       <div
         class="marking-menu-item bottom-right-item active"
         data-item-id="item-1-key"
-        part="plate plate--active"
         style="--angle: 10deg; --cosine: 0.984807753012208; --sine: -0.17364817766693033;"
       >
         <div
@@ -468,7 +373,7 @@ exports[`createMenu > update the active element 2`] = `
         />
         <div
           class="marking-menu-label"
-          part="label label--active"
+          part="plate label plate--active label--active"
         >
           item-1-name
         </div>
@@ -476,7 +381,6 @@ exports[`createMenu > update the active element 2`] = `
       <div
         class="marking-menu-item bottom-right-item"
         data-item-id="item-2-key"
-        part="plate"
         style="--angle: 20deg; --cosine: 0.9396926207859084; --sine: -0.3420201433256687;"
       >
         <div
@@ -485,7 +389,7 @@ exports[`createMenu > update the active element 2`] = `
         />
         <div
           class="marking-menu-label"
-          part="label"
+          part="plate label"
         >
           item-2-name
         </div>
@@ -493,7 +397,6 @@ exports[`createMenu > update the active element 2`] = `
       <div
         class="marking-menu-item bottom-right-item"
         data-item-id="item-3-key"
-        part="plate"
         style="--angle: 30deg; --cosine: 0.8660254037844387; --sine: -0.49999999999999994;"
       >
         <div
@@ -502,7 +405,7 @@ exports[`createMenu > update the active element 2`] = `
         />
         <div
           class="marking-menu-label"
-          part="label"
+          part="plate label"
         >
           item-3-name
         </div>

--- a/src/layout/menu.css
+++ b/src/layout/menu.css
@@ -1,119 +1,78 @@
-/* A label is sized by its content and padded around it, and the layout adds
-   that padding back to place it (see `--item-box-width` below). A host reset
-   that makes everything `border-box`, as Tailwind's preflight and normalize
-   both do, would take the padding out of the label instead, dropping its
-   text off centre and its box off position. The menu states the box model
-   its own arithmetic assumes rather than inheriting one. */
-.marking-menu,
-.marking-menu * {
-  box-sizing: content-box;
-}
-
-.marking-menu {
-  --item-width: 120px;
-  --item-height: 20px;
-  --item-font-size: 20px;
-  --item-padding: 4px;
-  --item-background: #f2f2f2;
-  --item-color: #333333;
-  --active-item-background: #d9d9d9;
-  --active-item-color: #000;
-  --item-radius: calc(var(--item-padding) * 2);
-  --menu-radius: 80px;
-  --center-radius: 10px;
-  --line-thickness: 4px;
-  --line-color: var(--item-background);
-  --active-line-color: var(--active-item-background);
-
-  /* Minimum gaps the label-layout solver keeps: between two plates
-     (horizontal/vertical), between a plate and the ring, and between a
-     connector line and a plate it doesn't belong to. */
-  --item-horizontal-gap: 14px;
-  --item-vertical-gap: 7px;
-  --item-ring-gap: 12px;
-  --item-connector-gap: 3px;
-
-  /* The two following variables must be set from JS. */
-  --center-x: 0px;
-  --center-y: 0px;
-
+:host {
   position: absolute;
   top: var(--center-y);
   left: var(--center-x);
   pointer-events: none;
-  /* Using transform to make .marking-menu a stacking context and confine
-     z-ordered children in the document's z-stack. */
   transform: translate(0px, 0px);
-  /* No z-index here on purpose: the menu sits between the two stroke
-     canvases, above the lower stroke and below both the upper one and the
-     completed-gesture feedback. The renderer keeps it there by ordering
-     the siblings itself, so a z-index here would break that. */
 }
 
 .marking-menu-item {
-  /* The three following variables must be set from JS for each item. */
   --angle: 0deg;
   --cosine: 1;
   --sine: 0;
-
-  --item-box-width: calc(var(--item-width) + var(--item-padding) * 2);
-  --item-box-height: calc(var(--item-height) + var(--item-padding) * 2);
+  --item-box-width: calc(
+    var(--item-width, 120px) + var(--mm-plate-padding, 4px) * 2
+  );
+  --item-box-height: calc(
+    var(--mm-plate-height, 20px) + var(--mm-plate-padding, 4px) * 2
+  );
 
   position: absolute;
   z-index: 0;
 }
 
-.marking-menu-item .marking-menu-label {
+.marking-menu-label {
   position: absolute;
-  bottom: calc(
-    var(--sine) * var(--menu-radius) + (min(1, max(-1, var(--sine) * 2)) - 1) *
-      var(--item-box-height) / 2
+  bottom: var(
+    --solved-bottom,
+    calc(
+      var(--sine) * var(--mm-ring-radius, 80px) +
+        (min(1, max(-1, var(--sine) * 2)) - 1) * var(--item-box-height) / 2
+    )
   );
-  left: calc(
-    var(--cosine) * var(--menu-radius) +
-      (min(1, max(-1, var(--cosine) * 2)) - 1) * var(--item-box-width) / 2
+  left: var(
+    --solved-left,
+    calc(
+      var(--cosine) * var(--mm-ring-radius, 80px) +
+        (min(1, max(-1, var(--cosine) * 2)) - 1) * var(--item-box-width) / 2
+    )
   );
-  border-radius: var(--item-radius);
-  background-color: var(--item-background);
-  padding: var(--item-padding);
-  width: var(--item-width);
-  height: var(--item-height);
+  top: var(--solved-top, auto);
+  border-radius: var(
+    --mm-plate-corner-radius,
+    calc(var(--mm-plate-padding, 4px) * 2)
+  );
+  background-color: var(--mm-plate-background, #f2f2f2);
+  padding: var(--mm-plate-padding, 4px);
+  width: var(--item-width, 120px);
+  height: var(--mm-plate-height, 20px);
   overflow: hidden;
   vertical-align: middle;
   text-align: center;
   text-overflow: ellipsis;
-  line-height: var(--item-height);
-  color: var(--item-color);
-  font-size: var(--item-font-size);
+  line-height: var(--mm-plate-height, 20px);
+  color: var(--mm-plate-color, #333333);
+  font-size: var(--mm-plate-font-size, 20px);
 }
 
-.marking-menu-item .marking-menu-line {
+.marking-menu-line {
   position: absolute;
-  top: calc(var(--line-thickness) / -2);
-  background-color: var(--line-color);
-  width: calc(var(--menu-radius) + var(--item-radius) + var(--line-thickness));
-  height: var(--line-thickness);
+  top: calc(var(--mm-connector-thickness, 4px) / -2);
+  background-color: var(
+    --mm-connector-color,
+    var(--mm-plate-background, #f2f2f2)
+  );
+  width: var(
+    --solved-connector-width,
+    calc(
+      var(--mm-ring-radius, 80px) +
+        var(--mm-plate-corner-radius, calc(var(--mm-plate-padding, 4px) * 2)) +
+        var(--mm-connector-thickness, 4px)
+    )
+  );
+  height: var(--mm-connector-thickness, 4px);
   transform-origin: center left;
   transform: rotate(var(--angle));
-}
-
-/* Once the label-layout solver finds a conflict-free arrangement, `--x`,
-   `--y`, and `--contact-radius` (set from JS, in the same pixel coordinates
-   as `--center-x`/`--center-y`: right and down positive) replace the fixed
-   shared radius above. `.marking-menu` gets `.solved` only when the solver
-   didn't report the menu as oversized: an oversized menu keeps rendering
-   every label at the fixed radius, unmodified, rather than with no layout
-   at all. */
-.marking-menu.solved .marking-menu-item .marking-menu-label {
-  left: calc(var(--x) - var(--item-box-width) / 2);
-  top: calc(var(--y) - var(--item-box-height) / 2);
-  bottom: auto;
-}
-
-.marking-menu.solved .marking-menu-item .marking-menu-line {
-  width: calc(
-    var(--contact-radius) + var(--item-radius) + var(--line-thickness)
-  );
 }
 
 .marking-menu-item.active {
@@ -121,25 +80,57 @@
 }
 
 .marking-menu-item.active .marking-menu-label {
-  background-color: var(--active-item-background);
-  color: var(--active-item-color);
+  background-color: var(--mm-plate-background-active, #d9d9d9);
+  color: var(--mm-plate-color-active, #000);
   font-weight: bolder;
 }
 
 .marking-menu-item.active .marking-menu-line {
-  background-color: var(--active-line-color);
+  background-color: var(
+    --mm-connector-color-active,
+    var(--mm-plate-background-active, #d9d9d9)
+  );
 }
 
-/* Corner items should have hard corner where the line departs. */
 .marking-menu-item.bottom-right-item .marking-menu-label {
   border-top-left-radius: 0;
 }
+
 .marking-menu-item.bottom-left-item .marking-menu-label {
   border-top-right-radius: 0;
 }
+
 .marking-menu-item.top-left-item .marking-menu-label {
   border-bottom-right-radius: 0;
 }
+
 .marking-menu-item.top-right-item .marking-menu-label {
   border-bottom-left-radius: 0;
+}
+
+.marking-menu-layout-probe {
+  position: absolute;
+  visibility: hidden;
+  height: 0;
+  contain: strict;
+}
+
+.marking-menu-layout-probe--ring-radius {
+  width: var(--mm-ring-radius, 80px);
+}
+
+.marking-menu-layout-probe--plate-gap-horizontal {
+  width: var(--mm-plate-gap-horizontal, 14px);
+}
+
+.marking-menu-layout-probe--plate-gap-vertical {
+  width: var(--mm-plate-gap-vertical, 7px);
+}
+
+.marking-menu-layout-probe--plate-gap-ring {
+  width: var(--mm-plate-gap-ring, 12px);
+}
+
+.marking-menu-layout-probe--plate-gap-connector {
+  width: var(--mm-plate-gap-connector, 3px);
 }

--- a/src/layout/menu.css
+++ b/src/layout/menu.css
@@ -1,4 +1,31 @@
 :host {
+  --item-width: 120px;
+  --default-ring-radius: var(--mm-ring-radius, 80px);
+  --default-plate-padding: var(--mm-plate-padding, 4px);
+  --default-plate-height: var(--mm-plate-height, 20px);
+  --default-plate-corner-radius: var(
+    --mm-plate-corner-radius,
+    calc(var(--default-plate-padding) * 2)
+  );
+  --default-plate-background: var(--mm-plate-background, #f2f2f2);
+  --default-plate-color: var(--mm-plate-color, #333333);
+  --default-plate-background-active: var(--mm-plate-background-active, #d9d9d9);
+  --default-plate-color-active: var(--mm-plate-color-active, #000);
+  --default-plate-font-size: var(--mm-plate-font-size, 20px);
+  --default-connector-thickness: var(--mm-connector-thickness, 4px);
+  --default-connector-color: var(
+    --mm-connector-color,
+    var(--default-plate-background)
+  );
+  --default-connector-color-active: var(
+    --mm-connector-color-active,
+    var(--default-plate-background-active)
+  );
+  --default-plate-gap-horizontal: var(--mm-plate-gap-horizontal, 14px);
+  --default-plate-gap-vertical: var(--mm-plate-gap-vertical, 7px);
+  --default-plate-gap-ring: var(--mm-plate-gap-ring, 12px);
+  --default-plate-gap-connector: var(--mm-plate-gap-connector, 3px);
+
   position: absolute;
   top: var(--center-y);
   left: var(--center-x);
@@ -10,11 +37,9 @@
   --angle: 0deg;
   --cosine: 1;
   --sine: 0;
-  --item-box-width: calc(
-    var(--item-width, 120px) + var(--mm-plate-padding, 4px) * 2
-  );
+  --item-box-width: calc(var(--item-width) + var(--default-plate-padding) * 2);
   --item-box-height: calc(
-    var(--mm-plate-height, 20px) + var(--mm-plate-padding, 4px) * 2
+    var(--default-plate-height) + var(--default-plate-padding) * 2
   );
 
   position: absolute;
@@ -26,51 +51,41 @@
   bottom: var(
     --solved-bottom,
     calc(
-      var(--sine) * var(--mm-ring-radius, 80px) +
+      var(--sine) * var(--default-ring-radius) +
         (min(1, max(-1, var(--sine) * 2)) - 1) * var(--item-box-height) / 2
     )
   );
   left: var(
     --solved-left,
     calc(
-      var(--cosine) * var(--mm-ring-radius, 80px) +
+      var(--cosine) * var(--default-ring-radius) +
         (min(1, max(-1, var(--cosine) * 2)) - 1) * var(--item-box-width) / 2
     )
   );
   top: var(--solved-top, auto);
-  border-radius: var(
-    --mm-plate-corner-radius,
-    calc(var(--mm-plate-padding, 4px) * 2)
-  );
-  background-color: var(--mm-plate-background, #f2f2f2);
-  padding: var(--mm-plate-padding, 4px);
-  width: var(--item-width, 120px);
-  height: var(--mm-plate-height, 20px);
+  border-radius: var(--default-plate-corner-radius);
+  background-color: var(--default-plate-background);
+  padding: var(--default-plate-padding);
+  width: var(--item-width);
+  height: var(--default-plate-height);
   overflow: hidden;
   vertical-align: middle;
   text-align: center;
   text-overflow: ellipsis;
-  line-height: var(--mm-plate-height, 20px);
-  color: var(--mm-plate-color, #333333);
-  font-size: var(--mm-plate-font-size, 20px);
+  line-height: var(--default-plate-height);
+  color: var(--default-plate-color);
+  font-size: var(--default-plate-font-size);
 }
 
 .marking-menu-line {
   position: absolute;
-  top: calc(var(--mm-connector-thickness, 4px) / -2);
-  background-color: var(
-    --mm-connector-color,
-    var(--mm-plate-background, #f2f2f2)
+  top: calc(var(--default-connector-thickness) / -2);
+  background-color: var(--default-connector-color);
+  width: calc(
+    var(--solved-connector-contact-radius, var(--default-ring-radius)) +
+      var(--default-plate-corner-radius) + var(--default-connector-thickness)
   );
-  width: var(
-    --solved-connector-width,
-    calc(
-      var(--mm-ring-radius, 80px) +
-        var(--mm-plate-corner-radius, calc(var(--mm-plate-padding, 4px) * 2)) +
-        var(--mm-connector-thickness, 4px)
-    )
-  );
-  height: var(--mm-connector-thickness, 4px);
+  height: var(--default-connector-thickness);
   transform-origin: center left;
   transform: rotate(var(--angle));
 }
@@ -80,16 +95,13 @@
 }
 
 .marking-menu-item.active .marking-menu-label {
-  background-color: var(--mm-plate-background-active, #d9d9d9);
-  color: var(--mm-plate-color-active, #000);
+  background-color: var(--default-plate-background-active);
+  color: var(--default-plate-color-active);
   font-weight: bolder;
 }
 
 .marking-menu-item.active .marking-menu-line {
-  background-color: var(
-    --mm-connector-color-active,
-    var(--mm-plate-background-active, #d9d9d9)
-  );
+  background-color: var(--default-connector-color-active);
 }
 
 .marking-menu-item.bottom-right-item .marking-menu-label {
@@ -116,21 +128,21 @@
 }
 
 .marking-menu-layout-probe--ring-radius {
-  width: var(--mm-ring-radius, 80px);
+  width: var(--default-ring-radius);
 }
 
 .marking-menu-layout-probe--plate-gap-horizontal {
-  width: var(--mm-plate-gap-horizontal, 14px);
+  width: var(--default-plate-gap-horizontal);
 }
 
 .marking-menu-layout-probe--plate-gap-vertical {
-  width: var(--mm-plate-gap-vertical, 7px);
+  width: var(--default-plate-gap-vertical);
 }
 
 .marking-menu-layout-probe--plate-gap-ring {
-  width: var(--mm-plate-gap-ring, 12px);
+  width: var(--default-plate-gap-ring);
 }
 
 .marking-menu-layout-probe--plate-gap-connector {
-  width: var(--mm-plate-gap-connector, 3px);
+  width: var(--default-plate-gap-connector);
 }

--- a/src/layout/menu.test.ts
+++ b/src/layout/menu.test.ts
@@ -38,11 +38,22 @@ const stubbedLabelSize = (width: number, height: number): Disposable => {
   };
 };
 
+const getShadowRoot = (parent: HTMLElement): ShadowRoot => {
+  const root = parent.querySelector<HTMLElement>('.marking-menu')?.shadowRoot;
+  if (root === null || root === undefined) {
+    throw new Error('Menu shadow root is missing.');
+  }
+
+  return root;
+};
+
+const getItems = (parent: HTMLElement): HTMLElement[] => [
+  ...getShadowRoot(parent).querySelectorAll<HTMLElement>('.marking-menu-item'),
+];
+
 /**
- The label-layout solver's ring radius and clearances aren't set from any
- stylesheet under test (`?inline` CSS imports resolve to an empty string
- here). Set them as inline style on `parent` instead, which `main`
- inherits, exactly as it would inherit them from a real stylesheet.
+ Vitest resolves the CSS inline import to empty text, so tests supply probe
+ widths from inherited test variables.
  */
 const withSolverConfig = (
   parent: HTMLElement,
@@ -61,12 +72,37 @@ const withSolverConfig = (
     ringGap = 12,
     connectorGap = 3,
   } = overrides;
-  parent.style.setProperty('--menu-radius', `${menuRadius}px`);
-  parent.style.setProperty('--item-horizontal-gap', `${horizontalGap}px`);
-  parent.style.setProperty('--item-vertical-gap', `${verticalGap}px`);
-  parent.style.setProperty('--item-ring-gap', `${ringGap}px`);
-  parent.style.setProperty('--item-connector-gap', `${connectorGap}px`);
+  const properties = {
+    'ring-radius': `${menuRadius}px`,
+    'plate-gap-horizontal': `${horizontalGap}px`,
+    'plate-gap-vertical': `${verticalGap}px`,
+    'plate-gap-ring': `${ringGap}px`,
+    'plate-gap-connector': `${connectorGap}px`,
+  };
+  for (const [name, value] of Object.entries(properties)) {
+    parent.style.setProperty(`--mm-${name}`, value);
+  }
+
+  const getComputedStyle = globalThis.getComputedStyle.bind(globalThis);
+  vi.spyOn(globalThis, 'getComputedStyle').mockImplementation((element) => {
+    const probeClass = [...element.classList].find((className) =>
+      className.startsWith('marking-menu-layout-probe--'),
+    );
+    if (probeClass === undefined) {
+      return getComputedStyle(element);
+    }
+
+    const name = probeClass.replace('marking-menu-layout-probe--', '');
+    const style: Pick<CSSStyleDeclaration, 'width'> = {
+      width: properties[name as keyof typeof properties],
+    };
+    return style as CSSStyleDeclaration;
+  });
 };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('createMenu', () => {
   it('renders', () => {
@@ -92,6 +128,30 @@ describe('createMenu', () => {
     expect(div).toMatchSnapshot();
   });
 
+  it('renders inside an open shadow root without adding a document style', () => {
+    const div = document.createElement('div');
+    const styles = document.head.querySelectorAll('style').length;
+    const menu = createMenu({
+      parent: div,
+      model: createModel(1),
+      center: [30, 50],
+      doc: document,
+    });
+
+    const root = menu.element.shadowRoot;
+    expect(root?.mode).toBe('open');
+    expect(root?.querySelector('style')).not.toBeNull();
+    expect(document.head.querySelectorAll('style')).toHaveLength(styles);
+    expect(root?.querySelector('[part="plate"]')).not.toBeNull();
+    expect(root?.querySelector('[part="connector"]')).not.toBeNull();
+    expect(root?.querySelector('[part="label"]')).not.toBeNull();
+
+    menu.setActive('item-0-key');
+    expect(root?.querySelector('[part~="plate--active"]')).not.toBeNull();
+    expect(root?.querySelector('[part~="connector--active"]')).not.toBeNull();
+    expect(root?.querySelector('[part~="label--active"]')).not.toBeNull();
+  });
+
   it('identifies corner items', () => {
     const div = document.createElement('div');
     createMenu({
@@ -106,7 +166,7 @@ describe('createMenu', () => {
       center: [30, 50],
       doc: document,
     });
-    const items = div.querySelectorAll('.marking-menu-item');
+    const items = getItems(div);
     expect((items[0] as Element).classList.contains('bottom-right-item')).toBe(
       true,
     );
@@ -138,7 +198,7 @@ describe('createMenu', () => {
       center: [30, 50],
       doc: document,
     });
-    const items = div.querySelectorAll('.marking-menu-item');
+    const items = getItems(div);
     expect((items[0] as Element).classList.contains('bottom-right-item')).toBe(
       true,
     );
@@ -212,7 +272,7 @@ describe('createMenu', () => {
       doc: document,
     });
 
-    const items = [...div.querySelectorAll<HTMLElement>('.marking-menu-item')];
+    const items = getItems(div);
     expect(items.map((elt) => elt.dataset.itemId)).toEqual(
       model.items.map((item) => item.key),
     );
@@ -234,14 +294,17 @@ describe('createMenu', () => {
       doc: document,
     });
 
-    const main = div.querySelector('.marking-menu');
-    expect(main?.classList.contains('solved')).toBe(true);
-    const items = [...div.querySelectorAll<HTMLElement>('.marking-menu-item')];
+    const items = getItems(div);
     expect(items).toHaveLength(8);
     for (const item of items) {
-      expect(item.style.getPropertyValue('--x')).not.toBe('');
-      expect(item.style.getPropertyValue('--y')).not.toBe('');
-      expect(item.style.getPropertyValue('--contact-radius')).not.toBe('');
+      const label = item.querySelector<HTMLElement>('.marking-menu-label');
+      const connector = item.querySelector<HTMLElement>('.marking-menu-line');
+      expect(label?.style.getPropertyValue('--solved-left')).not.toBe('');
+      expect(label?.style.getPropertyValue('--solved-top')).not.toBe('');
+      expect(label?.style.getPropertyValue('--solved-bottom')).toBe('auto');
+      expect(
+        connector?.style.getPropertyValue('--solved-connector-width'),
+      ).not.toBe('');
     }
   });
 
@@ -263,11 +326,13 @@ describe('createMenu', () => {
       doc: document,
     });
 
-    const main = div.querySelector('.marking-menu');
-    expect(main?.classList.contains('solved')).toBe(false);
-    const items = [...div.querySelectorAll<HTMLElement>('.marking-menu-item')];
+    const items = getItems(div);
     for (const item of items) {
-      expect(item.style.getPropertyValue('--x')).toBe('');
+      expect(
+        item
+          .querySelector<HTMLElement>('.marking-menu-label')
+          ?.style.getPropertyValue('--solved-left'),
+      ).toBe('');
     }
   });
 
@@ -291,14 +356,17 @@ describe('createMenu', () => {
       doc: document,
     });
 
-    const contactRadius = (parent: HTMLElement): number =>
-      // Trailing "px" needs stripping; `Number` alone can't do that.
-      // eslint-disable-next-line unicorn/prefer-number-coercion -- see above.
-      Number.parseFloat(
-        parent
-          .querySelector<HTMLElement>('.marking-menu-item')
-          ?.style.getPropertyValue('--contact-radius') ?? '',
-      );
-    expect(contactRadius(wideRing)).toBeGreaterThan(contactRadius(narrowRing));
+    const connectorContactRadius = (parent: HTMLElement): number => {
+      const width =
+        getItems(parent)[0]
+          ?.querySelector<HTMLElement>('.marking-menu-line')
+          ?.style.getPropertyValue('--solved-connector-width') ?? '';
+
+      return Number(width.slice(5, width.indexOf('px')));
+    };
+
+    expect(connectorContactRadius(wideRing)).toBeGreaterThan(
+      connectorContactRadius(narrowRing),
+    );
   });
 });

--- a/src/layout/menu.test.ts
+++ b/src/layout/menu.test.ts
@@ -142,9 +142,13 @@ describe('createMenu', () => {
     expect(root?.mode).toBe('open');
     expect(root?.querySelector('style')).not.toBeNull();
     expect(document.head.querySelectorAll('style')).toHaveLength(styles);
-    expect(root?.querySelector('[part="plate"]')).not.toBeNull();
+    expect(root?.querySelector('[part~="plate"]')).not.toBeNull();
     expect(root?.querySelector('[part="connector"]')).not.toBeNull();
-    expect(root?.querySelector('[part="label"]')).not.toBeNull();
+    expect(root?.querySelector('[part~="label"]')).not.toBeNull();
+    expect(root?.querySelector('.marking-menu-layout-probe')).toBeNull();
+    expect(
+      root?.querySelector('.marking-menu-label')?.getAttribute('part'),
+    ).toBe('plate label');
 
     menu.setActive('item-0-key');
     expect(root?.querySelector('[part~="plate--active"]')).not.toBeNull();
@@ -303,7 +307,7 @@ describe('createMenu', () => {
       expect(label?.style.getPropertyValue('--solved-top')).not.toBe('');
       expect(label?.style.getPropertyValue('--solved-bottom')).toBe('auto');
       expect(
-        connector?.style.getPropertyValue('--solved-connector-width'),
+        connector?.style.getPropertyValue('--solved-connector-contact-radius'),
       ).not.toBe('');
     }
   });
@@ -360,9 +364,9 @@ describe('createMenu', () => {
       const width =
         getItems(parent)[0]
           ?.querySelector<HTMLElement>('.marking-menu-line')
-          ?.style.getPropertyValue('--solved-connector-width') ?? '';
+          ?.style.getPropertyValue('--solved-connector-contact-radius') ?? '';
 
-      return Number(width.slice(5, width.indexOf('px')));
+      return Number(width.slice(0, -2));
     };
 
     expect(connectorContactRadius(wideRing)).toBeGreaterThan(

--- a/src/layout/menu.ts
+++ b/src/layout/menu.ts
@@ -71,20 +71,30 @@ function getCornerClass(angle: number): string | undefined {
   return CORNER_ITEM_CLASSES[Math.floor(normalizedAngle / 90)];
 }
 
-type LayoutProbeName =
-  | 'ringRadius'
-  | 'plateGapHorizontal'
-  | 'plateGapVertical'
-  | 'plateGapRing'
-  | 'plateGapConnector';
-
-type LayoutProbes = Record<LayoutProbeName, HTMLElement>;
+type LayoutProbes = {
+  ringRadius: HTMLElement;
+  plateGapHorizontal: HTMLElement;
+  plateGapVertical: HTMLElement;
+  plateGapRing: HTMLElement;
+  plateGapConnector: HTMLElement;
+};
 
 type MenuDom = {
   main: HTMLDivElement;
   root: ShadowRoot;
   probes: LayoutProbes;
 };
+
+function appendLayoutProbe(
+  root: ShadowRoot,
+  doc: Document,
+  property: string,
+): HTMLElement {
+  const probe = doc.createElement('div');
+  probe.className = `marking-menu-layout-probe marking-menu-layout-probe--${property}`;
+  root.append(probe);
+  return probe;
+}
 
 const template = (
   { items, center }: { items: readonly MenuLayoutItem[]; center: Point },
@@ -99,25 +109,17 @@ const template = (
   style.textContent = menuStyles;
   root.append(style);
 
-  const probes = Object.fromEntries(
-    [
-      ['ringRadius', 'ring-radius'],
-      ['plateGapHorizontal', 'plate-gap-horizontal'],
-      ['plateGapVertical', 'plate-gap-vertical'],
-      ['plateGapRing', 'plate-gap-ring'],
-      ['plateGapConnector', 'plate-gap-connector'],
-    ].map(([name, property]) => {
-      const probe = doc.createElement('div');
-      probe.className = `marking-menu-layout-probe marking-menu-layout-probe--${property}`;
-      root.append(probe);
-      return [name, probe];
-    }),
-  ) as LayoutProbes;
+  const probes: LayoutProbes = {
+    ringRadius: appendLayoutProbe(root, doc, 'ring-radius'),
+    plateGapHorizontal: appendLayoutProbe(root, doc, 'plate-gap-horizontal'),
+    plateGapVertical: appendLayoutProbe(root, doc, 'plate-gap-vertical'),
+    plateGapRing: appendLayoutProbe(root, doc, 'plate-gap-ring'),
+    plateGapConnector: appendLayoutProbe(root, doc, 'plate-gap-connector'),
+  };
 
   for (const item of items) {
     const elt = doc.createElement('div');
     elt.className = 'marking-menu-item';
-    elt.setAttribute('part', 'plate');
     elt.dataset.itemId = item.key;
     elt.style.setProperty('--angle', `${item.angle}deg`);
     const cornerClass = getCornerClass(item.angle);
@@ -137,7 +139,7 @@ const template = (
 
     const labelElt = doc.createElement('div');
     labelElt.className = 'marking-menu-label';
-    labelElt.setAttribute('part', 'label');
+    labelElt.setAttribute('part', 'plate label');
     labelElt.textContent = item.label;
     elt.append(labelElt);
     root.append(elt);
@@ -187,7 +189,7 @@ function applySolvedLayout(
     // The probe's resolved width retains its `px` suffix.
     // eslint-disable-next-line unicorn/prefer-number-coercion
     Number.parseFloat(view.getComputedStyle(probe).width);
-  const result = solveLabelLayout({
+  const layout = {
     plates,
     ringRadius: readPixels(probes.ringRadius),
     clearances: {
@@ -196,7 +198,12 @@ function applySolvedLayout(
       plateToRing: readPixels(probes.plateGapRing),
       plateToConnector: readPixels(probes.plateGapConnector),
     },
-  });
+  };
+  for (const probe of Object.values(probes)) {
+    probe.remove();
+  }
+
+  const result = solveLabelLayout(layout);
   if (result.oversized) {
     return;
   }
@@ -215,30 +222,43 @@ function applySolvedLayout(
 
     const connector = at(connectorElements, index);
     connector.style.setProperty(
-      '--solved-connector-width',
-      `calc(${Math.hypot(...plate.connectorContact)}px + var(--mm-plate-corner-radius, calc(var(--mm-plate-padding, 4px) * 2)) + var(--mm-connector-thickness, 4px))`,
+      '--solved-connector-contact-radius',
+      `${Math.hypot(...plate.connectorContact)}px`,
     );
   }
 }
 
+function togglePart(
+  element: HTMLElement,
+  part: string,
+  isActive: boolean,
+): void {
+  if (element.part !== undefined) {
+    element.part.toggle(part, isActive);
+    return;
+  }
+
+  const parts = new Set(element.getAttribute('part')?.split(' '));
+  if (isActive) {
+    parts.add(part);
+  } else {
+    parts.delete(part);
+  }
+
+  element.setAttribute('part', [...parts].join(' '));
+}
+
 function setItemActive(item: HTMLElement, isActive: boolean): void {
   item.classList.toggle('active', isActive);
-  for (const element of [item, ...item.children]) {
-    const part = element.getAttribute('part');
-    if (part === null) {
-      continue;
-    }
-
-    const [basePart] = part.split(' ', 2);
-    if (basePart === undefined) {
-      continue;
-    }
-
-    element.setAttribute(
-      'part',
-      isActive ? `${basePart} ${basePart}--active` : basePart,
-    );
+  const label = item.querySelector<HTMLElement>('.marking-menu-label');
+  const connector = item.querySelector<HTMLElement>('.marking-menu-line');
+  if (label === null || connector === null) {
+    throw new Error('Menu item element is incomplete.');
   }
+
+  togglePart(label, 'plate--active', isActive);
+  togglePart(label, 'label--active', isActive);
+  togglePart(connector, 'connector--active', isActive);
 }
 
 /**

--- a/src/layout/menu.ts
+++ b/src/layout/menu.ts
@@ -2,22 +2,6 @@ import { at, degreesToRadians, type Point } from '../utils.js';
 import { solveLabelLayout } from './label-layout.js';
 import menuStyles from './menu.css?inline';
 
-let hasInjectedStyles = false;
-
-/**
- Inject the menu's stylesheet into a document, once.
- */
-function ensureStylesInjected(doc: Document): void {
-  if (hasInjectedStyles) {
-    return;
-  }
-
-  hasInjectedStyles = true;
-  const style = doc.createElement('style');
-  style.textContent = menuStyles;
-  doc.head.append(style);
-}
-
 /**
  An item of the menu layout's model.
  */
@@ -87,17 +71,53 @@ function getCornerClass(angle: number): string | undefined {
   return CORNER_ITEM_CLASSES[Math.floor(normalizedAngle / 90)];
 }
 
+type LayoutProbeName =
+  | 'ringRadius'
+  | 'plateGapHorizontal'
+  | 'plateGapVertical'
+  | 'plateGapRing'
+  | 'plateGapConnector';
+
+type LayoutProbes = Record<LayoutProbeName, HTMLElement>;
+
+type MenuDom = {
+  main: HTMLDivElement;
+  root: ShadowRoot;
+  probes: LayoutProbes;
+};
+
 const template = (
   { items, center }: { items: readonly MenuLayoutItem[]; center: Point },
   doc: Document,
-): HTMLDivElement => {
+): MenuDom => {
   const main = doc.createElement('div');
   main.className = 'marking-menu';
   main.style.setProperty('--center-x', `${center[0]}px`);
   main.style.setProperty('--center-y', `${center[1]}px`);
+  const root = main.attachShadow({ mode: 'open' });
+  const style = doc.createElement('style');
+  style.textContent = menuStyles;
+  root.append(style);
+
+  const probes = Object.fromEntries(
+    [
+      ['ringRadius', 'ring-radius'],
+      ['plateGapHorizontal', 'plate-gap-horizontal'],
+      ['plateGapVertical', 'plate-gap-vertical'],
+      ['plateGapRing', 'plate-gap-ring'],
+      ['plateGapConnector', 'plate-gap-connector'],
+    ].map(([name, property]) => {
+      const probe = doc.createElement('div');
+      probe.className = `marking-menu-layout-probe marking-menu-layout-probe--${property}`;
+      root.append(probe);
+      return [name, probe];
+    }),
+  ) as LayoutProbes;
+
   for (const item of items) {
     const elt = doc.createElement('div');
     elt.className = 'marking-menu-item';
+    elt.setAttribute('part', 'plate');
     elt.dataset.itemId = item.key;
     elt.style.setProperty('--angle', `${item.angle}deg`);
     const cornerClass = getCornerClass(item.angle);
@@ -112,24 +132,19 @@ const template = (
     elt.style.setProperty('--sine', `${Math.sin(-radAngle)}`);
     const lineElt = doc.createElement('div');
     lineElt.className = 'marking-menu-line';
+    lineElt.setAttribute('part', 'connector');
     elt.append(lineElt);
 
     const labelElt = doc.createElement('div');
     labelElt.className = 'marking-menu-label';
+    labelElt.setAttribute('part', 'label');
     labelElt.textContent = item.label;
     elt.append(labelElt);
-    main.append(elt);
+    root.append(elt);
   }
 
-  return main;
+  return { main, root, probes };
 };
-
-function readPixels(style: CSSStyleDeclaration, property: string): number {
-  // `getPropertyValue` returns the raw declared value (e.g. "80px"); unlike
-  // `Number`, `parseFloat` strips that unit suffix instead of yielding NaN.
-  // eslint-disable-next-line unicorn/prefer-number-coercion -- see above.
-  return Number.parseFloat(style.getPropertyValue(property));
-}
 
 /**
  Measure `main`'s rendered label boxes, solve their layout once, and apply
@@ -138,12 +153,12 @@ function readPixels(style: CSSStyleDeclaration, property: string): number {
  already renders unconditionally, still valid, just not conflict-free.
  */
 function applySolvedLayout(
-  main: HTMLDivElement,
+  { root, probes }: MenuDom,
   items: readonly MenuLayoutItem[],
   doc: Document,
 ): void {
   const itemElements = [
-    ...main.querySelectorAll<HTMLElement>('.marking-menu-item'),
+    ...root.querySelectorAll<HTMLElement>('.marking-menu-item'),
   ];
   const labelElements = itemElements.map((element) => {
     const label = element.querySelector<HTMLElement>('.marking-menu-label');
@@ -153,35 +168,75 @@ function applySolvedLayout(
 
     return label;
   });
+  const connectorElements = itemElements.map((element) => {
+    const connector = element.querySelector<HTMLElement>('.marking-menu-line');
+    if (connector === null) {
+      throw new Error('Menu item element is missing its connector.');
+    }
+
+    return connector;
+  });
   const plates = items.map((item, index) => ({
     angle: item.angle,
     width: at(labelElements, index).offsetWidth,
     height: at(labelElements, index).offsetHeight,
   }));
 
-  const style = (doc.defaultView ?? globalThis).getComputedStyle(main);
+  const view = doc.defaultView ?? globalThis;
+  const readPixels = (probe: HTMLElement): number =>
+    // The probe's resolved width retains its `px` suffix.
+    // eslint-disable-next-line unicorn/prefer-number-coercion
+    Number.parseFloat(view.getComputedStyle(probe).width);
   const result = solveLabelLayout({
     plates,
-    ringRadius: readPixels(style, '--menu-radius'),
+    ringRadius: readPixels(probes.ringRadius),
     clearances: {
-      plateHorizontal: readPixels(style, '--item-horizontal-gap'),
-      plateVertical: readPixels(style, '--item-vertical-gap'),
-      plateToRing: readPixels(style, '--item-ring-gap'),
-      plateToConnector: readPixels(style, '--item-connector-gap'),
+      plateHorizontal: readPixels(probes.plateGapHorizontal),
+      plateVertical: readPixels(probes.plateGapVertical),
+      plateToRing: readPixels(probes.plateGapRing),
+      plateToConnector: readPixels(probes.plateGapConnector),
     },
   });
   if (result.oversized) {
     return;
   }
 
-  main.classList.add('solved');
-  for (const [index, element] of itemElements.entries()) {
-    const plate = at(result.plates, index);
-    element.style.setProperty('--x', `${plate.x}px`);
-    element.style.setProperty('--y', `${plate.y}px`);
-    element.style.setProperty(
-      '--contact-radius',
-      `${Math.hypot(...plate.connectorContact)}px`,
+  for (const [index, plate] of result.plates.entries()) {
+    const label = at(labelElements, index);
+    label.style.setProperty(
+      '--solved-left',
+      `calc(${plate.x}px - var(--item-box-width) / 2)`,
+    );
+    label.style.setProperty(
+      '--solved-top',
+      `calc(${plate.y}px - var(--item-box-height) / 2)`,
+    );
+    label.style.setProperty('--solved-bottom', 'auto');
+
+    const connector = at(connectorElements, index);
+    connector.style.setProperty(
+      '--solved-connector-width',
+      `calc(${Math.hypot(...plate.connectorContact)}px + var(--mm-plate-corner-radius, calc(var(--mm-plate-padding, 4px) * 2)) + var(--mm-connector-thickness, 4px))`,
+    );
+  }
+}
+
+function setItemActive(item: HTMLElement, isActive: boolean): void {
+  item.classList.toggle('active', isActive);
+  for (const element of [item, ...item.children]) {
+    const part = element.getAttribute('part');
+    if (part === null) {
+      continue;
+    }
+
+    const [basePart] = part.split(' ', 2);
+    if (basePart === undefined) {
+      continue;
+    }
+
+    element.setAttribute(
+      'part',
+      isActive ? `${basePart} ${basePart}--active` : basePart,
     );
   }
 }
@@ -209,27 +264,25 @@ export function createMenu({
   model: MenuLayoutModel;
   center: Point;
 }): Menu {
-  ensureStylesInjected(doc);
-
-  // Create the DOM.
-  const main = template({ items: model.items, center }, doc);
+  const menuDom = template({ items: model.items, center }, doc);
+  const { main, root } = menuDom;
   // Attach before measuring: a detached element's `offsetWidth`/`offsetHeight`
   // are always 0. Everything from here through `applySolvedLayout` runs
   // synchronously in this one call, so the unsolved layout is never
   // painted: a browser only paints between tasks, never mid-function.
   parent.append(main);
-  applySolvedLayout(main, model.items, doc);
+  applySolvedLayout(menuDom, model.items, doc);
 
   // Clear any  active items.
   const clearActiveItems = () => {
-    for (const itemDom of main.querySelectorAll('.active')) {
-      itemDom.classList.remove('active');
+    for (const itemDom of root.querySelectorAll<HTMLElement>('.active')) {
+      setItemActive(itemDom, false);
     }
   };
 
   // Return an item DOM element from its id.
   const getItemDom = (itemId: string | number) =>
-    [...main.querySelectorAll<HTMLElement>('.marking-menu-item')].find(
+    [...root.querySelectorAll<HTMLElement>('.marking-menu-item')].find(
       (elt) => elt.dataset.itemId === itemId,
     );
 
@@ -251,7 +304,7 @@ export function createMenu({
         throw new TypeError(`No menu item found for id: ${itemId}`);
       }
 
-      itemDom.classList.add('active');
+      setItemActive(itemDom, true);
     }
   };
 


### PR DESCRIPTION
## Summary

- Move menu DOM and styles into an open shadow root.
- Replace legacy theme properties with the new theming properties and exposed active parts.
- Read label layout geometry from resolved hidden probes.

## Tests

Ran yarn lint, yarn typecheck, yarn test, yarn e2e, yarn format:check, yarn package:lint, yarn package:types, and yarn package:smoke-test.

Fixes #295