### PR TITLE
playground: Clarify the breakdown checkbox label

### DIFF
--- a/demo/playground/app.tsx
+++ b/demo/playground/app.tsx
@@ -280,7 +280,7 @@ export function App() {
                   }}
                   className="size-3.5 [&_svg]:size-3"
                 />
-                Breakdown
+                Recognizer breakdown
               </label>
               {showBreakdown && <Legend />}
             </div>


### PR DESCRIPTION
The Live tab's "Breakdown" checkbox toggles a legend explaining how the recognizer classified the stroke, but the label alone did not say what it was a breakdown of. This renames it to "Recognizer breakdown" to match the legend it controls.