### PR TITLE
Anchor outer connectors at a configurable radius

### DIFF
--- a/.changeset/connector-start-radius.md
+++ b/.changeset/connector-start-radius.md
@@ -1,0 +1,6 @@
+---
+'marking-menu': major
+---
+
+`--mm-connector-start-radius` defaults to `--mm-ring-radius`, so outer
+connectors start at the wedge ring. Set it to `0` for a center-anchored line.

--- a/e2e/tests/mouse.spec.ts
+++ b/e2e/tests/mouse.spec.ts
@@ -124,8 +124,9 @@ test('novice mode: wedges and connector parts follow the menu directions', async
   await menu.evaluate((host) => {
     host.style.setProperty('--mm-inner-connector-color', 'rgb(1, 2, 3)');
     host.style.setProperty('--mm-outer-connector-color', 'rgb(4, 5, 6)');
+    host.style.setProperty('--mm-connector-start-radius', '0px');
   });
-  const colors = await menu.evaluate((host) => {
+  const connectorAtCenter = await menu.evaluate((host) => {
     const root = host.shadowRoot;
     const innerConnector = root?.querySelector<HTMLElement>(
       '.marking-menu-inner-connector',
@@ -145,9 +146,35 @@ test('novice mode: wedges and connector parts follow the menu directions', async
     return {
       inner: getComputedStyle(innerConnector).backgroundColor,
       outer: getComputedStyle(outerConnector).backgroundColor,
+      activePart: root
+        ?.querySelector('[part~="outer-connector--active"]')
+        ?.getAttribute('part'),
+      outerOffset:
+        outerConnector.getBoundingClientRect().x -
+        innerConnector.getBoundingClientRect().x,
     };
   });
-  expect(colors).toEqual({ inner: 'rgb(1, 2, 3)', outer: 'rgb(4, 5, 6)' });
+  expect(connectorAtCenter).toEqual({
+    activePart: 'outer-connector outer-connector--active',
+    inner: 'rgb(1, 2, 3)',
+    outer: 'rgb(4, 5, 6)',
+    outerOffset: 0,
+  });
+
+  await menu.evaluate((host) => {
+    host.style.setProperty('--mm-connector-start-radius', '9999px');
+  });
+  const clampedWidth = await menu.evaluate((host) => {
+    const connector = host.shadowRoot?.querySelector<HTMLElement>(
+      '.marking-menu-outer-connector',
+    );
+    if (connector === null || connector === undefined) {
+      throw new Error('Menu connector is missing.');
+    }
+
+    return connector.getBoundingClientRect().width;
+  });
+  expect(clampedWidth).toBe(12);
 
   await releaseAt(page);
 });

--- a/src/layout/menu.css
+++ b/src/layout/menu.css
@@ -22,6 +22,10 @@
     --mm-outer-connector-color,
     var(--default-plate-background-active)
   );
+  --default-connector-start-radius: var(
+    --mm-connector-start-radius,
+    var(--default-ring-radius)
+  );
   --default-wedge-fill: var(--mm-wedge-fill, var(--default-plate-background));
   --default-wedge-fill-active: var(
     --mm-wedge-fill-active,
@@ -113,11 +117,15 @@
 .marking-menu-outer-connector {
   background-color: var(--default-outer-connector-color);
   width: calc(
-    var(--solved-connector-contact-radius, var(--default-ring-radius)) +
-      var(--default-plate-corner-radius) + var(--default-connector-thickness) -
-      var(--default-ring-radius)
+    max(
+        0px,
+        var(--solved-connector-contact-radius, var(--default-ring-radius)) -
+          var(--default-connector-start-radius)
+      ) +
+      var(--default-plate-corner-radius) + var(--default-connector-thickness)
   );
-  transform: rotate(var(--angle)) translateX(var(--default-ring-radius));
+  transform: rotate(var(--angle))
+    translateX(var(--default-connector-start-radius));
 }
 
 .marking-menu-item.active {


### PR DESCRIPTION
## Summary

- Add `--mm-connector-start-radius`, which defaults to `--mm-ring-radius`.
- Keep `--mm-inner-connector-color` as the optional center-to-ring connector.
- Cover the default, center, oversized, and active outer-connector cases.

## Tests

- Formatting
- Unit tests
- Production build
- End-to-end tests
- Package linting

Fixes #297