### PR TITLE
ci: Handle visual regression updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,9 @@ jobs:
         with:
           name: dist
           path: dist/
+      - run: |
+          apt-get update
+          apt-get install -y --no-install-recommends jq
       # The fixture-only build, not `yarn e2e`: `dist/` was already built once
       # by the Build job above, so this avoids building the library again.
       - run: yarn e2e:build
@@ -88,33 +91,24 @@ jobs:
       # launch in that situation ("Running Nightly as root in a regular user's
       # session is not supported"); the other browsers do not care. Overriding
       # HOME here is the workaround Playwright's own error message prescribes.
-      - run: >-
-          yarn e2e:test --project=chromium --project=firefox
-          --project=webkit --project=chromium-touch
-        env:
-          HOME: /root
-
-  VisualRegression:
-    needs: Build
-    runs-on: ubuntu-latest
-    container: mcr.microsoft.com/playwright:v1.63.0-noble
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - uses: ./.github/actions/setup
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: dist
-          path: dist/
-      - run: yarn e2e:build
-      - id: visual
+      - id: e2e
         continue-on-error: true
-        run: yarn e2e:visual
+        run: yarn e2e:test --reporter=json > test-results.json
         env:
           HOME: /root
       - if: >-
-          steps.visual.outcome == 'failure' &&
+          steps.e2e.outcome == 'failure' &&
           github.event_name == 'pull_request'
+        id: visual
+        run: |
+          if jq -e '
+            [.. | objects | select(
+              .message? | type == "string" and contains("toHaveScreenshot")
+            )] | length > 0
+          ' test-results.json > /dev/null; then
+            echo 'failed=true' >> "$GITHUB_OUTPUT"
+          fi
+      - if: steps.visual.outputs.failed == 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
@@ -136,5 +130,5 @@ jobs:
               issue_number: context.payload.pull_request.number,
               body: `### ${heading}\n\nSome screenshots do not match their stored references. If the changes are intentional, add the \`update screenshots\` label to regenerate them.`,
             });
-      - if: steps.visual.outcome == 'failure'
+      - if: steps.e2e.outcome == 'failure'
         run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,53 @@ jobs:
       # launch in that situation ("Running Nightly as root in a regular user's
       # session is not supported"); the other browsers do not care. Overriding
       # HOME here is the workaround Playwright's own error message prescribes.
-      - run: yarn e2e:test
+      - run: >-
+          yarn e2e:test --project=chromium --project=firefox
+          --project=webkit --project=chromium-touch
         env:
           HOME: /root
+
+  VisualRegression:
+    needs: Build
+    runs-on: ubuntu-latest
+    container: mcr.microsoft.com/playwright:v1.63.0-noble
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: ./.github/actions/setup
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+      - run: yarn e2e:build
+      - id: visual
+        continue-on-error: true
+        run: yarn e2e:visual
+        env:
+          HOME: /root
+      - if: >-
+          steps.visual.outcome == 'failure' &&
+          github.event_name == 'pull_request'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+              },
+            );
+            const heading = 'Visual regression failures detected';
+            if (comments.some((comment) => comment.body?.includes(heading))) {
+              return;
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `### ${heading}\n\nSome screenshots do not match their stored references. If the changes are intentional, add the \`update screenshots\` label to regenerate them.`,
+            });
+      - if: steps.visual.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -1,7 +1,7 @@
 name: Update visual screenshots
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [main]
     types: [labeled]
 
@@ -31,6 +31,7 @@ jobs:
         continue-on-error: true
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        shell: bash
         run: |
           set -euo pipefail
           yarn build
@@ -73,17 +74,7 @@ jobs:
               issue_number: context.payload.pull_request.number,
               body: 'Visual screenshots were unchanged.',
             });
-      - if: steps.update.outcome != 'success'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body: 'Visual screenshot update failed. The label remains for retry.',
-            });
-      - if: steps.update.outcome == 'success'
+      - if: always()
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |


### PR DESCRIPTION
Visual screenshot failures need a distinct response from other end-to-end failures. The updater previously retained its label after a failed run, but a retained label does not fire another event.

The E2E job now writes a Playwright JSON report in CI. It posts the update instruction only when the report contains `toHaveScreenshot`; other end-to-end failures still fail without that comment.

Local runs keep the HTML report. The updater runs in Bash and removes its label after every run.

To verify, change a committed visual baseline in a same-repository pull request. CI posts the instruction; adding `update screenshots` commits regenerated images and removes the label.

Checked with Prettier and `git diff --check`. The nonvisual end-to-end command passed locally. The JSON matcher was checked against a failing visual assertion. The `jq` setup was checked in the pinned CI container.