### PR TITLE
ci: Allow visual failure comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,12 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
+            const updateLabel = 'update screenshots';
+            if (context.payload.pull_request.labels.some(
+              ({ name }) => name === updateLabel,
+            )) {
+              return;
+            }
             const comments = await github.paginate(
               github.rest.issues.listComments,
               {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   LintFormatTypecheck:


### PR DESCRIPTION
The visual E2E job needs permission to write a pull request comment. It posts that comment only when a screenshot mismatch has no `update screenshots` label. A label already on the pull request has already started the snapshot updater.

The comment lists each affected baseline, including a missing file. Repository contents remain read-only.

To verify, fail a visual snapshot with and without the label.