### PR TITLE
Rework the playground's layout tab click handling

### DIFF
--- a/demo/playground/layout-surface.tsx
+++ b/demo/playground/layout-surface.tsx
@@ -1,21 +1,30 @@
-import { useEffect, useRef, type PointerEvent } from 'react';
+import { useEffect, useRef, type MouseEvent, type PointerEvent } from 'react';
 import { createMenu } from '../../src/layout/menu.js';
-import { segmentAngle } from '../../src/recognizer/recognize-mm-stroke.js';
-import { dist, type Point } from '../../src/utils.js';
 import { nodeAt, type MenuModel } from './menu-model.js';
 import { useLatest } from './use-latest.js';
 
 /*
  The other half of the page: one level of the menu, laid out by the library
  at the centre of the surface and standing still, so it can be read rather
- than performed. Clicking an item with a sub-menu goes a level deeper.
+ than performed. Clicking an item selects it; clicking the selected item
+ goes a level deeper. Clicking empty space deselects; double-clicking it goes
+ back to the root.
  */
 
-// A click this close to the centre reads no direction, so it selects
-// nothing. The menu itself is `pointer-events: none` (see `menu.css`), so a
-// click is resolved by angle, the way the recognizer resolves a stroke, and
-// not by which element sits underneath it.
-const MIN_SELECTION_DIST_PX = 20;
+// The menu lives in a shadow root: a listener outside it only ever sees
+// `event.target` retargeted to the shadow host, never the wedge or item
+// actually under the pointer. `composedPath()` isn't retargeted.
+function hitItemId(event: Event): string | undefined {
+  const target = event.composedPath()[0];
+  if (!(target instanceof Element)) {
+    return undefined;
+  }
+
+  const hit = target.closest('[data-item-id]');
+  return hit instanceof HTMLElement || hit instanceof SVGElement
+    ? hit.dataset.itemId
+    : undefined;
+}
 
 export function LayoutSurface({
   model,
@@ -28,6 +37,10 @@ export function LayoutSurface({
 }) {
   const surfaceRef = useRef<HTMLDivElement | null>(null);
   const menuParentRef = useRef<HTMLDivElement | null>(null);
+  const menuRef = useRef<ReturnType<typeof createMenu> | null>(null);
+  // The selected-but-not-yet-opened item, read and written imperatively:
+  // nothing in JSX depends on it, `Menu.setActive` is what makes it visible.
+  const activeKeyRef = useRef<string | null>(null);
   const latestRef = useLatest({ model, focusPath, onFocus });
 
   useEffect(() => {
@@ -37,15 +50,21 @@ export function LayoutSurface({
       return;
     }
 
-    let menu: ReturnType<typeof createMenu> | null = null;
+    // A new level starts with nothing selected: a key selected at the
+    // previous level may not exist at this one, and `setActive` throws for
+    // an id it can't find.
+    activeKeyRef.current = null;
     const render = () => {
-      menu?.remove();
+      menuRef.current?.remove();
       const { width, height } = surface.getBoundingClientRect();
-      menu = createMenu({
+      const menu = createMenu({
         parent: menuParent,
         model: nodeAt(model, focusPath),
         center: [width / 2, height / 2],
+        pointerTarget: true,
       });
+      menu.setActive(activeKeyRef.current);
+      menuRef.current = menu;
     };
 
     render();
@@ -55,44 +74,62 @@ export function LayoutSurface({
     observer.observe(surface);
     return () => {
       observer.disconnect();
-      menu?.remove();
+      menuRef.current?.remove();
+      menuRef.current = null;
     };
   }, [model, focusPath]);
 
   const onClick = (event: PointerEvent<HTMLDivElement>) => {
-    const surface = surfaceRef.current;
-    if (surface === null || !event.isPrimary) {
+    if (!event.isPrimary) {
       return;
     }
 
-    const { width, height, left, top } = surface.getBoundingClientRect();
-    const center: Point = [width / 2, height / 2];
-    const point: Point = [event.clientX - left, event.clientY - top];
-    const node = nodeAt(latestRef.current.model, latestRef.current.focusPath);
-    if (node.isLeaf || dist(center, point) < MIN_SELECTION_DIST_PX) {
+    const itemId = hitItemId(event.nativeEvent);
+    if (itemId === undefined) {
+      if (activeKeyRef.current !== null) {
+        activeKeyRef.current = null;
+        menuRef.current?.setActive(null);
+      }
+
       return;
     }
 
-    const item = node.getNearestChild(segmentAngle(center, point));
-    const index = node.items.findIndex(
-      (candidate) => candidate.key === item?.key,
-    );
-    if (index === -1 || item === null || item.isLeaf) {
+    if (itemId !== activeKeyRef.current) {
+      activeKeyRef.current = itemId;
+      menuRef.current?.setActive(itemId);
       return;
     }
 
-    latestRef.current.onFocus([...latestRef.current.focusPath, index]);
+    const latest = latestRef.current;
+    const node = nodeAt(latest.model, latest.focusPath);
+    const index = node.items.findIndex((item) => item.key === itemId);
+    const item = index === -1 ? undefined : node.items[index];
+    if (item !== undefined && !item.isLeaf) {
+      latest.onFocus([...latest.focusPath, index]);
+    }
+  };
+
+  const onDoubleClick = (event: MouseEvent<HTMLDivElement>) => {
+    const latest = latestRef.current;
+    if (
+      hitItemId(event.nativeEvent) === undefined &&
+      latest.focusPath.length > 0
+    ) {
+      latest.onFocus([]);
+    }
   };
 
   return (
     <div
       ref={surfaceRef}
       onPointerDown={onClick}
+      onDoubleClick={onDoubleClick}
       className="relative min-h-85 flex-1 overflow-hidden bg-surface dot-grid wide:min-h-0"
     >
       <div ref={menuParentRef} className="absolute inset-0" />
       <span className="pointer-events-none absolute bottom-4 left-5 font-mono text-meta text-quietest">
-        click an item with a sub-menu to go a level deeper
+        click an item to select it, click again to go a level deeper, click
+        empty space to deselect, or double-click it for the root
       </span>
     </div>
   );

--- a/src/layout/menu.css
+++ b/src/layout/menu.css
@@ -39,6 +39,13 @@
   transform: translate(0px, 0px);
 }
 
+/* Drawing-only by default (see `createMenu`'s `pointerTarget` option): a
+   live gesture reads strokes on the surface behind the menu, not hovers or
+   clicks on the menu's own items and wedges. */
+:host(.marking-menu--pointer-target) {
+  pointer-events: auto;
+}
+
 .marking-menu-item {
   --angle: 0deg;
   --cosine: 1;

--- a/src/layout/menu.ts
+++ b/src/layout/menu.ts
@@ -514,6 +514,10 @@ function setItemActive(
  @param options.center - The pixel coordinates where the menu should be
  anchored.
  @param options.deadZoneRadius - The inner radius of the wedge ring.
+ @param options.pointerTarget - Whether the menu's items and wedges accept
+ pointer events. Off by default: a live gesture reads strokes on the surface
+ behind the menu, not hovers or clicks on the menu itself. Turn it on for a
+ menu meant to be operated directly, such as a static, non-gesture preview.
  @param options.doc - The root document of the menu. Mostly useful for testing
  purposes.
  @returns The menu controls.
@@ -524,16 +528,20 @@ export function createMenu({
   model,
   center,
   deadZoneRadius = 40,
+  pointerTarget = false,
 }: {
   doc?: Document;
   parent: HTMLElement;
   model: MenuLayoutModel;
   center: Point;
   deadZoneRadius?: number;
+  pointerTarget?: boolean;
 }): Menu {
   const menuDom = template({ items: model.items, center }, doc);
   const { main, root } = menuDom;
   main.style.setProperty('--inner-connector-length', `${deadZoneRadius}px`);
+  main.classList.toggle('marking-menu--pointer-target', pointerTarget);
+
   // Attach before measuring: a detached element's `offsetWidth`/`offsetHeight`
   // are always 0. Everything from here through `applySolvedLayout` runs
   // synchronously in this one call, so the unsolved layout is never


### PR DESCRIPTION
The layout tab figures out which item a click landed on by recomputing the click's angle from the pointer position and asking the model for the nearest child. This duplicates logic the menu's recognizer already owns, and its dead zone (a fixed 20 pixels) does not match the menu's actual rendered one, so clicks past it can still land on an item at radii where nothing is drawn.

`createMenu` now accepts a `pointerTarget` option. Off by default, the menu stays drawing-only, since a live gesture reads strokes from the surface behind it rather than from hovering or clicking the menu's own items and wedges. Turned on, those items and wedges accept pointer events directly, so a caller can read the clicked item straight from the DOM instead of re-deriving the geometry from a pointer position.

The layout tab turns this on and reads the clicked item through `event.composedPath()`, since `event.target` gets retargeted to the shadow host once the event crosses the shadow boundary and never reaches the wedge or item underneath it. Clicking an item selects it without changing level; clicking the selected item again opens it. Clicking empty space clears the selection, and double-clicking empty space returns to the root.

To try it, run `yarn demo:dev`, open the playground, and switch to the Layout tab. Click an item to see it highlight, click it again to descend into its sub-menu, click empty space to clear the highlight, and double-click empty space to jump back to the root.

Existing unit tests, `yarn lint`, and `yarn typecheck` all pass. The interaction itself was checked by hand in the running demo, since it depends on real pointer and shadow DOM behavior the test suite does not cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)