### PR TITLE
Drop togglePart's manual DOMTokenList fallback

### DIFF
--- a/src/layout/menu.ts
+++ b/src/layout/menu.ts
@@ -233,19 +233,7 @@ function togglePart(
   part: string,
   isActive: boolean,
 ): void {
-  if (element.part !== undefined) {
-    element.part.toggle(part, isActive);
-    return;
-  }
-
-  const parts = new Set(element.getAttribute('part')?.split(' '));
-  if (isActive) {
-    parts.add(part);
-  } else {
-    parts.delete(part);
-  }
-
-  element.setAttribute('part', [...parts].join(' '));
+  element.part.toggle(part, isActive);
 }
 
 function setItemActive(item: HTMLElement, isActive: boolean): void {

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -7,6 +7,7 @@
   "include": [
     "src/**/*.test.ts",
     "src/**/*.test-d.ts",
-    "src/**/__fixtures__/**/*"
+    "src/**/__fixtures__/**/*",
+    "vitest.setup.ts"
   ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    setupFiles: ['./vitest.setup.ts'],
     // Test files are being migrated from .js to .ts; match both until the
     // migration completes. The playground page (see `demo/playground`) has
     // tests of its own; coverage below stays scoped to `src`, so demo code

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,29 @@
+// JSDOM doesn't implement the CSS Shadow Parts API
+// (https://github.com/jsdom/jsdom/issues/3335), so `Element.prototype.part`
+// is undefined under test even though every real browser has it. Real
+// browsers return a live `DOMTokenList`; the codebase only ever calls
+// `.toggle()` on it, so this reflects just that against the `part`
+// attribute instead of implementing the full interface.
+if (!('part' in Element.prototype)) {
+  Object.defineProperty(Element.prototype, 'part', {
+    configurable: true,
+    get(this: Element): DOMTokenList {
+      return {
+        toggle: (token: string, shouldBePresent?: boolean): boolean => {
+          const tokens = new Set(
+            (this.getAttribute('part') ?? '').split(' ').filter(Boolean),
+          );
+          const isPresent = shouldBePresent ?? !tokens.has(token);
+          if (isPresent) {
+            tokens.add(token);
+          } else {
+            tokens.delete(token);
+          }
+
+          this.setAttribute('part', [...tokens].join(' '));
+          return isPresent;
+        },
+      } as unknown as DOMTokenList;
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- `togglePart` (`src/layout/menu.ts`) now only calls `element.part.toggle(part, isActive)`, dropping the manual `Set`/`getAttribute`/`setAttribute` fallback branch.
- Added a jsdom `Element.prototype.part` polyfill (`vitest.setup.ts`, wired via `vitest.config.ts`'s `setupFiles`) so the test suite exercises that same native call instead of silently losing coverage of it.
- `vitest.setup.ts` added to `tsconfig.test.json`'s `include` so it's type-checked and lintable under the project's test project (DOM lib types).

## Why

Flagged in review of #302 against #295: the fallback branch hand-reimplemented `DOMTokenList` token-set semantics for an environment that supports this PR's Shadow DOM + `::part()` styling but not `Element.part` — a combination with no browserslist entry or compatibility note anywhere in the repo. TypeScript already types `Element.prototype.part` as a non-optional `DOMTokenList` (`lib.dom.d.ts`), so the guard (`if (element.part !== undefined)`) was dead code by the type system's own account.

The catch: jsdom doesn't implement `Element.part` (https://github.com/jsdom/jsdom/issues/3335), which is exactly why the fallback branch was the *only* one any test exercised before this change — dropping it outright would have broken every test going through `setActive`. The added polyfill reflects `.toggle()` against the `part` attribute, matching real `DOMTokenList.toggle` semantics, so the suite now runs the actual native code path instead of a second, hand-written one.

## Tests

Ran under the project's pinned Node (26.8.1, fetched locally since the sandbox only had 20/21/22 available):
- `tsc -b` — no errors
- `eslint .` — no new errors (2 pre-existing, unrelated warnings)
- `prettier --check` — clean
- `vitest run` — 34 files / 397 tests passing
- `vitest run --coverage` — all thresholds met (statements 98.02%, branches 92.09%, functions 99.66%, lines 97.97%)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtruE9MZ8BasVRWcnon2jw

---
_Generated by [Claude Code](https://claude.ai/code/session_01DtruE9MZ8BasVRWcnon2jw)_