### PR TITLE
ci: Fix visual snapshot reports and updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,12 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
+            const updateLabel = 'update screenshots';
+            if (context.payload.pull_request.labels.some(
+              ({ name }) => name === updateLabel,
+            )) {
+              return;
+            }
             const comments = await github.paginate(
               github.rest.issues.listComments,
               {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,15 +102,29 @@ jobs:
           github.event_name == 'pull_request'
         id: visual
         run: |
-          if jq -e '
-            [.. | objects | select(
-              .message? | type == "string" and contains("toHaveScreenshot")
-            )] | length > 0
-          ' test-results.json > /dev/null; then
-            echo 'failed=true' >> "$GITHUB_OUTPUT"
+          snapshots=$(jq -r '
+            [
+              .. | objects | .message? | strings
+              | select(
+                  contains("toHaveScreenshot") or
+                  contains("A snapshot doesn't exist at")
+                )
+              | scan("menu-[A-Za-z0-9-]+\\.png")
+              | select(test("-(actual|diff|previous)\\.png$") | not)
+            ] | unique[]
+          ' test-results.json)
+          if [ -n "$snapshots" ]; then
+            {
+              echo 'failed=true'
+              echo 'snapshots<<EOF'
+              printf '%s\n' "$snapshots"
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
           fi
       - if: steps.visual.outputs.failed == 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          SNAPSHOTS: ${{ steps.visual.outputs.snapshots }}
         with:
           script: |
             const updateLabel = 'update screenshots';
@@ -131,11 +145,15 @@ jobs:
             if (comments.some((comment) => comment.body?.includes(heading))) {
               return;
             }
+            const snapshots = process.env.SNAPSHOTS.split('\n')
+              .filter(Boolean)
+              .map((snapshot) => `- \`${snapshot}\``)
+              .join('\n');
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body: `### ${heading}\n\nSome screenshots do not match their stored references. If the changes are intentional, add the \`update screenshots\` label to regenerate them.`,
+              body: `### ${heading}\n\n${snapshots}\n\nIf the changes are intentional, add the \`update screenshots\` label to regenerate them.`,
             });
       - if: steps.e2e.outcome == 'failure'
         run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   LintFormatTypecheck:

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -37,6 +37,7 @@ jobs:
           yarn build
           yarn e2e:build
           yarn e2e:visual --update-snapshots=changed
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git add -- e2e/tests/visual.spec.ts-snapshots/
           if ! git diff --cached --name-only | awk '
             $0 ~ /^e2e\/tests\/visual\.spec\.ts-snapshots\/.+\.png$/ { next }


### PR DESCRIPTION
Visual mismatch comments now list each affected baseline, including missing files. The screenshot updater also trusts its checked-out workspace before staging regenerated images, which lets the container commit them.

To verify, delete or change a visual baseline without the `update screenshots` label, then apply the label and confirm that the updater commits the regenerated images.