### PR TITLE
ci: Scope HOME=/root to the e2e:test command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,11 +92,13 @@ jobs:
       # launch in that situation ("Running Nightly as root in a regular user's
       # session is not supported"); the other browsers do not care. Overriding
       # HOME here is the workaround Playwright's own error message prescribes.
+      # It's set inline rather than as a step-level `env:` because the runner
+      # also uses step-level env when invoking the Docker client for this
+      # step, and pointing it at /root breaks `docker`'s own config lookup
+      # (`/root/.docker/config.json: permission denied`).
       - id: e2e
         continue-on-error: true
-        run: yarn e2e:test --reporter=json > test-results.json
-        env:
-          HOME: /root
+        run: HOME=/root yarn e2e:test --reporter=json > test-results.json
       - if: >-
           steps.e2e.outcome == 'failure' &&
           github.event_name == 'pull_request'


### PR DESCRIPTION
The end-to-end job runs as root inside the Playwright container, and Firefox refuses to start unless `HOME` points at a directory root actually owns, so the job sets `HOME=/root`. That was done as a step-level environment variable, which meant the runner also applied it when invoking the Docker client to run the step itself. Docker then went looking for `/root/.docker/config.json`, didn't find it, and printed a permission-denied warning before any tests ran (#321).

The fix keeps the Firefox workaround but narrows its scope: `HOME=/root` is now set only on the `yarn e2e:test` invocation, inside the `run:` command, rather than on the whole step. Docker's own environment is untouched.

There's no way to exercise the container job locally, so this needs a real workflow run to confirm the warning is gone and the browsers, Firefox included, still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)